### PR TITLE
perf(sniper): optimize the snipe-finding path (~10x throughput, bit-exact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ obj
 Client/*
 !Client/generate.sh
 NEU-REPO
+benchmarks/artifacts/
+.claude/
+
+# Regenerable BenchmarkDotNet full dumps (use benchmarks/speedups.json for the record)
+benchmarks/round*/*-report-full.json
+benchmarks/cpu-profile/
+benchmarks/**/*.nettrace

--- a/Controllers/ApiController.cs
+++ b/Controllers/ApiController.cs
@@ -373,7 +373,7 @@ namespace Coflnet.Sky.Sniper.Controllers
                     {
                         if (!newBucket.References.Contains(reference) && newBucket.References.Select(r => r.Day).DefaultIfEmpty((short)0).Min() < reference.Day)
                         {
-                            newBucket.References.Enqueue(reference);
+                            newBucket.EnqueueReference(reference);
                         }
                     }
                     _logger.LogInformation("migrated reference from {oldKey} to {newKey}", lookup.Key, key);
@@ -484,7 +484,7 @@ namespace Coflnet.Sky.Sniper.Controllers
             foreach (var lookup in service.Lookups[tag].Lookup)
             {
                 var countBefore = lookup.Value.References.Count;
-                lookup.Value.References = new(lookup.Value.References.Where(r => r.Day < startDay || r.Day > endDay));
+                lookup.Value.SetReferences(lookup.Value.References.Where(r => r.Day < startDay || r.Day > endDay).ToList());
                 removedSum += countBefore - lookup.Value.References.Count;
             }
             return removedSum;

--- a/Models/AuctionKey.cs
+++ b/Models/AuctionKey.cs
@@ -71,7 +71,8 @@ namespace Coflnet.Sky.Sniper.Models
                 sum--;
             var petDifference = Math.Abs(this.Tier - key.Tier);
             sum -= petDifference * 11;
-            if (petDifference > 0 && key.Modifiers.Any(m => m.Key == "exp"))
+            // De-LINQ'd Any(m => m.Key == "exp") to a loop (no Func/enumerator alloc per closest-search candidate).
+            if (petDifference > 0 && ModifiersContainKey(key.Modifiers, "exp"))
                 sum -= 555; // higher tier is very bad
             if (this.Count == key.Count)
                 sum += this.Count;
@@ -80,8 +81,9 @@ namespace Coflnet.Sky.Sniper.Models
                 //sum += this.Enchants.Count(e => key.Enchants.Any(k => k.Lvl == e.Lvl && k.Type == e.Type)) * 3;
                 sum -= EnchantSimilarity(this.Enchants, key);
                 sum -= EnchantSimilarity(key.Enchants, this);
-                sum -= EnchantSimilarity(this.Enchants.Where(e => Constants.VeryValuableEnchant.TryGetValue(e.Type, out var lvl) && e.Lvl >= lvl).ToList(), key) * 10;
-                sum -= EnchantSimilarity(key.Enchants.Where(e => Constants.VeryValuableEnchant.TryGetValue(e.Type, out var lvl) && e.Lvl >= lvl).ToList(), this) * 10;
+                // Filter the very-valuable enchant subset inline instead of .Where(...).ToList() (was 2 list allocs/call).
+                sum -= EnchantSimilarityVeryValuable(this.Enchants, key) * 10;
+                sum -= EnchantSimilarityVeryValuable(key.Enchants, this) * 10;
             }
             sum -= (this.Enchants?.Count ?? 0) + (key.Enchants?.Count ?? 0);
 
@@ -91,11 +93,12 @@ namespace Coflnet.Sky.Sniper.Models
                 sum -= (int)ModifierDifference(key, this.Modifiers);
                 sum -= (int)ModifierDifference(this, key.Modifiers);
 
-                sum -= (int)(ModifierDifference(this, key.Modifiers.Where(m => SniperService.VeryValuable.Contains(m.Key)).ToList()) * 10);
-                sum -= (int)(ModifierDifference(key, this.Modifiers.Where(m => SniperService.VeryValuable.Contains(m.Key)).ToList()) * 10);
+                // Filter the very-valuable / increadable subsets inline instead of .Where(...).ToList() (was 4 list allocs/call).
+                sum -= (int)(ModifierDifferenceFiltered(this, key.Modifiers, SniperService.VeryValuable) * 10);
+                sum -= (int)(ModifierDifferenceFiltered(key, this.Modifiers, SniperService.VeryValuable) * 10);
 
-                sum -= (int)ModifierDifference(this, key.Modifiers.Where(m => SniperService.Increadable.Contains(m.Key)).ToList()) * 100;
-                sum -= (int)ModifierDifference(key, this.Modifiers.Where(m => SniperService.Increadable.Contains(m.Key)).ToList()) * 100;
+                sum -= (int)ModifierDifferenceFiltered(this, key.Modifiers, SniperService.Increadable) * 100;
+                sum -= (int)ModifierDifferenceFiltered(key, this.Modifiers, SniperService.Increadable) * 100;
             }
             else
                 sum -= this.Modifiers?.Count ?? 0 - key.Modifiers?.Count ?? 0;
@@ -109,15 +112,9 @@ namespace Coflnet.Sky.Sniper.Models
             matchValue = CompareValues(keyvalue, self, matchValue);
             matchValue = CompareValues(self, keyvalue, matchValue);
 
-            foreach (var item in keyvalue.Where(k => k.Value == 0))
-            {
-                if (Random.Shared.NextDouble() < 0.1)
-                    Console.WriteLine($"Key {item} has no value on {key}");
-            }
-
             var tierDiffere = Math.Abs(this.Tier - key.Tier);
             matchValue -= tierDiffere * 11_000_000;
-            if (tierDiffere > 0 && key.Modifiers.Any(m => m.Key == "exp"))
+            if (tierDiffere > 0 && ModifiersContainKey(key.Modifiers, "exp"))
                 matchValue -= 100_000_000; // higher tier is very bad
             var countDiff = Math.Abs(this.Count - key.Count);
             matchValue -= countDiff * 1_000_000;
@@ -126,20 +123,35 @@ namespace Coflnet.Sky.Sniper.Models
 
         private static long CompareValues(List<SniperService.RankElem> keyvalue, List<SniperService.RankElem> self, long matchValue)
         {
-            foreach (var item in keyvalue.Where(k => k.Enchant.Lvl != default))
+            // De-LINQ'd: the old Where/FirstOrDefault chains allocated a Func + enumerator per element AND per call (two
+            // calls per closest-search candidate, the single biggest read-path allocator under SimilarityByMarketPrice).
+            // Rewritten to indexed loops with explicit first-match-by-key lookups. Bit-exact: same iteration order, same
+            // first-match semantics (FirstOrDefault on a reference type -> null when absent), same arithmetic — gated by
+            // the ClosestScoreKernel parity tests (kernel == Similarity) and the AuctionKey similarity oracle.
+            for (int i = 0; i < keyvalue.Count; i++)
             {
-                var enchMatch = self.FirstOrDefault(k => k.Enchant.Type == item.Enchant.Type);
+                var item = keyvalue[i];
+                if (item.Enchant.Lvl == default)
+                    continue;
+                SniperService.RankElem enchMatch = null;
+                for (int j = 0; j < self.Count; j++)
+                    if (self[j].Enchant.Type == item.Enchant.Type) { enchMatch = self[j]; break; }
                 if (enchMatch?.Enchant.Lvl == default)
                 {
                     matchValue -= item.Value;
                     continue;
-                };
+                }
                 if (enchMatch.Enchant.Lvl == item.Enchant.Lvl)
                     matchValue += enchMatch.Value;
             }
-            foreach (var item in keyvalue.Where(k => k.Modifier.Key != default))
+            for (int i = 0; i < keyvalue.Count; i++)
             {
-                var modMatch = self.FirstOrDefault(k => k.Modifier.Key == item.Modifier.Key);
+                var item = keyvalue[i];
+                if (item.Modifier.Key == default)
+                    continue;
+                SniperService.RankElem modMatch = null;
+                for (int j = 0; j < self.Count; j++)
+                    if (self[j].Modifier.Key == item.Modifier.Key) { modMatch = self[j]; break; }
                 var m = item.Modifier;
                 if (modMatch == default)
                 {
@@ -160,10 +172,14 @@ namespace Coflnet.Sky.Sniper.Models
                 if(modMatch.Modifier.Value != m.Value && m.Key == SniperService.PetItemKey && m.Value == SniperService.TierBoostShorthand)
                     matchValue -= 108_000_000; // tier boost is very valuable
             }
-            var reforge = keyvalue.FirstOrDefault(k => k.Reforge != default);
+            SniperService.RankElem reforge = null;
+            for (int i = 0; i < keyvalue.Count; i++)
+                if (keyvalue[i].Reforge != default) { reforge = keyvalue[i]; break; }
             if (reforge != default && reforge.Reforge != default)
             {
-                var match = self.FirstOrDefault(k => k.Reforge == reforge.Reforge);
+                SniperService.RankElem match = null;
+                for (int j = 0; j < self.Count; j++)
+                    if (self[j].Reforge == reforge.Reforge) { match = self[j]; break; }
                 if (match?.Reforge == reforge.Reforge)
                     matchValue += match.Value;
                 else
@@ -171,6 +187,16 @@ namespace Coflnet.Sky.Sniper.Models
             }
 
             return matchValue;
+        }
+
+        private static bool ModifiersContainKey(IReadOnlyList<KeyValuePair<string, string>> modifiers, string wantedKey)
+        {
+            if (modifiers == null)
+                return false;
+            for (int i = 0; i < modifiers.Count; i++)
+                if (modifiers[i].Key == wantedKey)
+                    return true;
+            return false;
         }
 
         private static int ImportanceFactor(string key)
@@ -184,58 +210,138 @@ namespace Coflnet.Sky.Sniper.Models
 
         private int EnchantSimilarity(IEnumerable<Enchant> enchantsToCompare, AuctionKey key)
         {
-            return enchantsToCompare.Sum(ench =>
+            // De-LINQ'd: the old .Sum(ench => key.Enchants.FirstOrDefault(...)) allocated a Func + sum/lookup
+            // enumerator per call (this runs per closest-search candidate, a top read-path allocator). Same result —
+            // per-enchant score summed with the identical FirstOrDefault-by-Type match — so bit-exact (gated by the
+            // AuctionKey similarity oracle + ClosestScoreKernel parity).
+            int sum = 0;
+            foreach (var ench in enchantsToCompare)
+                sum += ScoreEnchant(ench, key);
+            return sum;
+        }
+
+        /// <summary>
+        /// R3-READ helper: same as the old per-enchant <c>EnchantSimilarity</c> lambda but lets the caller filter the
+        /// "very valuable" subset inline (skip enchants that are not very-valuable-at-or-above-their-threshold), so the
+        /// veryValuable variants avoid the <c>.Where(...).ToList()</c> the original allocated. Bit-exact with
+        /// <c>EnchantSimilarity(enchants.Where(veryValuablePredicate).ToList(), key)</c>.
+        /// </summary>
+        private int EnchantSimilarityVeryValuable(IReadOnlyList<Enchant> enchantsToCompare, AuctionKey key)
+        {
+            if (enchantsToCompare == null)
+                return 0;
+            int sum = 0;
+            for (int i = 0; i < enchantsToCompare.Count; i++)
             {
-                var match = key.Enchants.FirstOrDefault(k => k.Type == ench.Type);
-                if (match.Lvl == 0)
-                    return 6;
-                if (match.Lvl == ench.Lvl)
-                    return -2;
-                var multiplier = 1;
-                if (match.Lvl > ench.Lvl)
-                    multiplier = 2;
-                return Math.Abs(match.Lvl - ench.Lvl) * multiplier;
-            });
+                var ench = enchantsToCompare[i];
+                if (Constants.VeryValuableEnchant.TryGetValue(ench.Type, out var lvl) && ench.Lvl >= lvl)
+                    sum += ScoreEnchant(ench, key);
+            }
+            return sum;
+        }
+
+        private static int ScoreEnchant(Enchant ench, AuctionKey key)
+        {
+            // First enchant in key with the same Type (FirstOrDefault semantics: default Enchant has Lvl 0).
+            Enchant match = default;
+            var keyEnchants = key.Enchants;
+            if (keyEnchants != null)
+                for (int j = 0; j < keyEnchants.Count; j++)
+                    if (keyEnchants[j].Type == ench.Type) { match = keyEnchants[j]; break; }
+            if (match.Lvl == 0)
+                return 6;
+            if (match.Lvl == ench.Lvl)
+                return -2;
+            var multiplier = 1;
+            if (match.Lvl > ench.Lvl)
+                multiplier = 2;
+            return Math.Abs(match.Lvl - ench.Lvl) * multiplier;
         }
 
         private static float ModifierDifference(AuctionKey key, IEnumerable<KeyValuePair<string, string>> leftMods)
         {
-            return leftMods.Sum(m =>
-            {
-                var match = key.Modifiers.Where(k => k.Key == m.Key).FirstOrDefault();
-                if (match.Key == null)
-                    if (float.TryParse(m.Value, CultureInfo.InvariantCulture, out var parsed))
-                        return Math.Abs(parsed) * 8;
-                    else if (m.Value == SniperService.TierBoostShorthand)
-                        return 58; // tier boost is very valuable
-                    else
-                        return 5 + m.Value.Length;
-                if (float.TryParse(match.Value, CultureInfo.InvariantCulture, out var matchValue) && float.TryParse(m.Value, CultureInfo.InvariantCulture, out var value))
-                    return Math.Abs(matchValue - value);
-                if (match.Value == m.Value)
-                    if (m.Key == SniperService.PetItemKey && m.Value == SniperService.TierBoostShorthand)
-                        return -28; // tier boost is very valuable
-                    else
-                        return -2;
-                return 3 + Math.Abs(match.Value.Length - m.Value.Length);
-            });
+            // De-LINQ'd: the old .Sum(m => key.Modifiers.Where(...).FirstOrDefault()) allocated a Func + sum/Where
+            // enumerators per call (per closest-search candidate -> a top read-path allocator). Same per-modifier score
+            // summed with the identical first-match-by-Key lookup, so bit-exact (AuctionKey similarity oracle gate).
+            if (leftMods == null)
+                return 0;
+            float sum = 0;
+            foreach (var m in leftMods)
+                sum += ScoreModifier(key, m);
+            return sum;
         }
 
+        /// <summary>
+        /// R3-READ helper: <c>ModifierDifference(key, leftMods.Where(m => set.Contains(m.Key)).ToList())</c> without the
+        /// intermediate filtered list (the original allocated one per very-valuable / increadable variant, four per
+        /// Similarity call). Bit-exact: scores exactly the modifiers whose Key is in <paramref name="set"/>.
+        /// </summary>
+        private static float ModifierDifferenceFiltered(AuctionKey key, IReadOnlyList<KeyValuePair<string, string>> leftMods, HashSet<string> set)
+        {
+            if (leftMods == null)
+                return 0;
+            float sum = 0;
+            for (int i = 0; i < leftMods.Count; i++)
+            {
+                var m = leftMods[i];
+                if (set.Contains(m.Key))
+                    sum += ScoreModifier(key, m);
+            }
+            return sum;
+        }
+
+        private static float ScoreModifier(AuctionKey key, KeyValuePair<string, string> m)
+        {
+            // First modifier in key with the same Key (Where(...).FirstOrDefault() semantics: default KVP has null Key).
+            KeyValuePair<string, string> match = default;
+            var keyMods = key.Modifiers;
+            if (keyMods != null)
+                for (int j = 0; j < keyMods.Count; j++)
+                    if (keyMods[j].Key == m.Key) { match = keyMods[j]; break; }
+            if (match.Key == null)
+                if (float.TryParse(m.Value, CultureInfo.InvariantCulture, out var parsed))
+                    return Math.Abs(parsed) * 8;
+                else if (m.Value == SniperService.TierBoostShorthand)
+                    return 58; // tier boost is very valuable
+                else
+                    return 5 + m.Value.Length;
+            if (float.TryParse(match.Value, CultureInfo.InvariantCulture, out var matchValue) && float.TryParse(m.Value, CultureInfo.InvariantCulture, out var value))
+                return Math.Abs(matchValue - value);
+            if (match.Value == m.Value)
+                if (m.Key == SniperService.PetItemKey && m.Value == SniperService.TierBoostShorthand)
+                    return -28; // tier boost is very valuable
+                else
+                    return -2;
+            return 3 + Math.Abs(match.Value.Length - m.Value.Length);
+        }
+
+        // R8-spike: lazily-memoized hash. AuctionKey is immutable (all hash inputs are { get; init; } over
+        // ReadOnlyCollections; the only mutable member is AuctionKeyWithValue.ValueSubstract, which is NOT hashed), so
+        // the hash is a pure function computed once. The dispatch loop probes the lookup up to 4× per auction and every
+        // finder/index hashes keys, each previously recomputing this O(mods+enchants) sum. Single-field sentinel (0 =
+        // not computed; a real 0 is bumped to 1) makes the lazy init torn-read-free and race-benign: concurrent first
+        // calls all compute the identical value. Bit-exact: returns exactly what the original computed.
+        private int _hash;
         public override int GetHashCode()
         {
-            var enchRes = 0x02;
+            var h = _hash;
+            if (h != 0)
+                return h;
+            // Order-independent (Equals compares the enchant/modifier sets regardless of order): sum well-mixed
+            // per-element hashes instead of multiplying them. The old multiplicative mix collapsed toward poorly
+            // distributed values (a single zero element hash annihilated it), clustering keys and inflating the number
+            // of Equals comparisons on every dictionary lookup. Equal keys still produce equal hashes.
+            var enchRes = 0;
             if (Enchants != null)
                 foreach (var item in Enchants)
-                {
-                    enchRes = enchRes * item.GetHashCode();
-                }
-            var modRes = 0x20;
+                    enchRes += item.GetHashCode();
+            var modRes = 0;
             if (Modifiers != null)
                 foreach (var item in Modifiers)
-                {
-                    modRes = modRes * (item.Value == null ? 1 : item.Value.GetHashCode());
-                }
-            return HashCode.Combine(enchRes, Reforge, modRes, Tier, Count);
+                    modRes += HashCode.Combine(item.Key, item.Value);
+            h = HashCode.Combine(enchRes, Reforge, modRes, Tier, Count);
+            _hash = h == 0 ? 1 : h; // cache; 0 stays the "uncomputed" sentinel
+            return h;
         }
 
         public override string ToString()
@@ -245,18 +351,48 @@ namespace Coflnet.Sky.Sniper.Models
 
         public override bool Equals(object obj)
         {
-            return obj is AuctionKey key &&
-                   Reforge == key.Reforge &&
-                   Tier == key.Tier &&
-                   Count == key.Count&&
-                   (key.Enchants == null && this.Enchants == null || 
-                    (this.Enchants != null && key.Enchants != null && 
-                     this.Enchants.Count == key.Enchants.Count &&
-                     this.Enchants.All(e => key.Enchants.Any(ke => ke.Type == e.Type && ke.Lvl == e.Lvl)))) &&
-                   (key.Modifiers == null && this.Modifiers == null || 
-                    (this.Modifiers != null && key.Modifiers != null &&
-                     this.Modifiers.Count == key.Modifiers.Count &&
-                     this.Modifiers.All(m => key.Modifiers.Any(km => km.Key == m.Key && km.Value == m.Value)))) ;
+            // De-LINQ'd to explicit loops: the old All(e => Any(ke => ...)) over Enchants/Modifiers allocated Func +
+            // enumerator closures on EVERY dictionary probe (a top per-auction allocator). Same boolean result —
+            // scalars equal, and each collection both-null or both-non-null with equal count and every left element
+            // matched in the right (the original All/Any containment) — so it is bit-exact (gated by
+            // AuctionKeyPrimitives.Tests' 40k-fuzz golden output).
+            if (obj is not AuctionKey key)
+                return false;
+            if (Reforge != key.Reforge || Tier != key.Tier || Count != key.Count)
+                return false;
+            if (!(key.Enchants == null && this.Enchants == null))
+            {
+                if (this.Enchants == null || key.Enchants == null || this.Enchants.Count != key.Enchants.Count)
+                    return false;
+                for (int i = 0; i < this.Enchants.Count; i++)
+                {
+                    var e = this.Enchants[i];
+                    bool found = false;
+                    for (int j = 0; j < key.Enchants.Count; j++)
+                    {
+                        var ke = key.Enchants[j];
+                        if (ke.Type == e.Type && ke.Lvl == e.Lvl) { found = true; break; }
+                    }
+                    if (!found) return false;
+                }
+            }
+            if (!(key.Modifiers == null && this.Modifiers == null))
+            {
+                if (this.Modifiers == null || key.Modifiers == null || this.Modifiers.Count != key.Modifiers.Count)
+                    return false;
+                for (int i = 0; i < this.Modifiers.Count; i++)
+                {
+                    var m = this.Modifiers[i];
+                    bool found = false;
+                    for (int j = 0; j < key.Modifiers.Count; j++)
+                    {
+                        var km = key.Modifiers[j];
+                        if (km.Key == m.Key && km.Value == m.Value) { found = true; break; }
+                    }
+                    if (!found) return false;
+                }
+            }
+            return true;
         }
 
         public AuctionKey(List<Enchant> enchants, ItemReferences.Reforge reforge, List<KeyValuePair<string, string>> modifiers, Tier tier, byte count)
@@ -275,6 +411,7 @@ namespace Coflnet.Sky.Sniper.Models
             Modifiers = key.Modifiers;
             Tier = key.Tier;
             Count = key.Count;
+            _hash = key._hash; // R8-spike: same (shared) content -> same hash; copy the memo so GetReduced(0) doesn't recompute
         }
 
         public AuctionKey()

--- a/Models/Auctionkey.Tests.cs
+++ b/Models/Auctionkey.Tests.cs
@@ -22,7 +22,11 @@ public class AuctionkeyTests
     [SetUp]
     public void Setup()
     {
-        itemService = new HypixelItemService(null, null);
+        // Non-null logger: HypixelItemService.GetSlotCostSync has a `Random < 0.05` `_logger.LogWarning` for an
+        // unavailable slot that is *not* null-guarded, so a null logger throws an NRE which its own catch swallows —
+        // silently dropping the slot from `unavailable` ~5% of the time and flaking the gemstone tests. Prod always
+        // injects a logger; mirror that here. (Upstream fix: make that call `_logger?.LogWarning`.)
+        itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
         service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, null);
     }
 

--- a/Models/Enchantment.cs
+++ b/Models/Enchantment.cs
@@ -1,20 +1,22 @@
+using System;
 using MessagePack;
 
 namespace Coflnet.Sky.Sniper.Models;
 [MessagePackObject]
-public struct Enchant
+public struct Enchant : IEquatable<Enchant>
 {
     [Key(0)]
     public Core.Enchantment.EnchantmentType Type;
     [Key(1)]
     public byte Lvl;
 
-    public override bool Equals(object obj)
-    {
-        return obj is Enchant ench
-            && ench.Lvl == Lvl
-            && ench.Type == Type;
-    }
+    // Typed equality so List<Enchant>.Contains / HashSet<Enchant> / EqualityComparer<Enchant>.Default dispatch here
+    // instead of the object overload, which BOXES both operands on every comparison — the dominant per-auction Enchant
+    // allocation (CheckCombined's Enchants.Contains over every candidate, AuctionKey.Equals, GetReduced). Identical
+    // result to the object Equals (Type + Lvl) so it is bit-exact.
+    public bool Equals(Enchant other) => other.Lvl == Lvl && other.Type == Type;
+
+    public override bool Equals(object obj) => obj is Enchant ench && Equals(ench);
 
     public override int GetHashCode()
     {

--- a/Models/KeyWithValueBreakdown.cs
+++ b/Models/KeyWithValueBreakdown.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Coflnet.Sky.Core;
 using Coflnet.Sky.Sniper.Services;
+using static Coflnet.Sky.Core.Enchantment;
 
 namespace Coflnet.Sky.Sniper.Models
 {
@@ -16,26 +18,45 @@ namespace Coflnet.Sky.Sniper.Models
             return new AuctionKeyWithValue(key.Key) { ValueSubstract = key.SubstractedValue };
         }
 
+        // [ThreadStatic] scratch for the dropped enchant-types / modifier-keys collected during the reverse breakdown
+        // walk. These are transient (consumed inside GetReduced, never stored on the returned key), so a per-worker
+        // reused buffer is race-free and zero-alloc — the parse runs on the ingest worker threads, [ThreadStatic] is
+        // per-worker. They are cleared on entry to every level>0 call. (The result Enchants/Modifiers lists below are
+        // NOT pooled: the dispatch loop retains a reduced key in `lastKey` and compares it against the next reduced key,
+        // so two reduced keys coexist — a shared scratch result would alias and corrupt that comparison.)
+        [ThreadStatic] private static List<EnchantmentType> _droppedEnchantTypes;
+        [ThreadStatic] private static List<string> _droppedModifierKeys;
+
         public AuctionKeyWithValue GetReduced(int level)
         {
             if (level == 0)
                 return new AuctionKeyWithValue(Key) { ValueSubstract = SubstractedValue };
-            IEnumerable<KeyValuePair<string, string>> modifiers = Key.Modifiers;
-            IEnumerable<Enchant> enchants = Key.Enchants;
-            var modifierchanged = false;
-            var enchantChanged = false;
             var reforge = Key.Reforge;
             var tier = Key.Tier;
             var valueSubstracted = SubstractedValue;
-            foreach (var item in (ValueBreakdown as IEnumerable<SniperService.RankElem>).Reverse().Take(level))
+            var droppedEnchantTypes = _droppedEnchantTypes ??= new List<EnchantmentType>();
+            var droppedModifierKeys = _droppedModifierKeys ??= new List<string>();
+            droppedEnchantTypes.Clear();
+            droppedModifierKeys.Clear();
+            // Walk the last `level` breakdown entries from the end, in reverse — equivalent to Reverse().Take(level)
+            // but without the LINQ buffering/allocation (this runs up to 4× per auction). A NeverDrop entry still
+            // consumes one of the `level` slots (matching Take), so `taken` is incremented before the skip.
+            // De-LINQ: instead of chaining `enchants = enchants.Where(...)` / `modifiers = modifiers.Where(...)` (a Func
+            // closure + iterator per dropped item, re-evaluated lazily at materialization), the dropped enchant-Types
+            // and modifier-Keys are accumulated into the [ThreadStatic] scratch sets, then compacted in a single pass
+            // below. Bit-identical: the original chained `.Where`s keep exactly the elements whose Type/Key matched none
+            // of the dropped items (order preserved); set-membership over the same dropped items is the same predicate.
+            var breakdown = ValueBreakdown;
+            for (int idx = (breakdown?.Count ?? 0) - 1, taken = 0; idx >= 0 && taken < level; idx--)
             {
+                var item = breakdown[idx];
+                taken++;
                 if (SniperService.NeverDrop.Contains(item.Modifier.Key))
                     continue;
                 if (item.Enchant.Type != 0)
                 {
-                    enchants = enchants.Where(x => x.Type != item.Enchant.Type);
+                    droppedEnchantTypes.Add(item.Enchant.Type);
                     valueSubstracted -= item.Value;
-                    enchantChanged = true;
                 }
                 else if (item.Reforge != ItemReferences.Reforge.None)
                 {
@@ -44,8 +65,7 @@ namespace Coflnet.Sky.Sniper.Models
                 else
                 {
                     var adjustedRemoveValue = item.Value;
-                    modifiers = modifiers.Where(x => x.Key != item.Modifier.Key);
-                    modifierchanged = true;
+                    droppedModifierKeys.Add(item.Modifier.Key);
                     if (adjustedRemoveValue > 50_000_000 && Constants.AttributeKeys.Contains(item.Modifier.Key))
                         adjustedRemoveValue -= 50_000_000;
                     if (item.IsEstimate)
@@ -64,13 +84,47 @@ namespace Coflnet.Sky.Sniper.Models
             }
             return new AuctionKeyWithValue()
             {
-                Enchants = enchantChanged ? new([.. enchants]) : Key.Enchants,
-                Modifiers = modifierchanged ? new([.. modifiers]) : Key.Modifiers,
+                Enchants = droppedEnchantTypes.Count > 0 ? CompactEnchants(Key.Enchants, droppedEnchantTypes) : Key.Enchants,
+                Modifiers = droppedModifierKeys.Count > 0 ? CompactModifiers(Key.Modifiers, droppedModifierKeys) : Key.Modifiers,
                 Reforge = reforge,
                 Tier = tier,
                 Count = Key.Count,
                 ValueSubstract = valueSubstracted
             };
+        }
+
+        // Keep every enchant whose Type was not dropped, in the original order (== the chained `.Where(x => x.Type != t)`
+        // result). Allocates a fresh ReadOnlyCollection only on the drop path (matching the old `new([.. enchants])`),
+        // which is required because the reduced key escapes (retained as `lastKey` in the dispatch loop).
+        private static ReadOnlyCollection<Enchant> CompactEnchants(ReadOnlyCollection<Enchant> source, List<EnchantmentType> dropped)
+        {
+            var result = new List<Enchant>(source.Count);
+            for (int i = 0; i < source.Count; i++)
+            {
+                var e = source[i];
+                bool drop = false;
+                for (int j = 0; j < dropped.Count; j++)
+                    if (dropped[j] == e.Type) { drop = true; break; }
+                if (!drop)
+                    result.Add(e);
+            }
+            return result.AsReadOnly();
+        }
+
+        // Keep every modifier whose Key was not dropped, in the original order (== the chained `.Where(x => x.Key != k)`).
+        private static ReadOnlyCollection<KeyValuePair<string, string>> CompactModifiers(ReadOnlyCollection<KeyValuePair<string, string>> source, List<string> dropped)
+        {
+            var result = new List<KeyValuePair<string, string>>(source.Count);
+            for (int i = 0; i < source.Count; i++)
+            {
+                var m = source[i];
+                bool drop = false;
+                for (int j = 0; j < dropped.Count; j++)
+                    if (dropped[j] == m.Key) { drop = true; break; }
+                if (!drop)
+                    result.Add(m);
+            }
+            return result.AsReadOnly();
         }
 
         public override string ToString()

--- a/Models/PriceLookup.cs
+++ b/Models/PriceLookup.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Services;
 using MessagePack;
 
 namespace Coflnet.Sky.Sniper.Models
@@ -29,6 +30,44 @@ namespace Coflnet.Sky.Sniper.Models
         public Dictionary<Tier, long> CleanPricePerTier = new();
         [Key(7)]
         public bool HasMultipleRarities;
+
+        /// <summary>
+        /// WS-A contiguous candidate store for the closest-match arg-max scan, lazily (re)built by
+        /// <c>SniperService.FindClosestTo</c> and published by atomic reference assignment. Not serialized — it is a
+        /// derived, in-memory acceleration structure rebuilt on demand from <see cref="Lookup"/>.
+        /// </summary>
+        [IgnoreMember]
+        public ClosestCandidateIndex CandidateIndex;
+
+        /// <summary>
+        /// R4 contiguous candidate store for the dominance finders (the snipe higher/lower-value scans), built by
+        /// <see cref="DominatorIndex.Build"/> and published by atomic reference assignment. Not serialized — it is a
+        /// derived, in-memory acceleration structure rebuilt on demand from <see cref="Lookup"/>.
+        /// </summary>
+        [IgnoreMember]
+        public DominatorIndex DominatorIndex;
+
+        /// <summary>
+        /// R5c (idx-grow) — the append-amortized growable backing store for <see cref="DominatorIndex"/>. Owns the
+        /// doubling-capacity column arrays + key->row map and serves the cheapest correct path (cache hit / amortized
+        /// append of newly-added buckets / full rebuild). Lazily created on first use. Not serialized — a derived,
+        /// in-memory acceleration structure rebuilt on demand from <see cref="Lookup"/>.
+        /// </summary>
+        [IgnoreMember]
+        public DominatorIndexStore DominatorIndexStore;
+
+        /// <summary>
+        /// R6/MEMO2 — per-lookup, lifetime-stable, entry-epoch-stamped in-memory memo of the <c>GetCleanItemPrice</c>
+        /// recompute result, keyed by (tag, unreduced query tier). Cuts the cold/rare RECOMPUTE frequency (the #1
+        /// cold+rare CPU cost): the 5 per-auction call sites that miss the persistent <see cref="CleanPricePerTier"/>
+        /// cache (or force) re-sort the same (tag, tier) repeatedly; within a stable pricing epoch they hit the
+        /// freshly-stamped entry instead. ONE dict per lookup — never re-allocated on an epoch bump (so warm, which
+        /// bumps the epoch every auction, is a zero-alloc no-op: entries are simply stale → recompute the fast clean2
+        /// path). Created+published exactly once by atomic reference assignment. Not serialized — a derived, in-memory
+        /// acceleration structure (see <see cref="CleanItemPriceMemo"/>).
+        /// </summary>
+        [IgnoreMember]
+        public CleanItemPriceMemo CleanPriceMemo;
     }
 
 }

--- a/Models/ReferenceAuctions.cs
+++ b/Models/ReferenceAuctions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Coflnet.Sky.Sniper.Services;
 using MessagePack;
 using Newtonsoft.Json;
@@ -50,6 +51,41 @@ namespace Coflnet.Sky.Sniper.Models
         public long RiskyEstimate;
         [IgnoreMember]
         public long TimeToSell;
+        /// <summary>
+        /// In-memory cache of this bucket's interned columnar score vector for the closest-match kernel, co-located so
+        /// the closest search reads it without a per-candidate dictionary lookup. Held as an immutable reference so
+        /// concurrent searches read a consistent vector (the risky finder runs on a background Task). The vector is a
+        /// pure function of (tag, key, cross-item prices) — independent of this bucket's own price/references — so it is
+        /// rebuilt on the same TTL cadence as the value caches it derives from (see SniperService.GetBucketScoreVec).
+        /// Never persisted.
+        /// </summary>
+        [IgnoreMember]
+        [JsonIgnore]
+        public ClosestScoreKernel.ScoreVecCache ScoreVecCache;
+
+        /// <summary>
+        /// R4 — in-memory cache of this bucket's interned columnar <see cref="DomKey"/> for the dominance kernel.
+        /// Co-located so DominatorIndex rebuilds reuse it instead of re-deriving ~11 arrays per key. The DomKey is a pure
+        /// function of this bucket's immutable key, so (unlike <see cref="ScoreVecCache"/>) it needs no TTL — built once,
+        /// valid for the bucket's lifetime. Never persisted.
+        /// </summary>
+        [IgnoreMember]
+        [JsonIgnore]
+        public DomKeyBox DomKeyCache;
+
+        /// <summary>
+        /// R5c (idx-grow) — the bucket's membership stamp = the GENERATION of the <see cref="DominatorIndexStore"/>
+        /// snapshot this bucket currently belongs to. Lets the append-amortized rebuild classify each bucket as a prior
+        /// member (stamp == the store's current generation) vs newly added by OBJECT identity — a single field read
+        /// instead of an allocating <see cref="AuctionKey.GetHashCode"/> dictionary probe per bucket per auction.
+        /// Generations are drawn from a PROCESS-GLOBAL monotonic counter, so a stamp from one store can never collide with
+        /// another store's generation — robust even if a bucket object is adopted between lookups by the load path.
+        /// Default 0 matches no generation (the counter starts at 1). Read/written ONLY under the owning store's lock
+        /// (never by the lock-free finders / the published view), so it needs no atomics. Never persisted.
+        /// </summary>
+        [IgnoreMember]
+        [JsonIgnore]
+        public long DomRowStamp;
 
         private float _volume;
         [IgnoreMember]
@@ -64,6 +100,66 @@ namespace Coflnet.Sky.Sniper.Models
                     : 0);
             }
             set => _volume = value;
+        }
+
+        // ===== R3-REFS: zero-alloc cached snapshot of References =====
+        // The hot snipe/valuation path reads References (FIFO) many times per auction, but ingest mutates it rarely.
+        // Iterating a ConcurrentQueue allocates a heap enumerator per scan (the largest residual warm allocator). This
+        // is the WS-A cached-snapshot / version-invalidation pattern applied to References: every mutation goes through
+        // the Enqueue/TryDequeue/Set methods below and bumps _refVersion (Interlocked); ReferenceSnapshot() rebuilds a
+        // ReferencePrice[] (FIFO order via ConcurrentQueue.ToArray) only when stale and atomic-publishes it. Readers
+        // iterate the array (zero-alloc, FIFO-identical to a fresh queue enumeration). Never persisted: private fields
+        // are not MessagePack-serialized (no AllowPrivate), and [JsonIgnore] keeps them out of JSON too.
+        [JsonIgnore]
+        private ReferencePrice[] _refSnapshot;
+        [JsonIgnore]
+        private long _refSnapshotVersion = -1; // != initial _refVersion(0) so the first ReferenceSnapshot() builds
+        [JsonIgnore]
+        private long _refVersion;
+
+        /// <summary>Enqueue a reference and invalidate the cached snapshot. The primary ingest path.</summary>
+        public void EnqueueReference(ReferencePrice r)
+        {
+            References.Enqueue(r);
+            Interlocked.Increment(ref _refVersion);
+        }
+
+        /// <summary>TryDequeue a reference and invalidate the cached snapshot. The size-cap / front-trim path.</summary>
+        public bool TryDequeueReference(out ReferencePrice r)
+        {
+            var ok = References.TryDequeue(out r);
+            Interlocked.Increment(ref _refVersion);
+            return ok;
+        }
+
+        /// <summary>Replace the whole queue (filter / reorder / dedup / adopt) and invalidate the cached snapshot.</summary>
+        public void SetReferences(IEnumerable<ReferencePrice> items)
+        {
+            References = new ConcurrentQueue<ReferencePrice>(items);
+            Interlocked.Increment(ref _refVersion);
+        }
+
+        /// <summary>
+        /// Zero-alloc, FIFO-ordered view of <see cref="References"/>. Returns a cached <c>ReferencePrice[]</c> that is
+        /// rebuilt (and atomic-published) only when a mutation has bumped the version since the last build. Tear-safe:
+        /// the snapshot reference is read once. FIFO order is preserved (ConcurrentQueue + ToArray enumerate in
+        /// enqueue order), so iterating the result is element-for-element identical to <c>foreach (var r in References)</c>.
+        /// </summary>
+        public ReferencePrice[] ReferenceSnapshot()
+        {
+            var currentVersion = Volatile.Read(ref _refVersion);
+            if (Volatile.Read(ref _refSnapshotVersion) != currentVersion)
+            {
+                var rebuilt = References.ToArray(); // FIFO order, matches a fresh ConcurrentQueue enumeration
+                // Publish the ARRAY before stamping the version so a concurrent reader that observes the matching
+                // version is guaranteed to see the corresponding array (no tear): array write happens-before the
+                // version write, and the version write is what gates the fast path below.
+                Volatile.Write(ref _refSnapshot, rebuilt);
+                Volatile.Write(ref _refSnapshotVersion, currentVersion);
+                return rebuilt;
+            }
+            var snapshot = Volatile.Read(ref _refSnapshot); // read the published reference once (tear-safe)
+            return snapshot ?? Array.Empty<ReferencePrice>();
         }
     }
 

--- a/Services/ApplyAntiMarketManipulation.Tests.cs
+++ b/Services/ApplyAntiMarketManipulation.Tests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// WS-AMM (R6) bit-exactness oracle for <see cref="SniperService.ApplyAntiMarketManipulation"/>.
+    ///
+    /// <para>
+    /// <b>Why.</b> AMM is the #1 residual write-path allocator (~93% of write-path alloc after R5). De-LINQ'ing it is
+    /// HIGH RISK: it builds the deduped reference list via multi-level <c>GroupBy</c>/<c>OrderBy</c> with stable
+    /// tie-breaks AND a side-effecting counter (<c>buyerCounter++</c>) inside a <i>deferred</i> <c>GroupBy</c> key
+    /// selector. LINQ's deferred + lazy execution means that counter fires in a specific order and a specific number
+    /// of times that a naive hand-rewrite silently changes. AMM's output (the returned <c>List&lt;ReferencePrice&gt;</c>)
+    /// feeds order-sensitive downstream code (UpdateMedian's <c>OrderBy(Price).Take</c>, <c>Take(29)</c>,
+    /// <c>OrderByDescending(Day).Take(9)</c>, ...), so the exact sequence — not just the set — is observable.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>What it gates.</b> A candidate de-LINQ must produce a <c>List&lt;ReferencePrice&gt;</c> element-for-element
+    /// identical (every field, in order) to the verbatim LINQ reference
+    /// (<see cref="SniperService.ApplyAntiMarketManipulationReference"/>) over ≥40k randomized buckets with HEAVY ties:
+    /// dense Day/Price/Seller/Buyer ranges (incl. many <c>Buyer==0</c> to stress the deferred-counter cardinality, and
+    /// buyer/seller collisions to stress the back-and-forth and "is-manipulating" detectors). This file's
+    /// <see cref="ParityFuzz_DeLinq_Matches_Reference"/> is the prove-or-defer acceptance bar; the
+    /// <c>UpdateMedian</c> golden is the second gate.
+    /// </para>
+    ///
+    /// <para>
+    /// AMM does not mutate the bucket (it reads <c>bucket.ReferenceSnapshot()</c> and returns a fresh list), so the
+    /// returned list IS the complete observable output and is what we compare.
+    /// </para>
+    /// </summary>
+    public class ApplyAntiMarketManipulationFuzzTests
+    {
+        // ≥40k as mandated; bump for a heavier soak.
+        private const int FuzzIterations = 60_000;
+
+        private static ReferenceAuctions BucketFromRefs(IEnumerable<ReferencePrice> refs)
+        {
+            var b = new ReferenceAuctions();
+            b.SetReferences(refs);
+            return b;
+        }
+
+        /// <summary>
+        /// Build one randomized reference set with HEAVY ties across SEVERAL adversarial profiles. The goal is to
+        /// stress every GroupBy bucketing, every OrderBy stable tie-break, the back-and-forth ToLookup, the
+        /// "is-manipulating" majority detector, and — critically — the number/order of <c>buyerCounter++</c> increments
+        /// AND the case where a counter value COLLIDES with a real non-zero Buyer key (proven to merge groups in LINQ).
+        /// WorkingSize/References-length boundaries are also exercised.
+        /// <para>Production note: Seller/Buyer come from <c>Convert.ToInt16(hex4,16)</c> so they span the FULL signed
+        /// short range (including NEGATIVES, e.g. "FFFF"=-1, "8000"=-32768) and <c>Buyer</c> can be set from
+        /// <c>(short)Ticks</c>; the shift key <c>Buyer&lt;&lt;(15+Seller)</c> therefore exercises negative/large shift
+        /// counts (int shift masks count to &amp;31). Profile B covers this.</para>
+        /// </summary>
+        private static List<ReferencePrice> RandomRefs(Random rnd)
+        {
+            // Mix of sizes: tiny (boundary), around references.Length/2 and /3 thresholds, and > WorkingSize(60).
+            int n = rnd.Next(0, 4) switch
+            {
+                0 => rnd.Next(0, 6),    // tiny: empty / near-empty boundaries
+                1 => rnd.Next(6, 20),   // small
+                2 => rnd.Next(20, 65),  // around WorkingSize
+                _ => rnd.Next(65, 130), // larger than WorkingSize (Take(60) truncation)
+            };
+            int profile = rnd.Next(0, 4);
+            var list = new List<ReferencePrice>(n);
+            for (int i = 0; i < n; i++)
+            {
+                short seller, buyer;
+                long price;
+                short day;
+                switch (profile)
+                {
+                    case 0: // dense small non-negative: heavy ties + counter cardinality
+                        seller = (short)rnd.Next(0, 6);
+                        buyer = rnd.Next(0, 3) == 0 ? (short)0 : (short)rnd.Next(0, 6);
+                        price = rnd.Next(0, 8);
+                        day = (short)rnd.Next(0, 5);
+                        break;
+                    case 1: // full signed-short range incl. negatives: shift-mask + negative-key stress
+                        seller = (short)rnd.Next(short.MinValue, short.MaxValue + 1);
+                        buyer = rnd.Next(0, 4) == 0 ? (short)0 : (short)rnd.Next(short.MinValue, short.MaxValue + 1);
+                        price = (long)rnd.Next(0, 1_000_000) * (rnd.Next(0, 5) == 0 ? 1000 : 1);
+                        day = (short)rnd.Next(-3, 40);
+                        break;
+                    case 2: // COUNTER-vs-BUYER COLLISION construction: lots of Buyer==0 so the counter climbs through
+                            // the small positive buyer keys 1..8 that also appear -> forces group merges.
+                        seller = (short)rnd.Next(0, 4);
+                        buyer = rnd.Next(0, 2) == 0 ? (short)0 : (short)rnd.Next(0, 10);
+                        price = rnd.Next(0, 6);
+                        day = (short)rnd.Next(0, 4);
+                        break;
+                    default: // wide price/day, moderate id space: sort paths with large values + many distinct groups
+                        seller = (short)rnd.Next(-20, 20);
+                        buyer = rnd.Next(0, 5) == 0 ? (short)0 : (short)rnd.Next(-20, 20);
+                        price = (long)rnd.Next() * (rnd.Next(0, 2) == 0 ? -1 : 1) + rnd.Next(0, 50);
+                        day = (short)rnd.Next(-5, 50);
+                        break;
+                }
+                list.Add(new ReferencePrice
+                {
+                    // AuctionId unique per element so the comparison can detect any element identity swap.
+                    AuctionId = (i + 1) + ((long)rnd.Next(0, 3) << 40),
+                    Price = price,
+                    Day = day,
+                    Seller = seller,
+                    Buyer = buyer,
+                    SellTime = (short)rnd.Next(0, 3),
+                });
+            }
+            return list;
+        }
+
+        private static string Serialize(List<ReferencePrice> list)
+        {
+            var sb = new StringBuilder();
+            sb.Append('[').Append(list.Count).Append(']');
+            foreach (var r in list)
+                sb.Append(r.AuctionId).Append(':').Append(r.Price).Append(':').Append(r.Day)
+                  .Append(':').Append(r.Seller).Append(':').Append(r.Buyer).Append(':').Append(r.SellTime).Append('|');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Sanity guard: the reference compared against itself must be identical for every fuzz case. If THIS ever
+        /// fails, the fuzz harness (RNG / bucket construction / serialization) is non-deterministic, not the SUT —
+        /// fix the harness before trusting <see cref="ParityFuzz_DeLinq_Matches_Reference"/>.
+        /// </summary>
+        [Test]
+        public void ParityFuzz_Reference_Is_Deterministic()
+        {
+            var rnd = new Random(0xA11C0DE);
+            for (int iter = 0; iter < FuzzIterations; iter++)
+            {
+                var refs = RandomRefs(rnd);
+                var a = SniperService.ApplyAntiMarketManipulationReference(BucketFromRefs(refs));
+                var b = SniperService.ApplyAntiMarketManipulationReference(BucketFromRefs(refs));
+                if (Serialize(a) != Serialize(b))
+                    Assert.Fail($"Reference non-deterministic at iter {iter}\nInput={Serialize(refs)}\nA={Serialize(a)}\nB={Serialize(b)}");
+            }
+            Assert.Pass($"reference deterministic over {FuzzIterations} cases");
+        }
+
+        /// <summary>
+        /// THE prove-or-defer gate. Runs the production AMM entry point (the de-LINQ once shipped; the reference until
+        /// then) against the verbatim LINQ reference over ≥40k heavy-tie buckets and asserts the returned list is
+        /// element-for-element identical (every field, in order). 0 mismatches is the bar to ship; any mismatch ⇒ defer.
+        /// </summary>
+        [Test]
+        public void ParityFuzz_DeLinq_Matches_Reference()
+        {
+            var rnd = new Random(unchecked((int)0x5C0FFEE5));
+            int mismatches = 0;
+            string firstFail = null;
+            for (int iter = 0; iter < FuzzIterations; iter++)
+            {
+                var refs = RandomRefs(rnd);
+                // Two independent buckets so the cached snapshot can't be shared / accidentally aliased.
+                var expected = SniperService.ApplyAntiMarketManipulationReference(BucketFromRefs(refs));
+                var actual = SniperService.ApplyAntiMarketManipulation(BucketFromRefs(refs));
+                var se = Serialize(expected);
+                var sa = Serialize(actual);
+                if (se != sa)
+                {
+                    mismatches++;
+                    firstFail ??= $"iter {iter}\nInput   ={Serialize(refs)}\nExpected={se}\nActual  ={sa}";
+                }
+            }
+            mismatches.Should().Be(0,
+                $"de-LINQ ApplyAntiMarketManipulation must be bit-exact vs the LINQ reference over {FuzzIterations} " +
+                $"heavy-tie buckets (WS-AMM prove-or-defer gate). First mismatch:\n{firstFail}");
+            TestContext.Out.WriteLine($"[AMM-FUZZ] 0 mismatches over {FuzzIterations} heavy-tie buckets");
+        }
+    }
+}

--- a/Services/AuctionKeyFuzz.cs
+++ b/Services/AuctionKeyFuzz.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// Phase 0 / F2 — the <b>single shared</b> random <see cref="AuctionKey"/> + priced breakdown generator the
+    /// bit-exactness fuzz harnesses reuse (see <c>benchmarks/COMPUTE_FLOOR_SPEC.md</c> §2 non-negotiables and §4 F2).
+    ///
+    /// It consolidates the two formerly-private generators (the closest-score kernel fuzz and the IsHigherValue fuzz)
+    /// into one pool/generator so every new scorer/extractor is fuzzed against the same broad input distribution. The
+    /// pools deliberately cover <b>every</b> branch the production scorers/extractors hit:
+    /// <list type="bullet">
+    ///   <item>enchants at matching / differing / missing level, including very-valuable enchant types;</item>
+    ///   <item>numeric modifiers (the float-difference path);</item>
+    ///   <item><c>candyUsed</c> (the "don't add value for same candy" branch);</item>
+    ///   <item><c>petItem</c> + <c>TIER_BOOST</c> (the tier-boost penalty);</item>
+    ///   <item>reforge match / mismatch;</item>
+    ///   <item>comma- and space-substring values (e.g. <c>unlocked_slots</c> "0,1,2") — the substring-containment rule;</item>
+    ///   <item>cake-year values (<c>new_years_cake</c>) including the <c>ImportantCakeYears</c> (69/420/400) guard;</item>
+    ///   <item>PET_SPIRIT-style pet values (the inverted/numeric pet modifiers) and non-numeric / "200k"-style values;</item>
+    ///   <item>every ImportanceFactor tier: normal / VeryValuable / Increadable.</item>
+    /// </list>
+    ///
+    /// The generator is <b>seed-deterministic</b>: a given <see cref="Random"/> sequence yields the same key/breakdown,
+    /// so the harnesses' per-seed loops remain reproducible. Modifier keys and enchant types are kept unique within a
+    /// single key (matching production key construction, where the inner key-match is at most one hit).
+    /// </summary>
+    internal static class AuctionKeyFuzz
+    {
+        /// <summary>
+        /// Modifier keys spanning all three <c>ImportanceFactor</c> tiers (normal / VeryValuable / Increadable) and the
+        /// special branches: <c>exp</c> (tier-boost interaction), <c>candyUsed</c> (same-candy / inverted), the
+        /// <c>petItem</c> tier-boost key, <c>new_years_cake</c> (cake-year / inverted), <c>edition</c> (inverted),
+        /// <c>unlocked_slots</c> (comma-substring), plus plain numeric and non-numeric attributes.
+        /// </summary>
+        public static readonly string[] ModKeyPool =
+        {
+            "exp", "candyUsed", "skin", "color", "ability_scroll", SniperService.PetItemKey,
+            "kills", "logs_cut", "rarity_upgrades", "winning_bid",
+            "edition", "new_years_cake", "unlocked_slots", "captured_player",
+        };
+
+        /// <summary>
+        /// Modifier values covering: small/large integers and a decimal (numeric float path), <c>"200k"</c> and
+        /// <c>"true"</c> / <c>"PERFECT"</c> (non-numeric else path), the <c>TIER_BOOST</c> shorthand, the
+        /// <c>ImportantCakeYears</c> 69/420/400, ordinary cake years (1/9/120), and comma-/space-substring values
+        /// (<c>"0,1,2"</c>, <c>"1,2,3,4"</c>, <c>"GEM RUBY"</c>) for the containment rule.
+        /// </summary>
+        public static readonly string[] ModValPool =
+        {
+            "1", "2", "3", "5", "8", "9", "3.5",            // numeric (incl. decimal)
+            "200k", "true", "PERFECT",                       // non-numeric else branch
+            SniperService.TierBoostShorthand,                // petItem tier-boost
+            "69", "420", "400", "120",                       // cake years (69/420/400 are ImportantCakeYears)
+            "0,1,2", "1,2,3,4", "GEM RUBY",                  // comma / space substring containment
+        };
+
+        /// <summary>
+        /// Enchant types spanning ordinary, very-valuable (<c>ultimate_wise</c>), and a couple of common types so the
+        /// enchant same-level / different-level / missing branches all fire.
+        /// </summary>
+        public static readonly EnchantmentType[] EnchPool =
+        {
+            EnchantmentType.sharpness, EnchantmentType.growth, EnchantmentType.protection,
+            EnchantmentType.critical, EnchantmentType.ultimate_wise,
+        };
+
+        public static readonly ItemReferences.Reforge[] ReforgePool =
+        {
+            ItemReferences.Reforge.Any, ItemReferences.Reforge.Gilded,
+            ItemReferences.Reforge.jaded, ItemReferences.Reforge.Necrotic,
+        };
+
+        /// <summary>
+        /// Random priced-breakdown value: hits the 0 (GetValueOrDefault default path), tiny, and realistic-coin buckets.
+        /// </summary>
+        public static long RandomValue(Random rng)
+        {
+            int roll = rng.Next(6);
+            return roll switch
+            {
+                0 => 0,                                  // exercises GetValueOrDefault default path
+                1 => rng.Next(1, 50),                    // tiny
+                _ => (long)rng.Next(1, 2000) * 1_000_000 // realistic coin values
+            };
+        }
+
+        /// <summary>
+        /// Builds an <see cref="AuctionKey"/> the same way the harness helpers do (enchants, reforge, modifiers, tier,
+        /// count); a thin wrapper so callers don't repeat the cast dance.
+        /// </summary>
+        public static AuctionKey Key(int tier, int count, List<Enchant> enchants = null,
+            List<KeyValuePair<string, string>> modifiers = null, ItemReferences.Reforge reforge = ItemReferences.Reforge.Any)
+            => new(enchants ?? new(), reforge, modifiers ?? new(), (Tier)tier, (byte)count);
+
+        /// <summary>
+        /// The shared generator: a random <see cref="AuctionKey"/> together with its priced breakdown (the <c>cv</c>
+        /// list of <see cref="SniperService.RankElem"/> produced by ComparisonValue). The <c>cv</c> mirrors the key's
+        /// enchants/modifiers (1:1) plus an optional reforge RankElem, exactly as the production breakdown does, so the
+        /// pair is consistent for both the score kernel (which consumes the <c>cv</c>) and IsHigherValue (which consumes
+        /// only the key).
+        /// </summary>
+        public static (AuctionKey key, List<SniperService.RankElem> cv) RandomKeyAndBreakdown(Random rng)
+        {
+            var enchants = new List<Enchant>();
+            var cv = new List<SniperService.RankElem>();
+            int enchCount = rng.Next(0, 4);
+            var usedTypes = new HashSet<EnchantmentType>();
+            for (int i = 0; i < enchCount; i++)
+            {
+                var t = EnchPool[rng.Next(EnchPool.Length)];
+                if (!usedTypes.Add(t)) continue; // keep enchant types unique within a key
+                var e = new Enchant { Type = t, Lvl = (byte)rng.Next(1, 8) };
+                enchants.Add(e);
+                cv.Add(new(e, RandomValue(rng)));
+            }
+
+            var modifiers = new List<KeyValuePair<string, string>>();
+            int modCount = rng.Next(0, 5);
+            var usedKeys = new HashSet<string>();
+            for (int i = 0; i < modCount; i++)
+            {
+                var k = ModKeyPool[rng.Next(ModKeyPool.Length)];
+                if (!usedKeys.Add(k)) continue; // unique modifier keys within a key
+                // petItem leans toward TIER_BOOST so the tier-boost branch is hit often.
+                var v = k == SniperService.PetItemKey && rng.Next(2) == 0
+                    ? SniperService.TierBoostShorthand
+                    : ModValPool[rng.Next(ModValPool.Length)];
+                var kv = new KeyValuePair<string, string>(k, v);
+                modifiers.Add(kv);
+                cv.Add(new(kv, RandomValue(rng)));
+            }
+
+            var reforge = ReforgePool[rng.Next(ReforgePool.Length)];
+            if (reforge != ItemReferences.Reforge.Any && rng.Next(2) == 0)
+                cv.Add(new(reforge, RandomValue(rng)));
+
+            var key = Key(rng.Next(0, 12), rng.Next(1, 5), enchants, modifiers, reforge);
+            return (key, cv);
+        }
+    }
+}

--- a/Services/AuctionKeyPrimitives.Reference.cs
+++ b/Services/AuctionKeyPrimitives.Reference.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R2 Phase 0 / F3 bit-exactness oracle for the <b>cross-cutting <see cref="AuctionKey"/> primitives</b>
+    /// (<c>Equals</c> / <c>GetHashCode</c> / <c>ToString</c>) — the gate for workstream <b>R2-E</b>
+    /// (zero-alloc primitives, see <c>benchmarks/COMPUTE_FLOOR_SPEC_R2.md</c> §2.1 + §5 R2-E).
+    ///
+    /// These static <c>*Reference</c> methods are <b>verbatim copies of the CURRENT (pre-de-LINQ)
+    /// <see cref="AuctionKey"/> implementation</b> of <c>Equals(object)</c>, <c>GetHashCode()</c> and
+    /// <c>ToString()</c> (Models/AuctionKey.cs as of this commit). R2-E will rewrite the production methods to
+    /// explicit, zero-alloc loops; the only contract that rewrite must preserve is that, for every fuzzed input,
+    /// the production result is byte-identical to the snapshot captured here. They are referenced <b>only</b> by
+    /// <see cref="AuctionKeyPrimitivesTests"/>; they are never called from production.
+    ///
+    /// Because <c>GetHashCode</c>/<c>Equals</c> are exercised on every dictionary probe, the oracle also asserts the
+    /// hash/equality contract invariant (<c>Equals(a,b) =&gt; GetHashCode(a)==GetHashCode(b)</c>) directly against the
+    /// reference, so a refactor cannot silently break the dictionary-correctness property R2-E depends on.
+    /// </summary>
+    internal static class AuctionKeyPrimitivesReference
+    {
+        /// <summary>
+        /// Verbatim copy of <see cref="AuctionKey.GetHashCode"/> as of the R2 Phase 0 snapshot
+        /// (order-independent: sums well-mixed per-element hashes).
+        /// </summary>
+        public static int GetHashCodeReference(AuctionKey self)
+        {
+            var enchRes = 0;
+            if (self.Enchants != null)
+                foreach (var item in self.Enchants)
+                    enchRes += item.GetHashCode();
+            var modRes = 0;
+            if (self.Modifiers != null)
+                foreach (var item in self.Modifiers)
+                    modRes += HashCode.Combine(item.Key, item.Value);
+            return HashCode.Combine(enchRes, self.Reforge, modRes, self.Tier, self.Count);
+        }
+
+        /// <summary>
+        /// Verbatim copy of <see cref="AuctionKey.ToString"/> as of the R2 Phase 0 snapshot.
+        /// </summary>
+        public static string ToStringReference(AuctionKey self)
+        {
+            return $"{(self.Enchants == null ? "ne" : string.Join(',', self.Enchants.Select(m => $"{m.Type}={m.Lvl}")))} {self.Reforge} {(self.Modifiers == null ? "nm" : string.Join(',', self.Modifiers.Select(m => m.ToString())))} {self.Tier} {self.Count}";
+        }
+
+        /// <summary>
+        /// Verbatim copy of <see cref="AuctionKey.Equals(object)"/> as of the R2 Phase 0 snapshot
+        /// (order-independent set comparison of enchants and modifiers, LINQ <c>All</c>/<c>Any</c>).
+        /// </summary>
+        public static bool EqualsReference(AuctionKey self, object obj)
+        {
+            return obj is AuctionKey key &&
+                   self.Reforge == key.Reforge &&
+                   self.Tier == key.Tier &&
+                   self.Count == key.Count &&
+                   (key.Enchants == null && self.Enchants == null ||
+                    (self.Enchants != null && key.Enchants != null &&
+                     self.Enchants.Count == key.Enchants.Count &&
+                     self.Enchants.All(e => key.Enchants.Any(ke => ke.Type == e.Type && ke.Lvl == e.Lvl)))) &&
+                   (key.Modifiers == null && self.Modifiers == null ||
+                    (self.Modifiers != null && key.Modifiers != null &&
+                     self.Modifiers.Count == key.Modifiers.Count &&
+                     self.Modifiers.All(m => key.Modifiers.Any(km => km.Key == m.Key && km.Value == m.Value))));
+        }
+    }
+}

--- a/Services/AuctionKeyPrimitives.Tests.cs
+++ b/Services/AuctionKeyPrimitives.Tests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R2 Phase 0 / F3 bit-exactness oracle for the cross-cutting <see cref="AuctionKey"/> primitives
+    /// (<c>Equals</c> / <c>GetHashCode</c> / <c>ToString</c>). This is the gate workstream <b>R2-E</b>
+    /// (zero-alloc primitives, <c>benchmarks/COMPUTE_FLOOR_SPEC_R2.md</c> §2.1 + §5 R2-E) is held to: the de-LINQ'd
+    /// production methods must be <b>byte-identical</b> to the snapshot captured in
+    /// <see cref="AuctionKeyPrimitivesReference"/> (a verbatim copy of the current impl) over a large fuzzed input set.
+    ///
+    /// What is gated and how (golden-output capture against the verbatim reference):
+    /// <list type="bullet">
+    ///   <item><b><see cref="AuctionKey.GetHashCode"/></b> — every fuzzed key's hash equals
+    ///     <see cref="AuctionKeyPrimitivesReference.GetHashCodeReference"/>, AND is stable across element re-ordering
+    ///     (Equals is order-independent, so the hash must be too — the dictionary-correctness property).</item>
+    ///   <item><b><see cref="AuctionKey.ToString"/></b> — every fuzzed key's string equals
+    ///     <see cref="AuctionKeyPrimitivesReference.ToStringReference"/> (the <c>MedianKey</c>/log string, 31% of strings).</item>
+    ///   <item><b><see cref="AuctionKey.Equals(object)"/></b> (and <c>operator ==</c>/<c>!=</c>) — for every fuzzed PAIR
+    ///     the production verdict equals <see cref="AuctionKeyPrimitivesReference.EqualsReference"/>, including the
+    ///     null-collection branches, the order-independent set semantics, and reflexivity/symmetry.</item>
+    ///   <item>The hash/equality <b>contract invariant</b>: <c>Equals(a,b) =&gt; GetHashCode(a)==GetHashCode(b)</c>,
+    ///     asserted directly so a refactor cannot break dictionary lookups.</item>
+    /// </list>
+    ///
+    /// Inputs come from the shared <see cref="AuctionKeyFuzz"/> generator (the same broad distribution every other
+    /// bit-exactness harness uses) plus a hand-built set of edge keys (null collections, empty collections, the
+    /// permutation/near-miss pairs that exercise the order-independent <c>All</c>/<c>Any</c> set comparison).
+    /// </summary>
+    public class AuctionKeyPrimitivesTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
+        // ---------- single-key primitives: GetHashCode + ToString golden output ----------
+
+        [Test]
+        public void GetHashCode_And_ToString_BitExact_VsReference()
+        {
+            int checkedCount = 0;
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                var (key, _) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+
+                key.GetHashCode().Should().Be(AuctionKeyPrimitivesReference.GetHashCodeReference(key),
+                    $"GetHashCode must equal the reference snapshot (seed={seed}, key={key})");
+                key.ToString().Should().Be(AuctionKeyPrimitivesReference.ToStringReference(key),
+                    $"ToString must equal the reference snapshot (seed={seed})");
+                checkedCount++;
+            }
+            checkedCount.Should().Be(40_000);
+        }
+
+        // ---------- pairwise Equals golden output + contract invariant ----------
+
+        [Test]
+        public void Equals_BitExact_VsReference_AndHonorsHashContract()
+        {
+            int checkedPairs = 0, equalPairs = 0, reorderedEqualPairs = 0;
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                var (a, _) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+                var (b, _) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+
+                // distinct-key pair (mostly unequal — exercises the unequal branches at every field)
+                AssertPair(a, b, $"seed={seed}");
+                checkedPairs++;
+
+                // structural clone: forces the fully-equal branch through every field on every iteration.
+                var aClone = CloneKey(a);
+                AssertPair(a, aClone, $"seed={seed} self-clone");
+                a.Equals(aClone).Should().BeTrue($"a key must equal its structural clone (seed={seed}, key={a})");
+                equalPairs++; // the clone pair is always equal
+
+                // a genuinely-equal-but-distinct pair built by re-ordering the collections — the high-entropy fuzz keys
+                // essentially never collide by chance, so this is how the equal branch's order-independent set semantics
+                // (Enchants/Modifiers .All/.Any) are exercised against the reference on non-clone instances.
+                var reordered = ShuffleCollections(a, new Random(seed * 17 + 3));
+                AssertPair(a, reordered, $"seed={seed} reordered");
+                if (a.Equals(reordered)) reorderedEqualPairs++;
+            }
+            checkedPairs.Should().Be(40_000);
+            equalPairs.Should().Be(40_000, "the clone pair exercises the equal branch on every iteration");
+            reorderedEqualPairs.Should().Be(40_000,
+                "every re-ordering of a key must compare equal (order-independent set semantics), proving the equal branch on distinct instances");
+        }
+
+        // ---------- order-independence (the set-semantics Equals depends on) ----------
+
+        [Test]
+        public void Permuted_KeysAreEqual_AndHashStable()
+        {
+            int permuted = 0;
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                var (key, _) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+                var shuffled = ShuffleCollections(key, new Random(seed * 31 + 7));
+
+                // a re-ordering of the same enchants/modifiers must compare equal (order-independent set semantics)...
+                key.Equals(shuffled).Should().BeTrue($"permuted key must equal original (seed={seed}, key={key})");
+                AuctionKeyPrimitivesReference.EqualsReference(key, shuffled).Should().BeTrue();
+                (key == shuffled).Should().BeTrue();
+                // ...and therefore (hash contract) must hash identically, against BOTH prod and the reference.
+                shuffled.GetHashCode().Should().Be(key.GetHashCode(),
+                    $"order-independent Equals demands an order-independent hash (seed={seed}, key={key})");
+                AuctionKeyPrimitivesReference.GetHashCodeReference(shuffled)
+                    .Should().Be(AuctionKeyPrimitivesReference.GetHashCodeReference(key));
+                if (key.Enchants.Count > 1 || key.Modifiers.Count > 1) permuted++;
+            }
+            permuted.Should().BeGreaterThan(0, "fuzz must yield keys with >1 enchant/modifier so permutation actually reorders something");
+        }
+
+        // ---------- hand-built edge keys (null / empty collections, near-miss pairs) ----------
+
+        [Test]
+        public void EdgeCases_BitExact_VsReference()
+        {
+            var keys = EdgeKeys();
+            for (int i = 0; i < keys.Count; i++)
+            {
+                var k = keys[i];
+                k.GetHashCode().Should().Be(AuctionKeyPrimitivesReference.GetHashCodeReference(k), $"hash edge[{i}]");
+                k.ToString().Should().Be(AuctionKeyPrimitivesReference.ToStringReference(k), $"toString edge[{i}]");
+            }
+            for (int i = 0; i < keys.Count; i++)
+                for (int j = 0; j < keys.Count; j++)
+                    AssertPair(keys[i], keys[j], $"edge pair [{i}]x[{j}]");
+
+            // explicit operator coverage incl. null operands (operator== short-circuits on null left)
+            AuctionKey nullKey = null;
+            (nullKey == keys[0]).Should().BeFalse();
+            (keys[0] == nullKey).Should().BeFalse();
+            keys[0].Equals(null).Should().Be(AuctionKeyPrimitivesReference.EqualsReference(keys[0], null));
+        }
+
+        // ---------- core pair assertion: production verdict + ops == reference, both directions ----------
+
+        private static void AssertPair(AuctionKey a, AuctionKey b, string ctx)
+        {
+            var refAb = AuctionKeyPrimitivesReference.EqualsReference(a, b);
+            var refBa = AuctionKeyPrimitivesReference.EqualsReference(b, a);
+
+            a.Equals(b).Should().Be(refAb, $"Equals(a,b) must match reference [{ctx}]\n  a={a}\n  b={b}");
+            b.Equals(a).Should().Be(refBa, $"Equals(b,a) must match reference [{ctx}]\n  a={a}\n  b={b}");
+            (a == b).Should().Be(refAb, $"operator== must match reference [{ctx}]");
+            (a != b).Should().Be(!refAb, $"operator!= must match reference [{ctx}]");
+
+            if (a.Equals(b))
+            {
+                // symmetry (Equals is defined symmetric) ...
+                b.Equals(a).Should().BeTrue($"Equals must be symmetric [{ctx}]");
+                // ... and the hash/equality contract: equal keys MUST hash equally (prod and reference).
+                a.GetHashCode().Should().Be(b.GetHashCode(),
+                    $"equal keys must share a hash code [{ctx}]\n  a={a}\n  b={b}");
+                AuctionKeyPrimitivesReference.GetHashCodeReference(a)
+                    .Should().Be(AuctionKeyPrimitivesReference.GetHashCodeReference(b), $"reference hash contract [{ctx}]");
+            }
+        }
+
+        // ---------- helpers ----------
+
+        private static AuctionKey CloneKey(AuctionKey k) => new AuctionKey
+        {
+            Enchants = k.Enchants == null ? null : new(k.Enchants.ToList()),
+            Reforge = k.Reforge,
+            Modifiers = k.Modifiers == null ? null : new(k.Modifiers.ToList()),
+            Tier = k.Tier,
+            Count = k.Count,
+        };
+
+        private static AuctionKey ShuffleCollections(AuctionKey k, Random rng)
+        {
+            var ench = k.Enchants?.OrderBy(_ => rng.Next()).ToList();
+            var mods = k.Modifiers?.OrderBy(_ => rng.Next()).ToList();
+            return new AuctionKey
+            {
+                Enchants = ench == null ? null : new(ench),
+                Reforge = k.Reforge,
+                Modifiers = mods == null ? null : new(mods),
+                Tier = k.Tier,
+                Count = k.Count,
+            };
+        }
+
+        private static List<AuctionKey> EdgeKeys()
+        {
+            var e0 = new Enchant { Type = Enchantment.EnchantmentType.sharpness, Lvl = 5 };
+            var e1 = new Enchant { Type = Enchantment.EnchantmentType.growth, Lvl = 3 };
+            var m0 = new KeyValuePair<string, string>("exp", "1000000");
+            var m1 = new KeyValuePair<string, string>("candyUsed", "1");
+
+            return new List<AuctionKey>
+            {
+                // null collections (the `Enchants == null` / `Modifiers == null` branches)
+                new AuctionKey { Enchants = null, Modifiers = null, Reforge = ItemReferences.Reforge.Any, Tier = Tier.COMMON, Count = 1 },
+                new AuctionKey { Enchants = null, Modifiers = new(new List<KeyValuePair<string,string>>()), Reforge = ItemReferences.Reforge.Any, Tier = Tier.COMMON, Count = 1 },
+                // empty collections
+                AuctionKeyFuzz.Key((int)Tier.COMMON, 1),
+                // single element each
+                AuctionKeyFuzz.Key((int)Tier.RARE, 2, new List<Enchant> { e0 }, new List<KeyValuePair<string,string>> { m0 }),
+                // two-element collections (order-independence + near-miss diffs below)
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 1, new List<Enchant> { e0, e1 }, new List<KeyValuePair<string,string>> { m0, m1 }),
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 1, new List<Enchant> { e1, e0 }, new List<KeyValuePair<string,string>> { m1, m0 }), // permuted clone of prior
+                // near-miss: differs only by enchant level
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 1, new List<Enchant> { new Enchant { Type = Enchantment.EnchantmentType.sharpness, Lvl = 6 }, e1 },
+                    new List<KeyValuePair<string,string>> { m0, m1 }),
+                // near-miss: differs only by reforge
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 1, new List<Enchant> { e0, e1 }, new List<KeyValuePair<string,string>> { m0, m1 }, ItemReferences.Reforge.Gilded),
+                // near-miss: differs only by tier / count
+                AuctionKeyFuzz.Key((int)Tier.LEGENDARY, 1, new List<Enchant> { e0, e1 }, new List<KeyValuePair<string,string>> { m0, m1 }),
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 3, new List<Enchant> { e0, e1 }, new List<KeyValuePair<string,string>> { m0, m1 }),
+                // near-miss: differs only by a modifier value
+                AuctionKeyFuzz.Key((int)Tier.EPIC, 1, new List<Enchant> { e0, e1 },
+                    new List<KeyValuePair<string,string>> { new KeyValuePair<string,string>("exp", "2000000"), m1 }),
+            };
+        }
+    }
+}

--- a/Services/CleanItemPrice.Tests.cs
+++ b/Services/CleanItemPrice.Tests.cs
@@ -1,0 +1,146 @@
+using System;
+using AwesomeAssertions;
+using Coflnet.Sky.Sniper.Models;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R5B (partial selection) bit-exactness gate for the clean-price order-statistic selection.
+    ///
+    /// <para>
+    /// <b>What is under test.</b> <see cref="SniperService.GetCleanItemPrice"/>'s hottest internal (≈55–65% of cold/rare
+    /// Sniper CPU, per <c>COMPUTE_FLOOR_SPEC_R5.md</c> P4) is the two-full-stable-sort selection
+    /// <see cref="SniperService.CleanItemPriceSelectTargetReference"/>: it sorts ALL n references by
+    /// (Day DESC, Price ASC, idx ASC), takes the first <c>size</c>, stable-sorts that prefix by (Price ASC,
+    /// prefix-position ASC), and returns the element at position <c>skip</c>. R5B replaces it with
+    /// <see cref="SniperService.CleanItemPriceSelectTarget"/> — two bounded quickselect partitions (no full sort) —
+    /// which must return the <b>identical</b> <see cref="ReferencePrice"/> for every input.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Why this fuzz is heavier than competitor A's.</b> Partial/selection methods diverge from a stable full sort
+    /// precisely at TIE boundaries (equal Day and/or equal Price). A naive <c>nth_element</c> is unstable and would
+    /// pick the wrong element of a tie group. This fuzz therefore generates <b>40,000</b> seeds of randomized
+    /// <see cref="ReferencePrice"/>[] (length 0..~400) with deliberately <b>narrow Day AND Price ranges</b> so ties are
+    /// dense, plus random valid (size, skip), and asserts the partial selection equals the reference selection on
+    /// <b>all of Price, Day, AND AuctionId</b> (AuctionId is the discriminator that catches a same-Price/same-Day tie
+    /// being resolved to the wrong original element). 0 mismatches is the ship gate.
+    /// </para>
+    /// </summary>
+    public class CleanItemPriceTests
+    {
+        [Test]
+        public void Fuzz_PartialSelection_BitExact_VsReference_HeavyTies()
+        {
+            int mismatches = 0;
+            string first = "";
+            long totalRefs = 0;
+            int maxN = 0;
+            int tiePathExercised = 0; // count of cases where ties actually existed in the consumed prefix
+
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                int n = rng.Next(0, 401); // 0..400 references
+
+                // Heavy ties: keep Day and Price ranges SMALL relative to n so equal-key collisions are dense.
+                // Range width is itself randomized (1..8 for Day, 1..6 for Price) so we span "almost all equal"
+                // through "moderately distinct"; AuctionId is unique per element (the tie discriminator).
+                int dayRange = rng.Next(1, 9);
+                int priceRange = rng.Next(1, 7);
+                short dayBase = (short)rng.Next(-30, 30);
+
+                var refs = new ReferencePrice[n];
+                bool sawDup = false;
+                for (int i = 0; i < n; i++)
+                {
+                    refs[i] = new ReferencePrice
+                    {
+                        AuctionId = ((long)seed << 20) | (uint)i, // globally unique within the run
+                        Day = (short)(dayBase + rng.Next(0, dayRange)),
+                        Price = rng.Next(0, priceRange),
+                        Seller = (short)rng.Next(0, 4),
+                        Buyer = (short)rng.Next(0, 4),
+                    };
+                }
+                _ = sawDup;
+
+                // Mirror the GetCleanItemPrice sizing so (size, skip) span realistic and edge shapes.
+                // size = min(max(Volume*10, 50), n) with a randomized Volume; plus the devider-derived skip.
+                float volume = (float)(rng.NextDouble() * rng.Next(0, 60));
+                int size = (int)Math.Min(Math.Max(volume * 10, 50), n);
+                // also throw in fully-random valid (size, skip) on half the seeds to stress arbitrary ranks
+                if ((seed & 1) == 0 && n > 0)
+                    size = rng.Next(1, n + 1);
+                int devider = new[] { 10, 14, 30 }[rng.Next(3)];
+                int skip = size / devider + 1;
+                if ((seed & 3) == 0 && size > 0)
+                    skip = rng.Next(0, size + 2); // sometimes push skip past the guard boundary
+
+                var live = SniperService.CleanItemPriceSelectTarget(refs, size, skip);
+                var reference = SniperService.CleanItemPriceSelectTargetReference(refs, size, skip);
+
+                if (live.Price != reference.Price || live.Day != reference.Day || live.AuctionId != reference.AuctionId)
+                {
+                    if (mismatches == 0)
+                        first = $"seed={seed} n={n} size={size} skip={skip} dayRange={dayRange} priceRange={priceRange}\n"
+                              + $"  live=(Price={live.Price},Day={live.Day},Auc={live.AuctionId})\n"
+                              + $"  ref =(Price={reference.Price},Day={reference.Day},Auc={reference.AuctionId})";
+                    mismatches++;
+                }
+
+                totalRefs += n;
+                if (n > maxN) maxN = n;
+                // crude tie-density signal: dense ranges over many refs => the prefix has ties
+                if (n >= 20 && (dayRange <= 4 || priceRange <= 3)) tiePathExercised++;
+            }
+
+            // Sanity: the fuzz actually exercised dense-tie inputs at non-trivial sizes.
+            tiePathExercised.Should().BeGreaterThan(1000,
+                "the heavy-tie generator must have produced many dense-tie cases");
+            maxN.Should().BeGreaterThan(300, "the fuzz must cover large reference counts");
+
+            mismatches.Should().Be(0,
+                $"partial selection must be bit-exact with the two-full-sort reference over 40000 heavy-tie seeds "
+              + $"({totalRefs} refs total, maxN={maxN}). First mismatch: {first}");
+        }
+
+        [Test]
+        public void EdgeCases_Match_Reference()
+        {
+            // Empty / guard / single-element / all-equal / size==n / skip at boundaries.
+            var cases = new (ReferencePrice[] refs, int size, int skip)[]
+            {
+                (Array.Empty<ReferencePrice>(), 0, 0),                       // empty -> guard -> default
+                (Refs((1, 0, 5)), 1, 0),                                     // single element, skip 0
+                (Refs((1, 0, 5)), 1, 1),                                     // skip >= size -> guard -> default
+                (Refs((1, 0, 5)), 0, 0),                                     // size 0 -> guard -> default
+                (Refs((1,1,5),(2,1,5),(3,1,5),(4,1,5)), 4, 2),              // all Day & Price equal -> idx tiebreak only
+                (Refs((1,1,5),(2,2,5),(3,1,5),(4,2,5)), 4, 0),              // Day ties, Price ties interleaved
+                (Refs((1,1,10),(2,1,20),(3,1,30)), 3, 0),                    // same Day, distinct Price, skip first
+                (Refs((1,1,10),(2,1,20),(3,1,30)), 2, 1),                    // size<n prefix + skip last in prefix
+                (Refs((1,3,5),(2,2,5),(3,1,5)), 3, 1),                       // distinct Day same Price (Day desc)
+                (Refs((1,1,5),(2,1,5),(3,1,5),(4,1,5),(5,1,5)), 5, 4),      // all equal, skip last
+            };
+
+            foreach (var (refs, size, skip) in cases)
+            {
+                var live = SniperService.CleanItemPriceSelectTarget(refs, size, skip);
+                var reference = SniperService.CleanItemPriceSelectTargetReference(refs, size, skip);
+                live.Price.Should().Be(reference.Price);
+                live.Day.Should().Be(reference.Day);
+                live.AuctionId.Should().Be(reference.AuctionId);
+            }
+        }
+
+        // helper: build a ReferencePrice[] from (auctionId, day, price) tuples.
+        private static ReferencePrice[] Refs(params (long auc, short day, long price)[] xs)
+        {
+            var r = new ReferencePrice[xs.Length];
+            for (int i = 0; i < xs.Length; i++)
+                r[i] = new ReferencePrice { AuctionId = xs[i].auc, Day = xs[i].day, Price = xs[i].price };
+            return r;
+        }
+    }
+}

--- a/Services/CleanItemPriceMemo.Tests.cs
+++ b/Services/CleanItemPriceMemo.Tests.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R6/MEMO2 bit-exactness soak for the entry-epoch-stamped <see cref="CleanItemPriceMemo"/> (the version-invalidated
+    /// memo of the <c>GetCleanItemPrice</c> recompute). Mirrors the <c>ReferenceSnapshot</c> soak / <c>VerifyClosestIndex</c>
+    /// parity pattern: drives MANY <c>GetCleanItemPrice</c> calls across tiers/tags/forces under simulated lookup
+    /// mutation and asserts the memoized result (live production, which now routes through the memo) EQUALS a fresh,
+    /// non-memoized recompute (<see cref="SniperService.GetCleanItemPriceForTest"/>'s verbatim reference) EVERY time —
+    /// 0 divergences.
+    ///
+    /// <para>The reference (<c>GetCleanItemPriceReference</c>) re-checks <c>CleanPricePerTier</c> and re-runs the full
+    /// flatten/sort/select itself, touching NONE of the memo, so equality proves the memo never returns a value a fresh
+    /// recompute (with identical force/non-force semantics) wouldn't — including across invalidation boundaries and for
+    /// the <c>force:true</c> callers (force is exercised on every key).</para>
+    ///
+    /// <para>The warm fix (vs the deferred clean3) is per-ENTRY stamping: ONE memo dict per lookup for its lifetime (the
+    /// dict reference never changes after first publication), each entry carrying its own (epoch, Count, Volume, builtAt)
+    /// stamp. <see cref="Memo_IsActuallyHit_AndInvalidatedByEntryStamp"/> asserts exactly that — the dict is reused
+    /// across an epoch bump (no realloc) while the stale entry is re-stamped on the next read.</para>
+    /// </summary>
+    public class CleanItemPriceMemoTests
+    {
+        private SniperService service = null!;
+        private CraftCostMock craftCost = null!;
+        private HypixelItemService itemService = null!;
+        private static long idCounter;
+
+        private class CraftCostMock : ICraftCostService
+        {
+            public Dictionary<string, double> Costs { get; } = new();
+            public Dictionary<string, Category> ItemCategories { get; } = new();
+            public void AddCostForSpecialItems() { }
+            public bool TryGetCost(string itemId, out double cost) => Costs.TryGetValue(itemId, out cost);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            SniperService.StartTime = new DateTime(2021, 9, 25);
+            craftCost = new CraftCostMock();
+            itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, craftCost);
+            idCounter = 100;
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        // ============================================================================================================
+        // The soak: live (memo) == fresh recompute, across tiers/tags/forces, REPEATED (hits) and under MUTATION.
+        // ============================================================================================================
+
+        [Test]
+        public void Memo_BitExact_VsFreshRecompute_UnderMutation()
+        {
+            // A non-pet tag, a pet tag, and a gem-capable tag — exercises isPet, the gem-devider, and tier filtering.
+            string[] tags = { "SOME_SOAK_SWORD", "PET_SOAK_LION", "DIVAN_DRILL_4" };
+            foreach (var tag in tags)
+                SeedTag(tag);
+            service.FinishedUpdate();
+
+            int comparisons = 0;
+            // Outer loop simulates lookup mutation between waves: each AddSoldItem -> UpdateMedian bumps the pricing
+            // epoch (and may change references / dict Count / Volume), which is exactly what invalidates the memo
+            // entries. We assert equality BEFORE and AFTER each mutation, and also repeatedly within a wave (to force
+            // memo HITS off the freshly-stamped entries).
+            for (int wave = 0; wave < 12; wave++)
+            {
+                foreach (var tag in tags)
+                {
+                    service.Lookups.TryGetValue(tag, out var lookup).Should().BeTrue();
+                    var keys = lookup.Lookup.Keys.ToList();
+                    // Repeat the inner sweep so the 2nd+ pass within a stable epoch is served by the memo (hits), not builds.
+                    for (int pass = 0; pass < 3; pass++)
+                    {
+                        foreach (var k in keys)
+                            comparisons += AssertParity(tag, lookup, k);
+                        // also drive synthetic reduced-tier keys (TIER_BOOST / rarity_upgrades) per pass
+                        comparisons += AssertParity(tag, lookup, ReducedTierKey(tag, Tier.LEGENDARY, SniperService.PetItemKey, SniperService.TierBoostShorthand));
+                        comparisons += AssertParity(tag, lookup, ReducedTierKey(tag, Tier.LEGENDARY, "rarity_upgrades", "1"));
+                        // and a few tiers that may not have a bucket at all (empty-flatten path)
+                        foreach (var t in new[] { Tier.UNKNOWN, Tier.COMMON, Tier.MYTHIC, Tier.DIVINE })
+                            comparisons += AssertParity(tag, lookup, PlainTierKey(tag, t));
+                    }
+                }
+
+                // mutate: add a sold item to one tag (bumps epoch + grows references/volume; sometimes a new dict key)
+                var mutTag = tags[wave % tags.Length];
+                var mut = AuctionFor(mutTag, (Tier)(Tier.UNCOMMON + wave % 4));
+                if (wave % 2 == 0)
+                    mut.FlatenedNBT["soakmod" + wave] = "1"; // occasionally a novel bucket key -> dict Count change
+                AddVolume(mut, 5);
+                service.FinishedUpdate();
+            }
+
+            comparisons.Should().BeGreaterThan(500, "the soak must exercise many (tag, tier, force) recomputes + hits");
+        }
+
+        [Test]
+        public void Memo_IsActuallyHit_AndInvalidatedByEntryStamp()
+        {
+            string tag = "MEMO_HIT_SWORD";
+            SeedTag(tag);
+            service.FinishedUpdate();
+            service.Lookups.TryGetValue(tag, out var lookup).Should().BeTrue();
+
+            var key = lookup.Lookup.Keys.First();
+            var detailed = service.ValueKeyForTest(AuctionFromKey(tag, key));
+
+            // first force call builds+stamps the memo entry; subsequent identical force calls must hit it (same epoch)
+            var first = service.GetCleanItemPrice(tag, detailed, lookup, force: true);
+            var memo = lookup.CleanPriceMemo;
+            memo.Should().NotBeNull("a memo dict must be published after the recompute");
+            memo!.Values.TryGetValue((tag, key.Tier), out var entry1).Should().BeTrue("the recompute result must be memoized");
+            entry1.Value.Should().Be(first);
+
+            var second = service.GetCleanItemPrice(tag, detailed, lookup, force: true);
+            second.Should().Be(first, "a force call within the same epoch must return the memoized recompute (bit-exact)");
+            // The warm fix: the memo DICT is reused for the lookup's lifetime — never re-allocated on a hit.
+            ReferenceEquals(lookup.CleanPriceMemo, memo).Should().BeTrue("a hit must not rebuild the memo dict");
+
+            // a mutation bumps the pricing epoch -> the existing entry's stamp goes stale (a MISS), the next call must
+            // recompute and RE-STAMP the entry in place. The dict reference itself must NOT change (no per-window realloc).
+            AddVolume(AuctionFor(tag, Tier.RARE), 5);
+            service.FinishedUpdate();
+            var third = service.GetCleanItemPrice(tag, detailed, lookup, force: true);
+            ReferenceEquals(lookup.CleanPriceMemo, memo).Should().BeTrue("an epoch bump must NOT reallocate the memo dict (the warm fix)");
+            lookup.CleanPriceMemo!.Values.TryGetValue((tag, key.Tier), out var entry2).Should().BeTrue();
+            entry2.Epoch.Should().NotBe(entry1.Epoch, "the stale entry must have been re-stamped at the new epoch");
+
+            // and it stays bit-exact with a fresh recompute after invalidation
+            var (live, reference) = service.GetCleanItemPriceForTest(tag, detailed, lookup, force: true);
+            live.Should().Be(reference, "the post-invalidation memo must equal a fresh recompute");
+        }
+
+        [Test]
+        public void Memo_BitExact_UnderConcurrency()
+        {
+            // The risky finder runs on a background Task; assert the memo is tear-safe and bit-exact under parallel
+            // GetCleanItemPrice calls for the same lookup (concurrent build + hit races store identical deterministic
+            // values, so a concurrent reader can never observe a value a fresh recompute wouldn't).
+            string tag = "MEMO_CONC_SWORD";
+            SeedTag(tag);
+            service.FinishedUpdate();
+            service.Lookups.TryGetValue(tag, out var lookup).Should().BeTrue();
+            var keys = lookup.Lookup.Keys.ToList();
+            var detaileds = keys.Select(k => service.ValueKeyForTest(AuctionFromKey(tag, k))).ToList();
+
+            long divergences = 0;
+            Parallel.For(0, 2000, i =>
+            {
+                int idx = i % detaileds.Count;
+                bool force = (i & 1) == 0;
+                var (live, reference) = service.GetCleanItemPriceForTest(tag, detaileds[idx], lookup, force);
+                if (live != reference)
+                    Interlocked.Increment(ref divergences);
+            });
+            divergences.Should().Be(0, "the memo must be bit-exact with a fresh recompute under concurrent access");
+            // The memo dict is created exactly once even under a concurrent first-touch race (atomic CAS publish).
+            lookup.CleanPriceMemo.Should().NotBeNull();
+        }
+
+        // ---------- helpers ----------
+
+        /// <summary>Asserts live (memo) == fresh recompute for both force values; returns the number of comparisons made.</summary>
+        private int AssertParity(string tag, PriceLookup lookup, AuctionKey key)
+        {
+            var detailed = service.ValueKeyForTest(AuctionFromKey(tag, key));
+            int made = 0;
+            foreach (var force in new[] { false, true })
+            {
+                var (live, reference) = service.GetCleanItemPriceForTest(tag, detailed, lookup, force);
+                live.Should().Be(reference,
+                    $"memo (force={force}) must equal a fresh recompute for {tag} tier={key.Tier} mods=[{string.Join(",", key.Modifiers.Select(m => m.Key + "=" + m.Value))}]");
+                made++;
+            }
+            return made;
+        }
+
+        private AuctionKey ReducedTierKey(string tag, Tier tier, string modKey, string modVal)
+        {
+            var a = AuctionWith(tag, tier, new() { { modKey, modVal } });
+            return service.ValueKeyForTest(a).Key;
+        }
+
+        private AuctionKey PlainTierKey(string tag, Tier tier)
+            => service.ValueKeyForTest(AuctionWith(tag, tier, new())).Key;
+
+        private void SeedTag(string tag)
+        {
+            bool isPet = NBT.IsPet(tag);
+            for (int t = (int)Tier.COMMON; t <= (int)Tier.LEGENDARY; t++)
+            {
+                var a = AuctionFor(tag, (Tier)t);
+                a.HighestBidAmount = 1_000_000L * (t + 1);
+                AddVolume(a, 8);
+            }
+            // a bucket carrying an excluded modifier (attribute for non-pet, TIER_BOOST for pet) for filter coverage
+            var extra = AuctionFor(tag, Tier.LEGENDARY);
+            if (isPet)
+                extra.FlatenedNBT["heldItem"] = "PET_ITEM_TIER_BOOST";
+            else
+                extra.FlatenedNBT["mending"] = "5";
+            extra.HighestBidAmount = 77_000_000;
+            AddVolume(extra, 8);
+        }
+
+        private SaveAuction AuctionFor(string tag, Tier tier)
+        {
+            var nbt = new Dictionary<string, string>();
+            if (NBT.IsPet(tag))
+            {
+                nbt["exp"] = "10000000";
+                nbt["candyUsed"] = "0";
+            }
+            else
+            {
+                nbt["skin"] = "soak";
+            }
+            return new SaveAuction
+            {
+                Tag = tag,
+                Tier = tier,
+                FlatenedNBT = nbt,
+                Enchantments = new List<Enchantment>(),
+                Category = Category.UNKNOWN,
+                Count = 1,
+                StartingBid = 1000,
+                HighestBidAmount = 1000,
+                UId = idCounter++,
+                Uuid = (idCounter++).ToString().PadRight(8, '0'),
+                AuctioneerId = ((short)(idCounter++ % 20000)).ToString().PadRight(8, '0'),
+            };
+        }
+
+        private static SaveAuction AuctionWith(string tag, Tier tier, Dictionary<string, string> nbt)
+        {
+            if (NBT.IsPet(tag) && !nbt.ContainsKey("exp"))
+            {
+                nbt["exp"] = "10000000";
+                nbt["candyUsed"] = "0";
+            }
+            return new SaveAuction
+            {
+                Tag = tag,
+                Tier = tier,
+                FlatenedNBT = nbt,
+                Enchantments = new List<Enchantment>(),
+                Count = 1,
+                StartingBid = 1000,
+                HighestBidAmount = 1000,
+            };
+        }
+
+        private static SaveAuction AuctionFromKey(string tag, AuctionKey key)
+        {
+            var nbt = new Dictionary<string, string>();
+            foreach (var m in key.Modifiers)
+                nbt[m.Key] = m.Value;
+            return new SaveAuction
+            {
+                Tag = tag,
+                Tier = key.Tier,
+                Reforge = key.Reforge,
+                Count = Math.Max((int)key.Count, 1),
+                Category = Category.UNKNOWN,
+                FlatenedNBT = nbt,
+                Enchantments = key.Enchants.Select(e => new Enchantment(e.Type, e.Lvl)).ToList(),
+                StartingBid = 1000,
+                HighestBidAmount = 1000,
+            };
+        }
+
+        private void AddVolume(SaveAuction toAdd, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var dup = new SaveAuction(toAdd)
+                {
+                    Uuid = (idCounter++).ToString().PadRight(8, '0'),
+                    UId = idCounter++,
+                    AuctioneerId = ((short)(idCounter++ % 20000)).ToString().PadRight(8, '0'),
+                    FlatenedNBT = new Dictionary<string, string>(toAdd.FlatenedNBT),
+                    Enchantments = toAdd.Enchantments == null ? null : new List<Enchantment>(toAdd.Enchantments),
+                };
+                service.AddSoldItem(dup);
+            }
+        }
+    }
+}

--- a/Services/CleanItemPriceMemo.cs
+++ b/Services/CleanItemPriceMemo.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Concurrent;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R6/MEMO2 (entry-epoch-stamped recompute memoization) — a per-<see cref="PriceLookup"/>, lifetime-stable,
+    /// in-memory memo of the <c>GetCleanItemPrice</c> RECOMPUTE result (the value returned on a persistent-cache MISS
+    /// or a <c>force</c> call), keyed by the inputs that determine it and validated by a PER-ENTRY freshness stamp.
+    ///
+    /// <para><b>Why an entry stamp (the warm fix).</b> R5's clean3 (branch <c>r5-deferred-cleanprice-memo</c>,
+    /// <c>dbf920a</c>) memoized the same recompute but with a per-WINDOW invalidation: a new <see cref="CleanItemPriceMemo"/>
+    /// (and its whole <see cref="ConcurrentDictionary{TKey,TValue}"/>) was allocated whenever the pricing epoch / dict
+    /// Count / Volume / TTL changed. On the WARM path the pricing epoch is bumped on EVERY auction (ingest /
+    /// <c>UpdateMedian</c>), so that design re-allocated the entire memo dict every auction — pure overhead where warm
+    /// never repeat-recomputes — and regressed warm p50 ~17 µs (the reason clean3 was deferred). This version keeps ONE
+    /// dict per lookup for its lifetime (NO per-window realloc) and stamps each ENTRY with the epoch/Count/Volume it was
+    /// computed at. A read whose entry stamp != the current epoch/Count/Volume (or is past the TTL) is a MISS — recompute
+    /// via the clean2 partial-select and OVERWRITE the entry with the fresh value+stamp. So warm becomes a no-op:
+    /// entries are always stale (epoch changed) → recompute the fast clean2 path, but ZERO dict realloc / alloc churn.
+    /// Cold/rare keep the intra-window hits: within one stable epoch the 5 per-auction call sites that touch the same
+    /// (tag, tier) hit the freshly-stamped entry instead of re-sorting.</para>
+    ///
+    /// <para><b>Key (what determines the recompute output).</b> For a fixed <see cref="PriceLookup"/> state the
+    /// recompute body is a pure function of <c>(tag, key.Key.Tier)</c>: <c>tag</c> drives <c>isPet</c> /
+    /// <c>matchRarity</c> / gem-devider / Midas; <c>key.Key.Tier</c> (the UNREDUCED query tier) drives the flatten
+    /// filter (<c>minRarity</c> / <c>ownTier</c>); everything else it reads — the matching buckets' references (via
+    /// <see cref="ReferenceAuctions.ReferenceSnapshot"/>) and <see cref="PriceLookup.Volume"/> — is a property of the
+    /// lookup, not the query key. The query key's Modifiers/Reforge/Enchants do NOT enter the recompute body (they
+    /// only pick the REDUCED tier used for the persistent-cache lookup, which is handled by the caller, never here).
+    /// So <c>(tag, unreduced-tier)</c> is the exact memo key.</para>
+    ///
+    /// <para><b>Per-entry freshness (identical triggers to <c>GetOrBuildCandidateIndex</c>).</b> An entry is valid while
+    /// its stamp's epoch == the service pricing epoch (bumped on every price transition — <c>UpdateMedian</c> plus every
+    /// out-of-band price write), its Count == the live dict Count (bucket add/remove), its Volume == the live
+    /// <see cref="PriceLookup.Volume"/>, and it is within the TTL. Reference and Volume mutations flow through
+    /// <c>UpdateMedian</c> (which bumps the epoch) on the hot path; the rare bulk-load paths that enqueue without an
+    /// immediate bump are bounded by the same TTL the candidate/dominator indexes already accept. These are the proven,
+    /// signed-off campaign invalidation triggers — only now applied per-entry instead of per-window.</para>
+    ///
+    /// <para><b>Force callers.</b> The memo caches the recompute OUTPUT, which is deterministic for fixed inputs within
+    /// a window; <c>force</c> currently means "ignore the persistent per-tier cache and recompute", and two recomputes
+    /// with a matching stamp are identical, so serving force callers from the memo is bit-exact (verified by the memo
+    /// soak, which drives forces under mutation and asserts equality with a fresh recompute every time).</para>
+    ///
+    /// <para><b>Concurrency.</b> The risky finder runs on a background Task and many auctions for one tag may evaluate
+    /// concurrently. The memo dict itself is published to <see cref="PriceLookup.CleanPriceMemo"/> exactly ONCE per
+    /// lookup lifetime by a single atomic reference assignment (tear-safe); after that the reference never changes, so
+    /// readers never observe a torn or swapped dict. Each entry value is a struct stored/read atomically through the
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> (its own striping lock makes the struct write/read atomic). A
+    /// stale-stamp miss recomputes and OVERWRITES the entry (last-writer-wins); the recompute is deterministic for the
+    /// current stamp's inputs, so any concurrent writer for the same (key, stamp) stores the IDENTICAL value and the
+    /// race is harmless. Never serialized — a derived in-memory acceleration structure.</para>
+    /// </summary>
+    public sealed class CleanItemPriceMemo
+    {
+        /// <summary>
+        /// One memoized recompute result plus the freshness stamp it was computed at. A value-type so the
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> stores it inline (no per-entry boxing/alloc) and a slot
+        /// overwrite is a single locked struct copy.
+        /// </summary>
+        public readonly struct Entry
+        {
+            public readonly long Value;
+            public readonly long Epoch;
+            public readonly int Count;
+            public readonly float Volume;
+            public readonly DateTime BuiltAt;
+
+            public Entry(long value, long epoch, int count, float volume, DateTime builtAt)
+            {
+                Value = value;
+                Epoch = epoch;
+                Count = count;
+                Volume = volume;
+                BuiltAt = builtAt;
+            }
+
+            /// <summary>
+            /// True while this entry still reflects the live lookup state. Mirrors <c>GetOrBuildCandidateIndex</c>'s
+            /// triggers (pricing epoch + live dict Count + TTL) PLUS <see cref="PriceLookup.Volume"/>: the recompute's
+            /// <c>size</c> reads <c>lookup.Volume</c>, which <c>PreCalculateVolume</c> sets INSIDE <c>UpdateMedian</c>
+            /// AFTER the start-of-method epoch bump, so an entry stamped between that bump and the Volume write would
+            /// otherwise serve a value computed against a stale Volume. Bit-comparing the float is exact (Volume is only
+            /// ever assigned a freshly computed value, never arithmetically derived from the cached one).
+            /// </summary>
+            public bool IsFresh(long epoch, int liveCount, float volume, DateTime now, double maxAgeMinutes)
+                => Epoch == epoch && Count == liveCount && Volume == volume
+                   && BuiltAt > now.AddMinutes(-maxAgeMinutes);
+        }
+
+        /// <summary>Memoized recompute results, keyed by (tag, UNREDUCED query tier), each carrying its freshness stamp.
+        /// ONE dict per lookup for the lookup's whole lifetime — never re-allocated on an epoch bump (the warm fix). A
+        /// stale-stamp read overwrites the slot in place. Sized small with low concurrency: a given lookup only ever
+        /// holds the few distinct (tag, tier) its call sites touch (one tag per lookup; a handful of tiers). The default
+        /// ConcurrentDictionary ctor over-allocates its bucket table + a per-core lock array (4×ProcessorCount locks);
+        /// concurrencyLevel=1 keeps the lock array to a single entry. The value is a small struct and concurrent writers
+        /// for a matching stamp store the identical deterministic value, so one striping lock is sufficient for
+        /// correctness.</summary>
+        public readonly ConcurrentDictionary<(string tag, Tier tier), Entry> Values
+            = new(concurrencyLevel: 1, capacity: 8);
+    }
+}

--- a/Services/ClosestCandidateIndex.cs
+++ b/Services/ClosestCandidateIndex.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// WS-A — contiguous candidate store for the closest-match arg-max scan (<c>FindClosestTo</c>).
+    ///
+    /// The deployed scan iterated a <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/> per
+    /// auction, paying ~50–60 ns/bucket of pointer-chasing (dict-node chase + per-bucket heap deref) to set up ~few-ns
+    /// of integer scoring. The <c>SoaScanBenchmarks</c> spike proved that walking a flat <see cref="ScoreVec"/>[]
+    /// instead is a clean ~2.2× at every bucket count — pure memory-access-pattern, both allocate ~0.
+    ///
+    /// This holds that flat layout: the priced, non-virtual candidate buckets of one <see cref="PriceLookup"/>, packed
+    /// into parallel columns the scan walks sequentially. It is built once per (lookup, pricing-epoch) and reused across
+    /// the many <c>FindClosestTo</c> calls between candidate-set changes — the snipe-evaluation hot path never reprices,
+    /// so the index is stable across calls and the amortized per-auction cost approaches the pure array scan.
+    ///
+    /// <b>R6 WS-LOH — chunked columns (off the LOH).</b> Each column used to be ONE flat array. On a hot tag
+    /// (N≈3000 priced buckets) the widest column, the <see cref="ScoreVec"/>[] (the struct is 112 B — eleven array
+    /// references plus scalars, see <see cref="ClosestScoreKernel.ScoreVec"/>), is ~3000·112 ≈ 336 KB — far over the
+    /// ~85 KB Large-Object-Heap threshold — so a fresh index per novel-key (price-dependent membership: the new-bucket
+    /// trap forces a real rebuild, the idx-grow append is unsound here) allocated on the LOH and promoted to gen2,
+    /// driving the rare gen2 <c>AllocLarge</c> stop-the-world pause tail (Round 10). The fix is to split every column
+    /// into <see cref="BlockSize"/>-element blocks so each block stays under the LOH threshold and is born in the SOH
+    /// (gen0), dying young instead of promoting. <see cref="BlockSize"/> = 512 keeps the dominant ScoreVec[] block at
+    /// 512·112 ≈ 57 KB — comfortably under 85 KB with margin — and every narrower column (8-byte refs/longs → ≤4 KB,
+    /// 2-byte shorts → 1 KB per block) far smaller. Only the per-column STORAGE layout changes: membership, ordering,
+    /// the epoch/Count/TTL invalidation, the ScoreVec reuse, and the branch-and-bound scan are all unchanged, and the
+    /// scan still reads element <c>i</c> as <c>X[i]</c> (an indexer hides the block math; <c>VecRef(i)</c> gives a
+    /// <c>ref readonly</c> ScoreVec so <c>in index.VecRef(i)</c> stays zero-copy).
+    ///
+    /// <b>Immutability + publication.</b> Every field is readonly and the blocks are never mutated after construction;
+    /// a fresh instance is published to <see cref="PriceLookup.CandidateIndex"/> by a single atomic reference
+    /// assignment (tear-safe), mirroring <see cref="ClosestScoreKernel.ScoreVecCache"/>. Concurrent rebuilds (the risky
+    /// finder runs on a background Task) are harmless: both build identical content and one wins the publish. Each
+    /// rebuild allocates BRAND-NEW private blocks owned solely by the index it returns (the blocks are never pooled,
+    /// shared, or reused across indexes), so there is structurally no use-after-return — a reader holding an older
+    /// index keeps walking that index's own immutable blocks, which no later rebuild ever touches.
+    ///
+    /// <b>Staleness / correctness.</b> The index is rebuilt when any of these no longer hold (see
+    /// <c>SniperService.FindClosestTo</c>):
+    ///   • <see cref="BuiltEpoch"/> != the service pricing epoch — bumped on every price transition (the new-bucket
+    ///     trap: a bucket flips <c>Price</c> 0↔positive without a dict add/remove, so Count alone is insufficient);
+    ///   • <see cref="BuiltLookupCount"/> != the live dict Count — catches bucket add/remove;
+    ///   • <see cref="BuiltAt"/> older than the vec TTL — matches the per-bucket ScoreVec refresh window so scores stay
+    ///     bit-exact with the deployed lazy-rebuild.
+    /// The arg-max it produces is bit-exact with the dict scan (same candidate set, same per-candidate score); a
+    /// soak parity assert (<c>SniperService.VerifyClosestIndex</c>) cross-checks index vs a fresh filter under churn.
+    /// </summary>
+    public sealed class ClosestCandidateIndex
+    {
+        /// <summary>
+        /// Per-block element count. Chosen so the widest column — the <see cref="ClosestScoreKernel.ScoreVec"/>[] at
+        /// 112 B/element — stays well under the 85,000-byte LOH threshold: 512·112 + 24 ≈ 57 KB/block. All narrower
+        /// columns (8-byte refs/longs, 2-byte shorts) are far smaller per block. A power of two so the block/offset
+        /// split is a shift/mask. Must not exceed ~759 (the point where ScoreVec[] crosses 85 KB).
+        /// </summary>
+        public const int BlockSize = 512;
+        private const int BlockShift = 9;          // log2(BlockSize)
+        private const int BlockMask = BlockSize - 1;
+
+        /// <summary>Columnar score vectors, one per candidate, in build-time enumeration order (chunked).</summary>
+        public readonly Chunked<ClosestScoreKernel.ScoreVec> Vecs;
+        /// <summary>Candidate keys, parallel to <see cref="Vecs"/> (needed to return the winning entry).</summary>
+        public readonly Chunked<AuctionKey> Keys;
+        /// <summary>Candidate buckets, parallel to <see cref="Vecs"/> (needed to return the winning entry).</summary>
+        public readonly Chunked<ReferenceAuctions> Buckets;
+        /// <summary>Per-candidate <see cref="ReferenceAuctions.OldestRef"/>, captured at build time; the call-time age
+        /// adjustment (<c>OldestRef &gt; minDay ? 0 : -10</c>) is applied during the scan so the index stays
+        /// independent of the per-call <c>minDay</c>.</summary>
+        public readonly Chunked<short> OldestRef;
+        /// <summary>WS-C — per-candidate <see cref="ClosestScoreKernel.PosCap"/>, query-independent, precomputed once here
+        /// so the closest scan's branch-and-bound prefilter (a sound upper bound) costs only a few int ops per candidate
+        /// and skips the exact kernel on the majority that can't beat the running best.</summary>
+        public readonly Chunked<long> Cap;
+        /// <summary>Number of populated entries.</summary>
+        public readonly int Count;
+
+        public readonly long BuiltEpoch;
+        public readonly int BuiltLookupCount;
+        public readonly DateTime BuiltAt;
+
+        public ClosestCandidateIndex(in Chunked<ClosestScoreKernel.ScoreVec> vecs, in Chunked<AuctionKey> keys,
+            in Chunked<ReferenceAuctions> buckets, in Chunked<short> oldestRef, in Chunked<long> cap, int count,
+            long builtEpoch, int builtLookupCount, DateTime builtAt)
+        {
+            Vecs = vecs; Keys = keys; Buckets = buckets; OldestRef = oldestRef; Cap = cap; Count = count;
+            BuiltEpoch = builtEpoch; BuiltLookupCount = builtLookupCount; BuiltAt = builtAt;
+        }
+
+        /// <summary>
+        /// Zero-copy <c>ref readonly</c> access to score vector <paramref name="i"/> so the scan can pass
+        /// <c>in index.VecRef(i)</c> to the kernel without copying the 112-byte struct. The <c>ref</c> aliases the
+        /// element inside this index's own immutable block (never mutated after construction).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref readonly ClosestScoreKernel.ScoreVec VecRef(int i) => ref Vecs.Ref(i);
+
+        /// <summary>
+        /// A column split into <see cref="BlockSize"/>-element blocks so no single backing array reaches the ~85 KB LOH
+        /// threshold. Element <c>i</c> lives at <c>blocks[i &gt;&gt; BlockShift][i &amp; BlockMask]</c>. A readonly
+        /// value-type wrapper over a private jagged array; the blocks are allocated fresh per index and never mutated
+        /// after the owning index is constructed, so concurrent readers are safe.
+        /// </summary>
+        public readonly struct Chunked<T>
+        {
+            private readonly T[][] _blocks;
+            public readonly int Count;
+
+            internal Chunked(T[][] blocks, int count) { _blocks = blocks; Count = count; }
+
+            /// <summary>Indexed element read; keeps the <c>X[i]</c> call-site syntax of the old flat arrays.</summary>
+            public T this[int i]
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => _blocks[i >> BlockShift][i & BlockMask];
+            }
+
+            /// <summary><c>ref readonly</c> element access (used by <see cref="VecRef"/> for the zero-copy ScoreVec read).</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public ref readonly T Ref(int i) => ref _blocks[i >> BlockShift][i & BlockMask];
+        }
+
+        /// <summary>
+        /// Append-then-freeze builder for one <see cref="Chunked{T}"/> column. <see cref="Add"/> writes into the current
+        /// block, allocating a brand-new private block (in the SOH — each block is under the LOH threshold) whenever the
+        /// current one fills, so the column grows without a single large allocation and without copying. <see cref="Build"/>
+        /// freezes the accumulated blocks into the immutable <see cref="Chunked{T}"/> (trimming the final partial block
+        /// so the scan never reads past <see cref="Count"/>). Used only during construction; the produced blocks are
+        /// owned solely by the resulting index.
+        /// </summary>
+        public struct Builder<T>
+        {
+            private readonly List<T[]> _blocks;
+            private T[] _current;
+            private int _inBlock;   // elements used in _current
+            private int _count;     // total elements appended
+
+            public Builder(int expectedCapacity)
+            {
+                int blockCount = expectedCapacity <= 0 ? 1 : (expectedCapacity + BlockSize - 1) / BlockSize;
+                _blocks = new List<T[]>(blockCount);
+                _current = new T[BlockSize];
+                _blocks.Add(_current);
+                _inBlock = 0;
+                _count = 0;
+            }
+
+            public readonly int Count => _count;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Add(in T value)
+            {
+                if (_inBlock == BlockSize)
+                {
+                    _current = new T[BlockSize]; // fresh SOH block; never copies the prior block's contents
+                    _blocks.Add(_current);
+                    _inBlock = 0;
+                }
+                _current[_inBlock++] = value;
+                _count++;
+            }
+
+            public readonly Chunked<T> Build()
+            {
+                var arr = _blocks.ToArray();
+                // Trim the final partial block to exactly its populated length so a reader can never observe a
+                // default-valued tail slot. Full blocks (and the block-pointer array itself) are kept as-is.
+                int lastUsed = _count == 0 ? 0 : _count - ((arr.Length - 1) << BlockShift);
+                if (lastUsed != BlockSize)
+                {
+                    var last = arr[arr.Length - 1];
+                    if (lastUsed != last.Length)
+                        Array.Resize(ref last, lastUsed);
+                    arr[arr.Length - 1] = last;
+                }
+                return new Chunked<T>(arr, _count);
+            }
+        }
+    }
+}

--- a/Services/ClosestScoreKernel.Tests.cs
+++ b/Services/ClosestScoreKernel.Tests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using AwesomeAssertions;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// TDD spec for <see cref="ClosestScoreKernel"/>: the columnar/interned scorer must be <b>bit-exact</b> with the
+    /// production <see cref="AuctionKey"/> market-price similarity, so the closest search can be swapped in wholesale.
+    /// "Bit-exact" here means integer equality of the returned score for every (query, candidate) pair; the single
+    /// internal floating-point term is additionally checked for 0-ulp agreement.
+    /// </summary>
+    public class ClosestScoreKernelTests
+    {
+        private SniperService service = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Non-null service routes Similarity into the market-price path; it also populates the static VeryValuable
+            // set that ImportanceFactor reads (so both scorers see the same importance tiers).
+            service = new SniperService(new HypixelItemService(null, NullLogger<HypixelItemService>.Instance), null, NullLogger<SniperService>.Instance, null);
+        }
+
+        // Reference: exactly the production call shape from FindClosestTo —
+        //   itemKey.Similarity(candidate, service, candidateCv, queryCv)
+        private int Reference(AuctionKey query, List<SniperService.RankElem> queryCv,
+                              AuctionKey candidate, List<SniperService.RankElem> candidateCv)
+            => query.Similarity(candidate, service, candidateCv, queryCv);
+
+        private static int Kernel(AuctionKey query, List<SniperService.RankElem> queryCv,
+                                  AuctionKey candidate, List<SniperService.RankElem> candidateCv)
+        {
+            var interner = new ClosestScoreKernel.Interner();
+            var qVec = ClosestScoreKernel.Build(query, queryCv, interner);
+            var cVec = ClosestScoreKernel.Build(candidate, candidateCv, interner);
+            return ClosestScoreKernel.Score(in qVec, in cVec);
+        }
+
+        // ---- Fuzz: thousands of random pairs must match bit-exactly ----
+
+        [Test]
+        public void Fuzz_BitExact_AgainstProductionSimilarity()
+        {
+            int mismatches = 0;
+            var firstFail = "";
+            for (int seed = 1; seed <= 20_000; seed++)
+            {
+                var rng = new Random(seed);
+                var (qKey, qCv) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+                var (cKey, cCv) = AuctionKeyFuzz.RandomKeyAndBreakdown(rng);
+
+                int expected = Reference(qKey, qCv, cKey, cCv);
+                int actual = Kernel(qKey, qCv, cKey, cCv);
+                if (expected != actual)
+                {
+                    if (mismatches == 0)
+                        firstFail = $"seed={seed} expected={expected} actual={actual}\n  q={Describe(qKey, qCv)}\n  c={Describe(cKey, cCv)}";
+                    mismatches++;
+                }
+            }
+            mismatches.Should().Be(0, $"kernel must be bit-exact over 20000 random pairs. First: {firstFail}");
+        }
+
+        // ---- Targeted branch coverage ----
+
+        [Test]
+        public void EnchantMatch_SameLevel_Adds_DifferentLevel_Ignores_Missing_Subtracts()
+        {
+            var ench = new Enchant { Type = EnchantmentType.sharpness, Lvl = 6 };
+            var q = Key(tier: 3, count: 1, enchants: new() { ench });
+            var qCv = new List<SniperService.RankElem> { new(ench, 5_000_000) };
+            // candidate: same enchant present (match)
+            var c = Key(tier: 3, count: 1, enchants: new() { ench });
+            var cCv = new List<SniperService.RankElem> { new(ench, 7_000_000) };
+            AssertExact(q, qCv, c, cCv);
+
+            // candidate: different level
+            var ench7 = new Enchant { Type = EnchantmentType.sharpness, Lvl = 7 };
+            AssertExact(q, qCv, Key(3, 1, enchants: new() { ench7 }), new() { new(ench7, 7_000_000) });
+
+            // candidate: missing the enchant entirely
+            AssertExact(q, qCv, Key(3, 1), new());
+        }
+
+        [Test]
+        public void NumericModifierDifference_UsesFloatPath_WhenMatchedValueIsZero()
+        {
+            // Both sides have "kills" (a numeric modifier), candidate's RankElem.Value == 0 -> the float default term
+            // (|a-b| * importance) is what's actually used. This is the only place float math reaches the result.
+            var qMods = new List<KeyValuePair<string, string>> { new("kills", "5") };
+            var cMods = new List<KeyValuePair<string, string>> { new("kills", "2") };
+            var q = Key(2, 1, modifiers: qMods);
+            var c = Key(2, 1, modifiers: cMods);
+            var qCv = new List<SniperService.RankElem> { new(qMods[0], 3_000_000) };
+            var cCv = new List<SniperService.RankElem> { new(cMods[0], 0) }; // 0 -> float default path
+            AssertExact(q, qCv, c, cCv);
+        }
+
+        [Test]
+        public void PetItem_TierBoost_AppliesPenalty()
+        {
+            var qMods = new List<KeyValuePair<string, string>> { new(SniperService.PetItemKey, SniperService.TierBoostShorthand) };
+            var cMods = new List<KeyValuePair<string, string>> { new(SniperService.PetItemKey, "SOMETHING_ELSE") };
+            var q = Key(2, 1, modifiers: qMods);
+            var c = Key(2, 1, modifiers: cMods);
+            AssertExact(q, new() { new(qMods[0], 1_000_000) }, c, new() { new(cMods[0], 1_000_000) });
+        }
+
+        [Test]
+        public void CandyUsed_SameValue_DoesNotAddValue()
+        {
+            var mods = new List<KeyValuePair<string, string>> { new("candyUsed", "3") };
+            var k = Key(2, 1, modifiers: mods);
+            AssertExact(k, new() { new(mods[0], 9_000_000) }, k, new() { new(mods[0], 9_000_000) });
+        }
+
+        [Test]
+        public void Reforge_Match_Adds_Mismatch_Subtracts()
+        {
+            var q = Key(2, 1, reforge: ItemReferences.Reforge.Gilded);
+            var qCv = new List<SniperService.RankElem> { new(ItemReferences.Reforge.Gilded, 4_000_000) };
+            // match
+            AssertExact(q, qCv, Key(2, 1, reforge: ItemReferences.Reforge.Gilded), new() { new(ItemReferences.Reforge.Gilded, 6_000_000) });
+            // mismatch (candidate has different reforge -> self lookup misses -> -1000)
+            AssertExact(q, qCv, Key(2, 1, reforge: ItemReferences.Reforge.Any), new());
+        }
+
+        [Test]
+        public void TierAndCountDifferences_WithExpModifier()
+        {
+            var expMods = new List<KeyValuePair<string, string>> { new("exp", "1234567") };
+            var q = Key(tier: 5, count: 1, modifiers: expMods);
+            var c = Key(tier: 2, count: 3, modifiers: expMods); // tier diff + count diff + exp on candidate
+            var cv = new List<SniperService.RankElem> { new(expMods[0], 2_000_000) };
+            AssertExact(q, cv, c, cv);
+        }
+
+        [Test]
+        public void NonNumericValue_FallsToImportanceDefault()
+        {
+            // "200k" does not parse as a float -> non-numeric else branch.
+            var qMods = new List<KeyValuePair<string, string>> { new("logs_cut", "200k") };
+            var cMods = new List<KeyValuePair<string, string>> { new("logs_cut", "2") };
+            AssertExact(Key(2, 1, modifiers: qMods), new() { new(qMods[0], 0) },
+                        Key(2, 1, modifiers: cMods), new() { new(cMods[0], 0) });
+        }
+
+        // ---- Explicit ULP check on the float sub-term ----
+
+        [Test]
+        public void FloatDifferenceTerm_IsZeroUlp()
+        {
+            // Reproduce the exact term used inside CompareValues: (float)|a-b| * importance, widened to double, ->long.
+            // The kernel must compute the identical float, i.e. 0 ulp from a straight reparse-and-multiply.
+            string[] values = { "1", "2", "3.5", "7", "9", "12.25", "100", "0.5" };
+            foreach (var av in values)
+                foreach (var bv in values)
+                {
+                    float a = float.Parse(av, CultureInfo.InvariantCulture);
+                    float b = float.Parse(bv, CultureInfo.InvariantCulture);
+                    int importance = 1_000_000;
+                    float reference = Math.Abs(a - b) * importance;
+
+                    // kernel path: values are interned/precomputed via the same float.TryParse overload
+                    float.TryParse(av, CultureInfo.InvariantCulture, out var ka);
+                    float.TryParse(bv, CultureInfo.InvariantCulture, out var kb);
+                    float kernel = Math.Abs(kb - ka) * importance;
+
+                    BitConverter.SingleToInt32Bits(kernel).Should().Be(BitConverter.SingleToInt32Bits(reference),
+                        $"{av} vs {bv}: float term must be 0 ulp (bit-identical)");
+                    ((long)(double)kernel).Should().Be((long)(double)reference);
+                }
+        }
+
+        // ---------------- helpers ----------------
+
+        private void AssertExact(AuctionKey q, List<SniperService.RankElem> qCv, AuctionKey c, List<SniperService.RankElem> cCv)
+            => Kernel(q, qCv, c, cCv).Should().Be(Reference(q, qCv, c, cCv),
+                $"kernel must match production\n  q={Describe(q, qCv)}\n  c={Describe(c, cCv)}");
+
+        // Thin wrapper over the shared fuzz helper so the targeted-branch tests below read naturally.
+        private static AuctionKey Key(int tier, int count, List<Enchant> enchants = null,
+            List<KeyValuePair<string, string>> modifiers = null, ItemReferences.Reforge reforge = ItemReferences.Reforge.Any)
+            => AuctionKeyFuzz.Key(tier, count, enchants, modifiers, reforge);
+
+        private static string Describe(AuctionKey k, List<SniperService.RankElem> cv)
+            => $"tier={k.Tier} count={k.Count} reforge={k.Reforge} mods=[{string.Join(",", k.Modifiers.Select(m => m.Key + "=" + m.Value))}] " +
+               $"cv=[{string.Join(",", cv.Select(e => e.Enchant.Lvl != 0 ? $"E:{e.Enchant.Type}{e.Enchant.Lvl}={e.Value}" : e.Modifier.Key != null ? $"M:{e.Modifier.Key}={e.Modifier.Value}:{e.Value}" : $"R:{e.Reforge}={e.Value}"))}]";
+    }
+}

--- a/Services/ClosestScoreKernel.cs
+++ b/Services/ClosestScoreKernel.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// Data-oriented, allocation-free re-implementation of the closest-match similarity score
+    /// (<see cref="AuctionKey"/>.SimilarityByMarketPrice / CompareValues), operating on interned, columnar
+    /// "score vectors" instead of <c>List&lt;RankElem&gt;</c> + LINQ.
+    ///
+    /// Goal: <b>bit-exact</b> with the production scorer so the closest search can be swapped wholesale. The accumulator
+    /// is <c>long</c> integer arithmetic; the single floating-point term (numeric-modifier difference) is reproduced with
+    /// the identical sequence — parse to <c>float</c>, multiply by the (int) importance factor in <c>float</c>, widen to
+    /// <c>double</c>, truncate to <c>long</c> — and only consulted when the matched element's value is 0, exactly as the
+    /// original. Strings are interned 1:1, so integer-id matching yields the same matches as the original string compares.
+    ///
+    /// This is the spike kernel; the columnar bucket store + SIMD pruning build on top of <see cref="Score"/>.
+    /// </summary>
+    public static class ClosestScoreKernel
+    {
+        // ============================ CANONICAL ID-SPACE CONTRACT (Phase 0 / F1) ============================
+        // This is THE single source of integer ids for the whole snipe path. Every ScoreVec compared against another
+        // MUST be built with the same Interner instance, or matches silently break. Production holds exactly one
+        // instance per SniperService (`scoreInterner`); tests use their own isolated instance.
+        //
+        // What is interned here (string -> int, 1:1, stable for the interner's lifetime):
+        //   - modifier KEYS   (AuctionKey.Modifiers[*].Key)   -> ScoreVec.ModKeyId
+        //   - modifier VALUES (AuctionKey.Modifiers[*].Value)  -> ScoreVec.ModValId
+        // Both draw from ONE monotonic counter (`_next`), so a modKey id and a modVal id can collide numerically. That
+        // is SAFE and intentional: the kernel only ever compares ModKeyId-vs-ModKeyId and ModValId-vs-ModValId (never
+        // a key id against a value id), so a shared counter never causes a false match. A future SIMD/columnar packing
+        // (WS-C) that wants width-segregated ids (e.g. modKey->u16, modVal->u32) must change this counter scheme AND
+        // re-prove parity against the oracle — do not assume the spaces are independent today.
+        //
+        // What is NOT interned (already stable small ints, fed to ScoreVec raw — keep it that way):
+        //   - enchant TYPE  -> raw `(int)EnchantmentType` enum value (dense, < 2^16, stable across the process)
+        //   - tier / count  -> raw key scalars
+        // The four well-known ids below (PetItemKey, TIER_BOOST, candyUsed, exp) are interned eagerly in the ctor so
+        // hot-path branch checks are integer compares, not string compares.
+        //
+        // Thread-safety: the closest search runs on a background Task and can race vec builds at update time, so
+        // Intern() must be safe under concurrency. GetOrAdd + Interlocked.Increment guarantee unique, stable ids; under
+        // contention the GetOrAdd factory may run twice and discard a counter value (harmless gap — uniqueness and
+        // stability are preserved). Ids are append-only and never reused, so a vec built earlier stays valid forever.
+        // ====================================================================================================
+        public sealed class Interner
+        {
+            private readonly ConcurrentDictionary<string, int> _ids = new(StringComparer.Ordinal);
+            private int _next = -1;
+            public readonly int PetItemKeyId;
+            public readonly int TierBoostValId;
+            public readonly int CandyUsedKeyId;
+            public readonly int ExpKeyId;
+
+            public Interner()
+            {
+                PetItemKeyId = Intern(SniperService.PetItemKey);
+                TierBoostValId = Intern(SniperService.TierBoostShorthand);
+                CandyUsedKeyId = Intern("candyUsed");
+                ExpKeyId = Intern("exp");
+            }
+
+            public int Intern(string s)
+            {
+                if (s == null) return -1;
+                return _ids.GetOrAdd(s, _ => Interlocked.Increment(ref _next));
+            }
+        }
+
+        /// <summary>Columnar, interned form of one key's priced breakdown (the <c>List&lt;RankElem&gt;</c>) + key scalars.</summary>
+        public readonly struct ScoreVec
+        {
+            // enchants
+            public readonly int[] EnchType;   // enum value
+            public readonly byte[] EnchLvl;
+            public readonly long[] EnchValue;
+            // modifiers
+            public readonly int[] ModKeyId;
+            public readonly int[] ModValId;
+            public readonly long[] ModValue;
+            public readonly bool[] ModIsNumeric;
+            public readonly float[] ModParsed;
+            public readonly int[] ModImportance;
+            public readonly bool[] ModIsCandyUsed;
+            public readonly bool[] ModIsPetTierBoost; // key==petItem && value==TIER_BOOST
+            // reforge (first reforge-bearing RankElem, if any)
+            public readonly bool HasReforge;
+            public readonly int Reforge;       // enum value
+            public readonly long ReforgeValue;
+            // key scalars
+            public readonly int Tier;
+            public readonly int Count;
+            public readonly bool HasExpModifier; // key.Modifiers.Any(m => m.Key == "exp")
+
+            public ScoreVec(int[] enchType, byte[] enchLvl, long[] enchValue,
+                int[] modKeyId, int[] modValId, long[] modValue, bool[] modIsNumeric, float[] modParsed,
+                int[] modImportance, bool[] modIsCandyUsed, bool[] modIsPetTierBoost,
+                bool hasReforge, int reforge, long reforgeValue, int tier, int count, bool hasExpModifier)
+            {
+                EnchType = enchType; EnchLvl = enchLvl; EnchValue = enchValue;
+                ModKeyId = modKeyId; ModValId = modValId; ModValue = modValue;
+                ModIsNumeric = modIsNumeric; ModParsed = modParsed; ModImportance = modImportance;
+                ModIsCandyUsed = modIsCandyUsed; ModIsPetTierBoost = modIsPetTierBoost;
+                HasReforge = hasReforge; Reforge = reforge; ReforgeValue = reforgeValue;
+                Tier = tier; Count = count; HasExpModifier = hasExpModifier;
+            }
+        }
+
+        /// <summary>
+        /// Immutable holder for a bucket's cached <see cref="ScoreVec"/> + build time. Stored as a reference on the
+        /// bucket so concurrent closest searches (the risky finder runs on a background Task) read a whole, consistent
+        /// vector — a reference assignment is atomic, whereas writing the multi-field struct in place is not.
+        /// </summary>
+        public sealed class ScoreVecCache
+        {
+            public readonly ScoreVec Vec;
+            public readonly DateTime At;
+            public ScoreVecCache(ScoreVec vec, DateTime at) { Vec = vec; At = at; }
+        }
+
+        private static int ImportanceFactor(string key)
+        {
+            if (SniperService.Increadable.Contains(key)) return 100 * 1_000_000;
+            if (SniperService.VeryValuable.Contains(key)) return 10 * 1_000_000;
+            return 1 * 1_000_000;
+        }
+
+        /// <summary>Builds a <see cref="ScoreVec"/> from a key and its priced breakdown (the <c>cv</c> list from ComparisonValue).</summary>
+        public static ScoreVec Build(AuctionKey key, List<SniperService.RankElem> cv, Interner interner)
+        {
+            var enchType = new List<int>(); var enchLvl = new List<byte>(); var enchValue = new List<long>();
+            var modKeyId = new List<int>(); var modValId = new List<int>(); var modValue = new List<long>();
+            var modIsNumeric = new List<bool>(); var modParsed = new List<float>(); var modImportance = new List<int>();
+            var modIsCandy = new List<bool>(); var modIsPtb = new List<bool>();
+            bool hasReforge = false; int reforge = 0; long reforgeValue = 0;
+
+            foreach (var e in cv)
+            {
+                if (e.Enchant.Lvl != default) // enchant RankElem
+                {
+                    enchType.Add((int)e.Enchant.Type); enchLvl.Add((byte)e.Enchant.Lvl); enchValue.Add(e.Value);
+                }
+                else if (e.Modifier.Key != default) // modifier RankElem
+                {
+                    var k = e.Modifier.Key; var v = e.Modifier.Value;
+                    modKeyId.Add(interner.Intern(k));
+                    modValId.Add(interner.Intern(v));
+                    modValue.Add(e.Value);
+                    // Identical overload to CompareValues' float.TryParse(value, InvariantCulture, out _) so the parsed
+                    // float is bit-identical.
+                    bool num = float.TryParse(v, CultureInfo.InvariantCulture, out var parsed);
+                    modIsNumeric.Add(num); modParsed.Add(num ? parsed : 0f);
+                    modImportance.Add(ImportanceFactor(k));
+                    modIsCandy.Add(k == "candyUsed");
+                    modIsPtb.Add(k == SniperService.PetItemKey && v == SniperService.TierBoostShorthand);
+                }
+                else if (e.Reforge != default && !hasReforge) // first reforge-bearing RankElem
+                {
+                    hasReforge = true; reforge = (int)e.Reforge; reforgeValue = e.Value;
+                }
+            }
+
+            bool hasExp = false;
+            if (key.Modifiers != null)
+                foreach (var m in key.Modifiers)
+                    if (m.Key == "exp") { hasExp = true; break; }
+
+            return new ScoreVec(
+                enchType.ToArray(), enchLvl.ToArray(), enchValue.ToArray(),
+                modKeyId.ToArray(), modValId.ToArray(), modValue.ToArray(), modIsNumeric.ToArray(), modParsed.ToArray(),
+                modImportance.ToArray(), modIsCandy.ToArray(), modIsPtb.ToArray(),
+                hasReforge, reforge, reforgeValue, (int)key.Tier, key.Count, hasExp);
+        }
+
+        // long GetValueOrDefault(value, defaultVal) — mirrors RankElem.GetValueOrDefault(double).
+        private static long Gvod(long value, double defaultVal) => value == 0 ? (long)defaultVal : value;
+
+        /// <summary>
+        /// WS-C — a SOUND positive cap on the additive contribution of <c>CompareValues(*, self=v)</c>: the sum of the
+        /// largest positive value each of <paramref name="v"/>'s own elements could add. Every additive term in
+        /// CompareValues reads <c>self</c>'s value and each self element matches at most once (match is by unique
+        /// enchant-type / mod-key), so this bounds the positive part; all subtractive terms are dropped. Used to build a
+        /// branch-and-bound upper bound for the closest scan — <c>UB(i) = PosCap(query) + PosCap(cand) − exact
+        /// tier/exp/count penalties ≥ exact Score·100</c>, so pruning a candidate whose UB can't beat the running best is
+        /// bit-exact (it could never have won). Query-independent per candidate → precompute once at index-build time.
+        /// </summary>
+        public static long PosCap(in ScoreVec v)
+        {
+            long cap = 0;
+            for (int e = 0; e < v.EnchValue.Length; e++)
+                if (v.EnchValue[e] > 0) cap += v.EnchValue[e];
+            for (int m = 0; m < v.ModValue.Length; m++)
+            {
+                long g = Gvod(v.ModValue[m], v.ModImportance[m]);
+                if (g > 0) cap += g;
+            }
+            if (v.ReforgeValue > 0) cap += v.ReforgeValue;
+            return cap;
+        }
+
+        /// <summary>
+        /// Bit-exact equivalent of <c>query.Similarity(candidateKey, service, candidateCv, queryCv)</c>.
+        /// <paramref name="a"/> is the query vec (the <c>this</c>/self side), <paramref name="b"/> the candidate (the
+        /// <c>key</c>/keyvalue side) — matching the production call where keyvalue=candidate, self=query.
+        /// </summary>
+        public static int Score(in ScoreVec a, in ScoreVec b)
+        {
+            long matchValue = 0;
+            matchValue = CompareValues(in b, in a, matchValue); // CompareValues(keyvalue=candidate, self=query)
+            matchValue = CompareValues(in a, in b, matchValue); // CompareValues(self=query, keyvalue=candidate)
+
+            int tierDiff = Math.Abs(a.Tier - b.Tier);
+            matchValue -= tierDiff * 11_000_000;
+            if (tierDiff > 0 && b.HasExpModifier)
+                matchValue -= 100_000_000;
+            int countDiff = Math.Abs(a.Count - b.Count);
+            matchValue -= countDiff * 1_000_000;
+            return (int)(matchValue / 100);
+        }
+
+        private static long CompareValues(in ScoreVec keyvalue, in ScoreVec self, long matchValue)
+        {
+            // enchants
+            for (int i = 0; i < keyvalue.EnchType.Length; i++)
+            {
+                int type = keyvalue.EnchType[i];
+                int mi = IndexOfEnch(in self, type);
+                if (mi < 0 || self.EnchLvl[mi] == default)
+                {
+                    matchValue -= keyvalue.EnchValue[i];
+                    continue;
+                }
+                if (self.EnchLvl[mi] == keyvalue.EnchLvl[i])
+                    matchValue += self.EnchValue[mi];
+            }
+            // modifiers
+            for (int i = 0; i < keyvalue.ModKeyId.Length; i++)
+            {
+                int keyId = keyvalue.ModKeyId[i];
+                int mi = IndexOfMod(in self, keyId);
+                int importance = keyvalue.ModImportance[i];
+                if (mi < 0)
+                {
+                    matchValue -= Gvod(keyvalue.ModValue[i], importance);
+                    continue;
+                }
+                if (self.ModValId[mi] == keyvalue.ModValId[i] && !keyvalue.ModIsCandyUsed[i])
+                    matchValue += Gvod(self.ModValue[mi], importance);
+                else if (keyvalue.ModIsNumeric[i] && self.ModIsNumeric[mi])
+                {
+                    float fdef = Math.Abs(self.ModParsed[mi] - keyvalue.ModParsed[i]) * importance;
+                    matchValue -= Gvod(self.ModValue[mi], fdef);
+                }
+                else
+                    matchValue -= Gvod(self.ModValue[mi], importance);
+
+                if (self.ModValId[mi] != keyvalue.ModValId[i] && keyvalue.ModIsPetTierBoost[i])
+                    matchValue -= 108_000_000;
+            }
+            // reforge
+            if (keyvalue.HasReforge && keyvalue.Reforge != default)
+            {
+                if (self.HasReforge && self.Reforge == keyvalue.Reforge)
+                    matchValue += self.ReforgeValue;
+                else
+                    matchValue -= 1_000; // self has no matching reforge -> the original's `match?.Value ?? 1_000` is 1_000
+            }
+            return matchValue;
+        }
+
+        private static int IndexOfEnch(in ScoreVec v, int type)
+        {
+            for (int i = 0; i < v.EnchType.Length; i++)
+                if (v.EnchType[i] == type) return i;
+            return -1;
+        }
+
+        private static int IndexOfMod(in ScoreVec v, int keyId)
+        {
+            for (int i = 0; i < v.ModKeyId.Length; i++)
+                if (v.ModKeyId[i] == keyId) return i;
+            return -1;
+        }
+    }
+}

--- a/Services/DominatorIndex.cs
+++ b/Services/DominatorIndex.cs
@@ -1,0 +1,614 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>One interned modifier of a <see cref="DomKey"/>. Packed into a single struct array (instead of ~9
+    /// parallel arrays) so building one DomKey allocates one array, not nine — the per-auction query build is on the
+    /// snipe hot path — and the kernel scans contiguous structs (better locality).</summary>
+    public readonly struct DomMod
+    {
+        public readonly int KeyId;          // interner.Intern(key)
+        public readonly int ValId;          // interner.Intern(value)  (== compare via id; interner is 1:1)
+        public readonly float Parsed;       // float.TryParse(value, out parsed) — default culture (subtlety A)
+        public readonly bool IsNumeric;     // float.TryParse(value, out _) — default culture (subtlety A)
+        public readonly bool IsInvKey;      // SniperService.InvertedValueKey.Contains(key)
+        public readonly bool IsImpCakeYear; // SniperService.ImportantCakeYears.Contains(value)
+        public readonly bool HasSpaceOrComma; // value.Contains(' ') || value.Contains(',')
+        public readonly bool IsExpKey;      // key == "exp" (MatchesTierBoost gate, interner-free)
+        public readonly string ValRaw;      // raw value string (mode-c substring compare)
+        public DomMod(int keyId, int valId, float parsed, bool isNumeric, bool isInvKey, bool isImpCakeYear,
+            bool hasSpaceOrComma, bool isExpKey, string valRaw)
+        {
+            KeyId = keyId; ValId = valId; Parsed = parsed; IsNumeric = isNumeric; IsInvKey = isInvKey;
+            IsImpCakeYear = isImpCakeYear; HasSpaceOrComma = hasSpaceOrComma; IsExpKey = isExpKey; ValRaw = valRaw;
+        }
+    }
+
+    /// <summary>One enchant of a <see cref="DomKey"/> (type + level).</summary>
+    public readonly struct DomEnch
+    {
+        public readonly int Type;  // (int)Enchant.Type
+        public readonly byte Lvl;
+        public DomEnch(int type, byte lvl) { Type = type; Lvl = lvl; }
+    }
+
+    /// <summary>
+    /// Round-4 Phase-0 foundation — the interned, columnar <b>dominance kernel</b> + a contiguous candidate store
+    /// (<see cref="DominatorIndex"/>) for the snipe-finding path's "does X dominate Y" predicate
+    /// (<see cref="SniperService.IsHigherValue"/>).
+    ///
+    /// <para>
+    /// <b>What "dominates" means.</b> <c>Dominates(b, c)</c> is true iff candidate <c>c</c> is same-or-higher on every
+    /// axis of base <c>b</c>: tier, count, every base modifier covered with an equal-or-greater value, and every base
+    /// enchant present at an equal-or-greater level. It is the de-LINQ'd production predicate
+    /// <see cref="SniperService.IsHigherValue"/> (oracle: <see cref="SniperService.IsHigherValueReference"/>),
+    /// re-expressed over interned integer ids so the hot loop is integer compares with no per-call string work.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>BIT-EXACTNESS is the contract.</b> The kernel is fuzzed (40k pairs) against the LINQ oracle in
+    /// <c>IsHigherValueTests.Fuzz_ColumnarKernel_VsReference</c> with zero tolerance. Two subtleties are reproduced by
+    /// construction (the fuzz may not surface them): (A) numeric pre-parse uses <c>float.TryParse(value, out _)</c> — the
+    /// <b>default-culture</b> overload, matching <see cref="SniperService.IsHigherValue"/> (NOT the InvariantCulture
+    /// overload <see cref="ClosestScoreKernel.Build"/> uses); (B) the <c>other.Value == m.Value</c> equality is realized
+    /// as an interned-id compare via the single shared <see cref="ClosestScoreKernel.Interner"/> (1:1, so id-equality
+    /// ⟺ string-equality), while the rarer substring branch keeps the raw value strings.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Mask prefilter.</b> Each <see cref="DomKey"/> carries a <see cref="DomKey.RequiredMask"/> (the keys/enchants a
+    /// base must have covered) and a <see cref="DomKey.ProvidedMask"/> (the keys/enchants a candidate supplies). For
+    /// direction base=query, <c>(query.RequiredMask &amp; cand.ProvidedMask) == query.RequiredMask</c> is a SOUND
+    /// necessary condition for <c>Dominates(query, cand)</c> (proven in the fuzz: when the oracle says true, the mask
+    /// test holds), so it never false-rejects and lets the scan skip the exact kernel on the majority of candidates.
+    /// </para>
+    /// </summary>
+    public readonly struct DomKey
+    {
+        public readonly DomMod[] Mods;   // interned modifiers, index i over key.Modifiers
+        public readonly DomEnch[] Enchs; // enchants, index i over key.Enchants
+
+        // ---- per-key scalars ----
+        public readonly int Tier;                // (int)key.Tier
+        public readonly int Count;
+        public readonly bool FirstModIsNYC;      // Modifiers.Count > 0 && Modifiers[0].Key == "new_years_cake"
+        public readonly bool HasPetTierBoost;    // any modifier key=="petItem" && value=="TIER_BOOST"
+
+        /// <summary>OR of <c>1UL &lt;&lt; (id &amp; 63)</c> over (non-inverted-key modifiers) ∪ (enchant types) — what a base
+        /// REQUIRES covered. Used when this DomKey is the BASE side of the mask prefilter.</summary>
+        public readonly ulong RequiredMask;
+        /// <summary>OR of <c>1UL &lt;&lt; (id &amp; 63)</c> over ALL modifiers ∪ enchant types — what a candidate PROVIDES. Used
+        /// when this DomKey is the CHECK/coverage side of the mask prefilter.</summary>
+        public readonly ulong ProvidedMask;
+
+        public DomKey(DomMod[] mods, DomEnch[] enchs, int tier, int count, bool firstModIsNyc, bool hasPetTierBoost,
+            ulong requiredMask, ulong providedMask)
+        {
+            Mods = mods; Enchs = enchs;
+            Tier = tier; Count = count; FirstModIsNYC = firstModIsNyc; HasPetTierBoost = hasPetTierBoost;
+            RequiredMask = requiredMask; ProvidedMask = providedMask;
+        }
+    }
+
+    /// <summary>
+    /// Immutable holder for a bucket's cached <see cref="DomKey"/>, co-located on the bucket so index rebuilds reuse it
+    /// instead of re-deriving it. The DomKey is a pure function of the bucket's (immutable) <see cref="AuctionKey"/> +
+    /// the process-stable interner/InvertedValueKey/ImportantCakeYears, so unlike <see cref="ClosestScoreKernel.ScoreVecCache"/>
+    /// it never needs a TTL — built once, valid forever. A reference assignment is atomic (tear-safe); concurrent builds
+    /// produce identical content and one wins the publish.
+    /// </summary>
+    public sealed class DomKeyBox
+    {
+        public readonly DomKey Value;
+        public DomKeyBox(DomKey value) { Value = value; }
+    }
+
+    public sealed class DominatorIndex
+    {
+        /// <summary>Builds one key's interned columnar <see cref="DomKey"/>. All DomKeys compared together MUST be built
+        /// with the same <paramref name="interner"/> instance (shared id space — see the interner contract).</summary>
+        public static DomKey BuildDomKey(AuctionKey key, ClosestScoreKernel.Interner interner)
+        {
+            var mods = key.Modifiers;
+            int mc = mods?.Count ?? 0;
+            var domMods = new DomMod[mc];
+            ulong required = 0, provided = 0;
+            bool firstNyc = mc > 0 && mods[0].Key == "new_years_cake";
+            bool hasPtb = false;
+            for (int i = 0; i < mc; i++)
+            {
+                var k = mods[i].Key;
+                var v = mods[i].Value;
+                int keyId = interner.Intern(k);
+                // SUBTLETY A: default-culture overload, matching IsHigherValue's float.TryParse(value, out var x).
+                bool num = float.TryParse(v, out var parsed);
+                bool inv = SniperService.InvertedValueKey.Contains(k);
+                bool impCake = SniperService.ImportantCakeYears.Contains(v);
+                bool hasSC = v != null && (v.Contains(' ') || v.Contains(','));
+                bool isExp = k == "exp";
+                domMods[i] = new DomMod(keyId, interner.Intern(v), num ? parsed : 0f, num, inv, impCake, hasSC, isExp, v);
+                ulong bit = 1UL << (keyId & 63);
+                provided |= bit;
+                if (!inv) required |= bit; // RequiredMask: only keys whose absence cannot be excused by the inverted-key rule
+                if (!hasPtb && k == SniperService.PetItemKey && v == SniperService.TierBoostShorthand) hasPtb = true;
+            }
+
+            var enchs = key.Enchants;
+            int ec = enchs?.Count ?? 0;
+            var domEnchs = new DomEnch[ec];
+            for (int i = 0; i < ec; i++)
+            {
+                int t = (int)enchs[i].Type;
+                domEnchs[i] = new DomEnch(t, enchs[i].Lvl);
+                ulong bit = 1UL << (t & 63);
+                required |= bit;
+                provided |= bit;
+            }
+
+            return new DomKey(domMods, domEnchs, (int)key.Tier, key.Count, firstNyc, hasPtb, required, provided);
+        }
+
+        /// <summary>
+        /// Bit-exact with <c>SniperService.IsHigherValue(tag, baseKey=b, checkKey=c)</c>:
+        /// true iff <paramref name="c"/> dominates <paramref name="b"/>. <paramref name="tagIsPetSpirit"/> is
+        /// <c>tag == "PET_SPIRIT"</c> (the only way the tag enters the predicate).
+        /// </summary>
+        public static bool Dominates(in DomKey b, in DomKey c, bool tagIsPetSpirit)
+        {
+            // 1. tier
+            if (b.Tier > c.Tier)
+                return false;
+            // 2. PET_SPIRIT legendary rule
+            if (tagIsPetSpirit && c.Tier == (int)Coflnet.Sky.Core.Tier.LEGENDARY)
+                return false;
+            // 3. count
+            if (b.Count > c.Count)
+                return false;
+
+            // 4. modifiers — every base modifier covered, or excused by the inverted-key-absent exception.
+            var bMods = b.Mods;
+            var cMods = c.Mods;
+            for (int i = 0; i < bMods.Length; i++)
+            {
+                ref readonly var bm = ref bMods[i];
+                bool tierBoostOk = MatchesTierBoost(in b, in c, in bm); // constant per i (mirrors IsHigherValue folding it inside the j-loop)
+                bool covered = false;
+                if (tierBoostOk)
+                {
+                    int keyId = bm.KeyId;
+                    for (int j = 0; j < cMods.Length; j++)
+                    {
+                        if (cMods[j].KeyId != keyId)
+                            continue;
+                        if (ValueOk(in bm, in b, in cMods[j]))
+                        {
+                            covered = true;
+                            break;
+                        }
+                    }
+                }
+                // original: covered || (InvertedValueKey.Contains(m.Key) && !check has any mod with key m.Key)
+                if (!covered && !(bm.IsInvKey && !CheckHasKey(in c, bm.KeyId)))
+                    return false;
+            }
+
+            // 5. enchants — every base enchant present in check at >= level.
+            var bEnchs = b.Enchs;
+            var cEnchs = c.Enchs;
+            for (int i = 0; i < bEnchs.Length; i++)
+            {
+                int type = bEnchs[i].Type;
+                byte lvl = bEnchs[i].Lvl;
+                bool found = false;
+                for (int j = 0; j < cEnchs.Length; j++)
+                {
+                    if (cEnchs[j].Type == type && cEnchs[j].Lvl >= lvl) { found = true; break; }
+                }
+                if (!found)
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// valueOk(base mod, check mod) — OR of three modes, with base/check sides exactly as in IsHigherValue
+        /// (there: other=check, m=base):
+        ///  (a) other.Value == m.Value                       -> cm.ValId == bm.ValId (interned 1:1)
+        ///  (b) numeric (check parses) && cake guard && (base parses) && inverted-aware compare on the CHECK side
+        ///  (c) other.Value.Contains(m.Value) && !checkNumeric && check value has space/comma
+        /// </summary>
+        private static bool ValueOk(in DomMod bm, in DomKey b, in DomMod cm)
+        {
+            // (a) equality via interned ids
+            if (cm.ValId == bm.ValId)
+                return true;
+            // (b) numeric compare. NOTE the sides: numeric guard + cake guard read the CHECK value; inverted-ness reads
+            // the CHECK key (InvertedValueKey.Contains(other.Key)); the cake first-mod guard reads the BASE first mod.
+            if (cm.IsNumeric
+                && (!b.FirstModIsNYC || !cm.IsImpCakeYear)
+                && bm.IsNumeric
+                && (cm.IsInvKey ? cm.Parsed < bm.Parsed : cm.Parsed > bm.Parsed))
+                return true;
+            // (c) substring containment on the raw CHECK value (rare branch, survivors only).
+            if (cm.HasSpaceOrComma && !cm.IsNumeric && cm.ValRaw.Contains(bm.ValRaw))
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// MatchesTierBoostOrLowerTier(base, check, base mod) — only constrains the "exp" modifier:
+        /// if the base mod is not "exp" -> true; else if check has no petItem=TIER_BOOST -> true; else base must itself
+        /// carry petItem=TIER_BOOST OR be of strictly lower tier.
+        /// </summary>
+        private static bool MatchesTierBoost(in DomKey b, in DomKey c, in DomMod bm)
+        {
+            if (!bm.IsExpKey)
+                return true;
+            if (!c.HasPetTierBoost)
+                return true;
+            return b.HasPetTierBoost || b.Tier < c.Tier;
+        }
+
+        /// <summary>Does check have ANY modifier whose key id == <paramref name="keyId"/>? (the inverted-key-absent exception)</summary>
+        private static bool CheckHasKey(in DomKey c, int keyId)
+        {
+            var m = c.Mods;
+            for (int j = 0; j < m.Length; j++)
+                if (m[j].KeyId == keyId) return true;
+            return false;
+        }
+
+        // ============================== contiguous candidate store ==============================
+
+        /// <summary>Candidate keys, parallel to the other arrays (returned to the caller on a hit).</summary>
+        public readonly AuctionKey[] Keys;
+        /// <summary>Candidate buckets, parallel to <see cref="Keys"/>. The finders read all MUTABLE bucket state
+        /// (Price / Lbin / References) LIVE off these, so no price/ref columns are cached (they would be stale).</summary>
+        public readonly ReferenceAuctions[] Buckets;
+        /// <summary>Per-candidate interned columnar form, parallel to <see cref="Keys"/>.</summary>
+        public readonly DomKey[] Doms;
+        /// <summary>Mirror of <c>Doms[i].RequiredMask</c> into a flat array (cache-friendly prefilter — used when the
+        /// candidate is the BASE side: <c>(RequiredMask[i] &amp; query.ProvidedMask) == RequiredMask[i]</c>).</summary>
+        public readonly ulong[] RequiredMask;
+        /// <summary>Mirror of <c>Doms[i].ProvidedMask</c> into a flat array (used when the candidate is the CHECK side:
+        /// <c>(query.RequiredMask &amp; ProvidedMask[i]) == query.RequiredMask</c>).</summary>
+        public readonly ulong[] ProvidedMask;
+        /// <summary>Per-candidate (int)reforge (key-derived, immutable). The one mutable-looking value the finders read
+        /// off the index rather than live, because reforge is part of the immutable key.</summary>
+        public readonly int[] Reforge;
+        /// <summary>Number of populated entries (arrays may be over-allocated; only the first Count are valid).</summary>
+        public readonly int Count;
+
+        public readonly long BuiltEpoch;
+        public readonly int BuiltLookupCount;
+        public readonly DateTime BuiltAt;
+
+        public DominatorIndex(AuctionKey[] keys, ReferenceAuctions[] buckets, DomKey[] doms,
+            ulong[] requiredMask, ulong[] providedMask, int[] reforge, int count,
+            long builtEpoch, int builtLookupCount, DateTime builtAt)
+        {
+            Keys = keys; Buckets = buckets; Doms = doms;
+            RequiredMask = requiredMask; ProvidedMask = providedMask;
+            Reforge = reforge; Count = count;
+            BuiltEpoch = builtEpoch; BuiltLookupCount = builtLookupCount; BuiltAt = builtAt;
+        }
+
+        /// <summary>
+        /// Packs the qualifying candidate buckets of <paramref name="l"/> into parallel arrays. The qualifying set is
+        /// the BROAD superset the four finders share — just the non-null guards
+        /// <c>m.Key != null &amp;&amp; m.Value?.References != null</c>. Unlike the closest search, the dominance finders
+        /// (GetLbinCap, PotentialSnipeHigherValueScan, CheckLowerKeyFull, the median lower-value scan) do NOT exclude
+        /// <c>Price==0</c> or <c>virtual</c> buckets (e.g. PotentialSnipeHigherValueScan's keyCount/percentile/divided-ref
+        /// outputs depend on those buckets being present), so the index is a superset and each finder applies its OWN
+        /// secondary predicate (Price&gt;0 / Lbin!=0 / RefCount / recency / reforge) over the buckets during its scan.
+        /// Only IMMUTABLE key-derived data is cached (DomKey/masks/Reforge/Keys/Buckets); mutable price/ref state is read
+        /// live. Over-allocated to <c>l.Count</c> and grown if the dict grows mid-enumeration so a new candidate is never
+        /// dropped.
+        /// </summary>
+        public static DominatorIndex Build(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l,
+            ClosestScoreKernel.Interner interner, long epoch, DateTime builtAt)
+        {
+            int cap = l.Count;
+            var keys = new AuctionKey[cap];
+            var buckets = new ReferenceAuctions[cap];
+            var doms = new DomKey[cap];
+            var required = new ulong[cap];
+            var provided = new ulong[cap];
+            var reforge = new int[cap];
+            int n = 0;
+            foreach (var m in l)
+            {
+                // BROAD superset: non-null guards only. Each finder applies its own Price>0 / virtual / RefCount / recency
+                // / reforge secondary predicate over the buckets during its scan (see the summary above).
+                if (m.Key == null || m.Value?.References == null)
+                    continue;
+                if (n >= keys.Length) // dict grew during enumeration -> grow so a new candidate is never dropped
+                {
+                    int g = n + 8;
+                    Array.Resize(ref keys, g); Array.Resize(ref buckets, g); Array.Resize(ref doms, g);
+                    Array.Resize(ref required, g); Array.Resize(ref provided, g); Array.Resize(ref reforge, g);
+                }
+                // Reuse the bucket's cached DomKey (pure-key-derived, never stale) so a rebuild does not re-derive it;
+                // only the flat column arrays below are re-allocated. Atomic-ref publish (tear-safe).
+                var box = m.Value.DomKeyCache;
+                DomKey dom;
+                if (box != null)
+                    dom = box.Value;
+                else
+                {
+                    dom = BuildDomKey(m.Key, interner);
+                    m.Value.DomKeyCache = new DomKeyBox(dom);
+                }
+                keys[n] = m.Key; buckets[n] = m.Value; doms[n] = dom;
+                required[n] = dom.RequiredMask; provided[n] = dom.ProvidedMask;
+                reforge[n] = (int)m.Key.Reforge;
+                n++;
+            }
+            return new DominatorIndex(keys, buckets, doms, required, provided, reforge, n, epoch, l.Count, builtAt);
+        }
+    }
+
+    /// <summary>
+    /// R5c (idx-grow) — an <b>append-amortized growable backing store</b> for the <see cref="DominatorIndex"/> columns.
+    ///
+    /// <para><b>Why.</b> On the RARE path a novel key is ADDED every auction, so the lookup dict's <c>Count</c> changes
+    /// every auction and the old <see cref="DominatorIndex.Build"/> re-allocated six fresh O(N) column arrays per call →
+    /// LOH → gen2 <c>AllocLarge</c> stop-the-world pauses (the #1 rare-pause driver). This store replaces the per-auction
+    /// full rebuild with an <b>amortized-O(1) APPEND</b> of only the newly-added buckets' rows into doubling-capacity
+    /// backing arrays, and falls back to a full rebuild only when a bucket was REMOVED/REPLACED or the TTL elapsed.</para>
+    ///
+    /// <para><b>The crucial property this exploits.</b> The DominatorIndex's membership is <b>price-INDEPENDENT</b> — it is
+    /// exactly the non-null buckets (<c>m.Key != null &amp;&amp; m.Value?.References != null</c>), and every finder reads all
+    /// MUTABLE price/ref state LIVE off <c>Buckets[i]</c>. So membership changes ONLY when the dict ADDS or REMOVES a
+    /// bucket — never on a price flip. Adds dominate the rare path, and an add is an append.</para>
+    ///
+    /// <para><b>Bit-exactness contract.</b> An appended snapshot must be byte-for-byte identical to what
+    /// <see cref="DominatorIndex.Build"/> would produce at that instant. A <c>Build</c> at append-time captures, for each
+    /// qualifying key, <c>(Key, Buckets[i]=current dict value, DomKey, masks, Reforge)</c>; the DomKey/masks/Reforge are
+    /// pure functions of the IMMUTABLE key, so the ONLY value that depends on the live dict is <c>Buckets[i]</c> (the
+    /// bucket object the finder reads live state off). The append therefore: (1) VERIFIES every prior member is still
+    /// present (else it cannot be a pure add → full rebuild); (2) appends only the new buckets' rows.</para>
+    ///
+    /// <para><b>Membership by OBJECT identity (zero per-bucket hashing).</b> Each bucket carries a
+    /// <see cref="ReferenceAuctions.DomRowStamp"/> = the GENERATION of the snapshot it currently belongs to, written when
+    /// its row is added. The append scan classifies each qualifying bucket by a single FIELD read of that stamp — a prior
+    /// member iff the stamp equals the store's current generation — instead of an allocating
+    /// <see cref="AuctionKey.GetHashCode"/> dictionary probe (the <c>ReadOnlyCollection</c> enumerators that hashing
+    /// allocates were the per-auction cost of a key-map design). Generations come from a PROCESS-GLOBAL monotonic counter,
+    /// so a stamp from one store can never equal a different store's generation — robust even if the load path adopts a
+    /// bucket object between lookups. The membership soundness gate is then exact: <c>seenPrior == priorCount</c> means
+    /// every prior member is still in the dict. A bucket object lives in the dict under exactly one key, and distinct dict
+    /// entries are distinct objects, so OBJECT-identity membership ≡ KEY-identity membership. A same-key bucket-OBJECT
+    /// replacement removes the OLD object from the dict, so the old row's stamp is no longer seen ⇒
+    /// <c>seenPrior &lt; priorCount</c> ⇒ rebuild (which captures the new object) — never a stale/duplicate row. A full
+    /// rebuild takes a fresh generation, invalidating every old stamp at once.</para>
+    ///
+    /// <para><b>Tear-safety.</b> Readers are lock-free: each holds one published <see cref="DominatorIndex"/> reference,
+    /// reads its <c>Count</c>, and indexes <c>[0, Count)</c> into its arrays. Append/grow + all stamp reads/writes are
+    /// serialized under <see cref="_gate"/> (only the rebuild path locks; finders never do, and the stamp is never in the
+    /// published view). A NO-GROW append writes the new rows into the shared backing arrays at <c>[priorCount, newCount)</c>
+    /// BEFORE the atomic publish of the larger-Count view, so an old reader (Count=priorCount) never touches them. A GROW
+    /// append allocates new doubled arrays, copies, writes the new rows, and publishes a view over the NEW arrays — old
+    /// readers keep the old (smaller) arrays untouched.</para>
+    /// </summary>
+    public sealed class DominatorIndexStore
+    {
+        // Process-global monotonic generation source. Every full rebuild (of ANY store) takes a fresh, never-reused
+        // generation, so a bucket's DomRowStamp from one store can NEVER equal a different store's current generation —
+        // making the OBJECT-identity membership test robust even if the load path adopts a bucket between lookups. Starts
+        // at 0, so the first generation handed out is 1; the default DomRowStamp(0) therefore matches no live generation.
+        private static long _globalGeneration;
+        private static long NextGeneration() => System.Threading.Interlocked.Increment(ref _globalGeneration);
+
+        private readonly object _gate = new();
+
+        // Growable backing columns (capacity may exceed Count; only [0,_count) are valid).
+        private AuctionKey[] _keys = Array.Empty<AuctionKey>();
+        private ReferenceAuctions[] _buckets = Array.Empty<ReferenceAuctions>();
+        private DomKey[] _doms = Array.Empty<DomKey>();
+        private ulong[] _required = Array.Empty<ulong>();
+        private ulong[] _provided = Array.Empty<ulong>();
+        private int[] _reforge = Array.Empty<int>();
+        private int _count;
+
+        // This store's current snapshot generation (the value its member buckets' DomRowStamp carry). Replaced by a fresh
+        // global generation on every full rebuild, which invalidates all old stamps at once. 0 until the first rebuild.
+        private long _generation;
+
+        // Reused scratch for the append's new-bucket batch (the dict entry carries both the key and the bucket). Reused
+        // across appends (cleared, not re-allocated) so the steady rare-path append (typically +1 bucket) is alloc-free
+        // once warmed. Touched only under _gate.
+        private readonly List<KeyValuePair<AuctionKey, ReferenceAuctions>> _scratchNew = new();
+
+        // The last published immutable view (returned on a cache HIT). Published by atomic ref store; read lock-free.
+        private DominatorIndex _published;
+
+        /// <summary>
+        /// Returns the up-to-date immutable <see cref="DominatorIndex"/> view of <paramref name="l"/>, taking the cheapest
+        /// correct path: a cache HIT (Count unchanged + within TTL), an amortized APPEND (live Count grew and every prior
+        /// member is still present), or a full REBUILD (a member was removed/de-qualified, the live Count shrank, or the
+        /// TTL elapsed). Identical output to <see cref="DominatorIndex.Build"/> in all cases.
+        /// </summary>
+        public DominatorIndex GetOrBuild(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l,
+            ClosestScoreKernel.Interner interner, long epoch, DateTime now, DateTime ttlCutoff)
+        {
+            // Lock-free cache-HIT fast path (mirrors the old GetOrBuildDominatorIndex hit guard: Count + TTL, epoch-free).
+            int liveCount = l.Count;
+            var pub = _published; // single atomic read
+            if (pub != null && pub.BuiltLookupCount == liveCount && pub.BuiltAt > ttlCutoff)
+                return pub;
+
+            // Slow path: serialize all builders/appenders for this lookup so in-place appends never race each other.
+            lock (_gate)
+            {
+                liveCount = l.Count; // re-read under the lock
+                pub = _published;
+                if (pub != null && pub.BuiltLookupCount == liveCount && pub.BuiltAt > ttlCutoff)
+                    return pub; // another thread published while we waited
+
+                // APPEND is admissible only when the dict grew (more entries) and we have a prior snapshot to extend.
+                // (liveCount < prior dict count -> a remove happened -> rebuild; liveCount == prior -> only same-count
+                //  replacements/price flips, which the Count-keyed HIT already covers exactly as the old code did.)
+                if (pub != null && liveCount > pub.BuiltLookupCount && pub.BuiltAt > ttlCutoff && TryAppend(l, interner, epoch, now, liveCount))
+                    return _published;
+
+                // Fall back to a full rebuild (cold start, removal, TTL, or an append that could not prove soundness).
+                return Rebuild(l, interner, epoch, now, liveCount);
+            }
+        }
+
+        /// <summary>
+        /// Full rebuild into the growable store (the <see cref="DominatorIndex.Build"/> fallback). Bumps the generation
+        /// (invalidating all old stamps), repacks the current qualifying membership into freshly-sized arrays, stamps each
+        /// row, and publishes a fresh view. Always correct. Caller holds <see cref="_gate"/>.
+        /// </summary>
+        private DominatorIndex Rebuild(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l,
+            ClosestScoreKernel.Interner interner, long epoch, DateTime now, int liveCount)
+        {
+            long gen = _generation = NextGeneration(); // fresh globally-unique generation; invalidates all prior stamps
+            int cap = liveCount > 0 ? liveCount : 0;
+            var keys = new AuctionKey[cap];
+            var buckets = new ReferenceAuctions[cap];
+            var doms = new DomKey[cap];
+            var required = new ulong[cap];
+            var provided = new ulong[cap];
+            var reforge = new int[cap];
+            int n = 0;
+            foreach (var m in l)
+            {
+                if (m.Key == null || m.Value?.References == null)
+                    continue;
+                if (n >= keys.Length) // dict grew during enumeration -> grow so a new candidate is never dropped
+                {
+                    int g = n + 8;
+                    Array.Resize(ref keys, g); Array.Resize(ref buckets, g); Array.Resize(ref doms, g);
+                    Array.Resize(ref required, g); Array.Resize(ref provided, g); Array.Resize(ref reforge, g);
+                }
+                var dom = GetDomKey(m.Value, m.Key, interner);
+                keys[n] = m.Key; buckets[n] = m.Value; doms[n] = dom;
+                required[n] = dom.RequiredMask; provided[n] = dom.ProvidedMask;
+                reforge[n] = (int)m.Key.Reforge;
+                m.Value.DomRowStamp = gen; // stamp this bucket OBJECT as a member of the new snapshot generation
+                n++;
+            }
+            _keys = keys; _buckets = buckets; _doms = doms; _required = required; _provided = provided; _reforge = reforge;
+            _count = n;
+            var view = new DominatorIndex(keys, buckets, doms, required, provided, reforge, n, epoch, liveCount, now);
+            _published = view; // atomic publish
+            return view;
+        }
+
+        /// <summary>
+        /// Amortized append: tries to extend the prior snapshot with ONLY the newly-added buckets' rows. Returns true and
+        /// publishes the grown view iff append is provably bit-exact with a full rebuild (every prior member still present);
+        /// returns false (no state changed) to signal the caller to rebuild. Caller holds <see cref="_gate"/>.
+        /// </summary>
+        private bool TryAppend(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l,
+            ClosestScoreKernel.Interner interner, long epoch, DateTime now, int liveCount)
+        {
+            int priorCount = _count;
+            long gen = _generation;
+            // PASS 1 (read-only, NO store mutation so we can bail to rebuild cleanly): classify each qualifying bucket by a
+            // single FIELD read of its stamp — prior member iff stamp's generation == this store's generation — and stage
+            // the new ones in the reused scratch list. Zero per-bucket hashing (the key-map design's GetHashCode/enumerator
+            // alloc is gone). One dict enumeration (unavoidable to discover the new keys).
+            var newRows = _scratchNew;
+            newRows.Clear();
+            int seenPrior = 0;
+            foreach (var m in l)
+            {
+                if (m.Key == null || m.Value?.References == null)
+                    continue;
+                if (m.Value.DomRowStamp == gen) // prior member of THIS store's current snapshot (object identity)
+                    seenPrior++;
+                else
+                    newRows.Add(m);
+            }
+
+            // SOUNDNESS GATE: append is bit-exact with a rebuild iff every prior member is still present. If a prior member
+            // vanished (seenPrior < priorCount) the change is NOT a pure add (a remove + an add can net to a larger Count)
+            // — the prior columns would hold a stale/removed row — so rebuild. (seenPrior can't exceed priorCount: each of
+            // the priorCount stamped objects appears once in the dict.)
+            if (seenPrior != priorCount)
+            {
+                newRows.Clear();
+                return false;
+            }
+            if (newRows.Count == 0)
+            {
+                // No genuinely-new qualifying key (the Count delta was all non-qualifying entries). Rebuild to produce the
+                // canonical snapshot stamped with the new dict Count (appending nothing would mis-stamp BuiltLookupCount).
+                return false;
+            }
+
+            // PASS 2 (commit): the change is a proven pure add. Grow once, then write + stamp the new rows.
+            int newN = priorCount + newRows.Count;
+            EnsureCapacity(newN); // grows the backing arrays (doubling + copy) only when needed; else writes in place.
+            var keys = _keys; var buckets = _buckets; var doms = _doms;
+            var required = _required; var provided = _provided; var reforge = _reforge;
+            int n = priorCount;
+            for (int i = 0; i < newRows.Count; i++)
+            {
+                var m = newRows[i];
+                var dom = GetDomKey(m.Value, m.Key, interner);
+                keys[n] = m.Key; buckets[n] = m.Value; doms[n] = dom;
+                required[n] = dom.RequiredMask; provided[n] = dom.ProvidedMask;
+                reforge[n] = (int)m.Key.Reforge;
+                m.Value.DomRowStamp = gen; // stamp the appended bucket OBJECT as a member of the current generation
+                n++;
+            }
+            newRows.Clear();
+            _count = n;
+            // Publish a view over the (possibly newly-grown) backing arrays with the larger Count. The new rows at
+            // [priorCount,n) were written above (happens-before this atomic publish), so any reader that reads this new
+            // reference sees them; readers holding the OLD view (Count=priorCount) never index past priorCount.
+            var view = new DominatorIndex(keys, buckets, doms, required, provided, reforge, n, epoch, liveCount, now);
+            _published = view; // atomic publish
+            return true;
+        }
+
+        /// <summary>Reuse the bucket's cached pure-key-derived DomKey (never stale); derive+cache it on first sight.</summary>
+        private static DomKey GetDomKey(ReferenceAuctions bucket, AuctionKey key, ClosestScoreKernel.Interner interner)
+        {
+            var box = bucket.DomKeyCache;
+            if (box != null)
+                return box.Value;
+            var dom = DominatorIndex.BuildDomKey(key, interner);
+            bucket.DomKeyCache = new DomKeyBox(dom);
+            return dom;
+        }
+
+        /// <summary>
+        /// Ensures the backing columns hold at least <paramref name="needed"/> rows, growing by DOUBLING (allocate new
+        /// arrays + copy the live prefix) when the current capacity is insufficient — so a published view that aliases the
+        /// OLD arrays is never mutated past its own Count, and the amortized per-append copy is O(1). When capacity already
+        /// suffices, the existing arrays are kept and new rows are written in place at [Count, needed) (no allocation).
+        /// </summary>
+        private void EnsureCapacity(int needed)
+        {
+            int cap = _keys.Length;
+            if (cap >= needed)
+                return; // capacity suffices -> write new rows in place into the shared arrays (no realloc)
+            int newCap = cap == 0 ? Math.Max(needed, 4) : cap;
+            while (newCap < needed)
+                newCap *= 2;
+            var keys = new AuctionKey[newCap];
+            var buckets = new ReferenceAuctions[newCap];
+            var doms = new DomKey[newCap];
+            var required = new ulong[newCap];
+            var provided = new ulong[newCap];
+            var reforge = new int[newCap];
+            int copy = _count;
+            Array.Copy(_keys, keys, copy);
+            Array.Copy(_buckets, buckets, copy);
+            Array.Copy(_doms, doms, copy);
+            Array.Copy(_required, required, copy);
+            Array.Copy(_provided, provided, copy);
+            Array.Copy(_reforge, reforge, copy);
+            _keys = keys; _buckets = buckets; _doms = doms; _required = required; _provided = provided; _reforge = reforge;
+        }
+    }
+}

--- a/Services/DropOff.Tests.cs
+++ b/Services/DropOff.Tests.cs
@@ -47,7 +47,7 @@ public class DropOffTests
         {
             loaded = File.ReadAllText("Mock/boots.json");
         }
-        sniperService = new SniperService(new(null, null), null, NullLogger<SniperService>.Instance, craftCostService);
+        sniperService = new SniperService(new HypixelItemService(null, NullLogger<HypixelItemService>.Instance), null, NullLogger<SniperService>.Instance, craftCostService);
         var parsed = JsonConvert.DeserializeObject<LookupLoad>(loaded);
         var xy =
                 parsed.Lookup.Where(l => l.Key.Contains("BLACK")).ToDictionary(l => ParseKey(l), l => l.Value);

--- a/Services/GetPrice.Tests.cs
+++ b/Services/GetPrice.Tests.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using dev;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R3 Phase 0 / F1 bit-exactness oracle for the read path
+    /// (<c>benchmarks/COMPUTE_FLOOR_SPEC_R3.md</c> §4-F1 + §5 R3-READ).
+    ///
+    /// <para>
+    /// <b>Why.</b> R3-READ rewrites the brute-force read search (<c>GetClosestLbins</c>'s
+    /// <c>Where().OrderByDescending(Similarity)</c> and <c>GetEstimatedMedian</c>) onto the WS-A contiguous index +
+    /// WS-C BnB + columnar kernel. That rewrite must reproduce the *current* public <see cref="SniperService.GetPrice"/>
+    /// result <b>byte-for-byte</b> on every fixture — same <c>Median</c>, <c>Lbin</c>, <c>SLbin</c>, <c>MedianKey</c>,
+    /// <c>LbinKey</c>, <c>ItemKey</c>, <c>Volume</c>, <c>Volatility</c>, <c>AvgSellTime</c>, <c>LastSale</c>. This is the
+    /// gate: the harness drives <c>GetPrice(SaveAuction)</c> over representative auctions and pins every returned
+    /// <see cref="PriceEstimate"/> field to an embedded golden snapshot.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Coverage.</b> The fixtures deliberately span both read-path shapes the rewrite touches:
+    /// <list type="bullet">
+    ///   <item><b>Exact-match</b> — the requested <c>itemKey</c> resolves to a populated bucket directly
+    ///     (the <c>l.TryGetValue(itemKey, out bucket)</c> fast path: <c>AssignMedian</c> + the bucket's own Lbin).</item>
+    ///   <item><b>No-exact-match (brute force)</b> — the requested key has no bucket, forcing the
+    ///     <c>GetEstimatedMedian</c> closest-median scan AND the <c>ClosestLbin</c>/<c>GetClosestLbins</c>
+    ///     <c>OrderByDescending(Similarity + Volume)</c> brute force. This is exactly the search R3-READ replaces, so
+    ///     these cases are the load-bearing half of the gate.</item>
+    ///   <item><b>Bazaar</b> — the <c>BazaarPrices</c> short-circuit (Median = bazaar * count).</item>
+    ///   <item><b>Higher-value cap / lower-key</b> — the <c>GetLbinCap</c> + lower-value-key adjustment branches.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// Construction mirrors <c>ValuationFinders.Tests.cs</c> / <c>SniperService.Tests.cs</c> Setup (NullLogger to
+    /// dodge the known flaky-logger NRE, MIN_TARGET=0, fixed StartTime, FullyLoaded, AddSoldItem/AddVolume to populate
+    /// buckets). <see cref="DISCOVER"/> is the regeneration switch: flip it to <c>true</c>, run, and paste the printed
+    /// <c>field=value</c> lines back into the golden constants below — never edit a golden by hand to make a failing
+    /// run pass without first confirming the new value is intended (that would defeat the gate).
+    /// </para>
+    /// </summary>
+    public class GetPriceGoldenTests
+    {
+        /// <summary>
+        /// Regeneration switch. Leave <c>false</c> in committed code: the test then *asserts* the live GetPrice result
+        /// equals the embedded golden. Flip to <c>true</c> only to (re)derive the goldens after an *intended* behavior
+        /// change — the test prints each fixture's serialized estimate and trivially passes so the new lines can be
+        /// copied into the constants. A green CI run with DISCOVER=true proves nothing; it must be committed false.
+        /// </summary>
+        private static readonly bool DISCOVER = false;
+
+        private SniperService service = null!;
+        private List<LowPricedAuction> found = null!;
+        private CraftCostMock craftCost = null!;
+        private HypixelItemService itemService = null!;
+        private static long idCounter;
+
+        private class CraftCostMock : ICraftCostService
+        {
+            public Dictionary<string, double> Costs { get; } = new();
+            public Dictionary<string, Category> ItemCategories { get; } = new();
+            public void AddCostForSpecialItems() { }
+            public bool TryGetCost(string itemId, out double cost) => Costs.TryGetValue(itemId, out cost);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            SniperService.StartTime = new DateTime(2021, 9, 25);
+            craftCost = new CraftCostMock();
+            itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, craftCost);
+            idCounter = 100;
+            found = new List<LowPricedAuction>();
+            service.FoundSnipe += found.Add;
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        // ============================================================================================================
+        // EXACT-MATCH fixtures: the requested key resolves directly to a populated bucket.
+        // ============================================================================================================
+
+        /// <summary>
+        /// Plain priced bucket with volume: the requested auction hits its own bucket (the
+        /// <c>l.TryGetValue(itemKey, out bucket)</c> fast path) for both Median (AssignMedian) and Lbin.
+        /// </summary>
+        [Test]
+        public void GetPrice_ExactMatch_PricedBucket_BitExact()
+        {
+            var sample = Dupplicate(Base());
+            sample.FlatenedNBT = new();
+            sample.Enchantments = new List<Enchantment>();
+            sample.Tag = "EXACT_SWORD";
+            sample.HighestBidAmount = 12_000_000;
+            AddVolume(sample, 10);
+            // an active (unsold) auction so the bucket has an Lbin too
+            var lbin = Dupplicate(sample);
+            lbin.HighestBidAmount = 0;
+            lbin.StartingBid = 15_000_000;
+            DrivePublic(lbin);
+
+            var probe = Dupplicate(sample);
+            AssertGoldenEstimate("ExactMatch_PricedBucket", service.GetPrice(probe), GOLD_EXACT_PRICED);
+        }
+
+        /// <summary>
+        /// Pet exact-match across tiers: the requested pet key resolves to its own populated bucket; exercises
+        /// AssignMedian on a pet bucket plus the pet-key Lbin path.
+        /// </summary>
+        [Test]
+        public void GetPrice_ExactMatch_Pet_BitExact()
+        {
+            var pet = Dupplicate(Base());
+            pet.Tag = "PET_LION";
+            pet.FlatenedNBT = new() { { "exp", "10000000" }, { "candyUsed", "0" } };
+            pet.Enchantments = new List<Enchantment>();
+            pet.Tier = Tier.LEGENDARY;
+            pet.HighestBidAmount = 40_000_000;
+            AddVolume(pet, 9);
+            var lbin = Dupplicate(pet);
+            lbin.HighestBidAmount = 0;
+            lbin.StartingBid = 45_000_000;
+            DrivePublic(lbin);
+
+            var probe = Dupplicate(pet);
+            AssertGoldenEstimate("ExactMatch_Pet", service.GetPrice(probe), GOLD_EXACT_PET);
+        }
+
+        // ============================================================================================================
+        // NO-EXACT-MATCH fixtures: forces GetEstimatedMedian (closest-median brute force) + GetClosestLbins.
+        // ============================================================================================================
+
+        /// <summary>
+        /// No bucket exists for the probed key (it carries an extra modifier none of the populated buckets has), so
+        /// GetPrice falls through to <c>GetEstimatedMedian</c> (the closest-median brute scan) and
+        /// <c>ClosestLbin</c>/<c>GetClosestLbins</c> (the <c>OrderByDescending(Similarity + Volume)</c> brute force) —
+        /// the exact search R3-READ replaces. Pins the resulting estimated Median/MedianKey + closest Lbin.
+        /// </summary>
+        [Test]
+        public void GetPrice_NoExactMatch_ClosestMedianAndLbin_BitExact()
+        {
+            // populate a couple of neighbour buckets with volume + an lbin, none matching the probe key exactly
+            var neighbourA = Dupplicate(Base());
+            neighbourA.Tag = "CRIMSON_CHESTPLATE";
+            neighbourA.FlatenedNBT = new() { { "magic_find", "5" }, { "veteran", "4" } };
+            neighbourA.Enchantments = new List<Enchantment>();
+            neighbourA.HighestBidAmount = 10_000_000;
+            AddVolume(neighbourA, 8);
+            var neighbourAlbin = Dupplicate(neighbourA);
+            neighbourAlbin.HighestBidAmount = 0;
+            neighbourAlbin.StartingBid = 11_000_000;
+            DrivePublic(neighbourAlbin);
+
+            var neighbourB = Dupplicate(neighbourA);
+            neighbourB.FlatenedNBT = new() { { "magic_find", "3" }, { "veteran", "4" } };
+            neighbourB.HighestBidAmount = 15_000_000;
+            AddVolume(neighbourB, 8);
+            var neighbourBlbin = Dupplicate(neighbourB);
+            neighbourBlbin.HighestBidAmount = 0;
+            neighbourBlbin.StartingBid = 16_000_000;
+            DrivePublic(neighbourBlbin);
+
+            // probe a key with a modifier set NONE of the buckets has -> no exact bucket -> brute force
+            var probe = Dupplicate(neighbourA);
+            probe.FlatenedNBT = new() { { "magic_find", "9" }, { "veteran", "4" }, { "mending", "5" } };
+            probe.HighestBidAmount = 0;
+            probe.StartingBid = 1000;
+            AssertGoldenEstimate("NoExactMatch_ClosestMedianAndLbin", service.GetPrice(probe), GOLD_NOEXACT_CLOSEST);
+        }
+
+        /// <summary>
+        /// Lower-value-key path: the probed (lower-value) auction has no own priced bucket, so the estimated-median
+        /// scan picks up a higher-value bucket and adds back a fraction of the missing value. Mirrors
+        /// <c>ChecksLowerKeysForHigherPrice</c>; gates the lower-key + missing-enchant adjustment in the read path.
+        /// </summary>
+        [Test]
+        public void GetPrice_NoExactMatch_LowerKeyHigherValue_BitExact()
+        {
+            SetBazaarPrice("ENCHANTMENT_PROTECTION_6", 6_200_000);
+            SetBazaarPrice("ENCHANTMENT_GROWTH_6", 6_200_000);
+            SetBazaarPrice("FUMING_POTATO_BOOK", 1_200_000);
+            SetBazaarPrice("FIRST_MASTER_STAR", 14_200_000);
+            SetBazaarPrice("RECOMBOBULATOR_3000", 8_200_000);
+
+            var seed = Dupplicate(Base());
+            seed.Tag = "LOWERKEY_HELM";
+            seed.FlatenedNBT = new() { { "rarity_ugprades", "1" }, { "upgrade_level", "6" } };
+            seed.Enchantments = new List<Enchantment> { new(EnchantmentType.growth, 6) };
+            var noVolume = Dupplicate(seed);
+            var target = Dupplicate(seed);
+            seed.Enchantments.Add(new(EnchantmentType.protection, 6));
+            seed.FlatenedNBT.Add("hpc", "15");
+            seed.HighestBidAmount = 32_000_000;
+
+            target.Enchantments.Clear();
+            target.HighestBidAmount = 35_000_000;
+            AddVolume(target);
+            AddVolume(seed);
+
+            AssertGoldenEstimate("NoExactMatch_LowerKeyHigherValue", service.GetPrice(noVolume), GOLD_NOEXACT_LOWERKEY);
+        }
+
+        // ============================================================================================================
+        // BAZAAR + EMPTY fixtures: short-circuit and no-lookup paths.
+        // ============================================================================================================
+
+        /// <summary>Bazaar short-circuit: Median = bazaar price * count, no bucket search at all.</summary>
+        [Test]
+        public void GetPrice_Bazaar_BitExact()
+        {
+            SetBazaarPrice("ENCHANTMENT_GROWTH_6", 6_200_000);
+            var probe = Dupplicate(Base());
+            probe.Tag = "ENCHANTMENT_GROWTH_6";
+            probe.Count = 3;
+            probe.FlatenedNBT = new();
+            probe.Enchantments = new List<Enchantment>();
+            AssertGoldenEstimate("Bazaar", service.GetPrice(probe), GOLD_BAZAAR);
+        }
+
+        /// <summary>Unknown tag with no lookup at all returns an empty estimate (the early <c>return result</c>).</summary>
+        [Test]
+        public void GetPrice_UnknownTag_Empty_BitExact()
+        {
+            var probe = Dupplicate(Base());
+            probe.Tag = "TOTALLY_UNKNOWN_TAG_XYZ";
+            probe.FlatenedNBT = new();
+            probe.Enchantments = new List<Enchantment>();
+            AssertGoldenEstimate("UnknownTag", service.GetPrice(probe), GOLD_UNKNOWN);
+        }
+
+        // ============================================================================================================
+        // Golden snapshots. (string) = serialized PriceEstimate, see SerializeEstimate.
+        // Regenerate with DISCOVER=true; never hand-edit to silence a real diff.
+        // ============================================================================================================
+
+        private const string GOLD_EXACT_PRICED =
+            "Median=12000000;Volume=10;Volatility=0;AvgSellTime=0;MedianKey= Any  UNKNOWN 1;LbinKey= Any  UNKNOWN 1;ItemKey= Any  UNKNOWN 1;Lbin.Price=15000000;Lbin.AuctionId!=0;SLbin.Price=0;LastSale.Price=12000000";
+
+        private const string GOLD_EXACT_PET =
+            "Median=40000000;Volume=9;Volatility=0;AvgSellTime=0;MedianKey= Any [exp, 2],[candyUsed, 0] LEGENDARY 1;LbinKey= Any [exp, 2],[candyUsed, 0] LEGENDARY 1;ItemKey= Any [exp, 2],[candyUsed, 0] LEGENDARY 1;Lbin.Price=45000000;Lbin.AuctionId!=0;SLbin.Price=0;LastSale.Price=40000000";
+
+        private const string GOLD_NOEXACT_CLOSEST =
+            "Median=113906250;Volume=8;Volatility=57;AvgSellTime=0;MedianKey= Any [magic_find, 3],[veteran, 4] UNKNOWN 1- 3;LbinKey= Any [magic_find, 5],[veteran, 4] UNKNOWN 1- 5;ItemKey= Any [magic_find, 9],[veteran, 4],[mending, 5] UNKNOWN 1;Lbin.Price=473744140;Lbin.AuctionId!=0;SLbin.Price=0;LastSale.Price=15000000";
+
+        private const string GOLD_NOEXACT_LOWERKEY =
+            "Median=35688888;Volume=4;Volatility=57;AvgSellTime=0;MedianKey=growth=6,protection=6 Any [upgrade_level, 6],[hotpc, 1] UNKNOWN 1- 1-protection6+HV- Any [upgrade_level, 6] UNKNOWN 1;LbinKey=;ItemKey=growth=6 Any [upgrade_level, 6] UNKNOWN 1;Lbin.Price=0;Lbin.AuctionId=0;SLbin.Price=0;LastSale.Price=32000000";
+
+        private const string GOLD_BAZAAR =
+            "Median=18600000;Volume=0;Volatility=0;AvgSellTime=0;MedianKey=;LbinKey=;ItemKey=;Lbin.Price=0;Lbin.AuctionId=0;SLbin.Price=0;LastSale.Price=0";
+
+        private const string GOLD_UNKNOWN =
+            "Median=0;Volume=0;Volatility=0;AvgSellTime=0;MedianKey=;LbinKey=;ItemKey=;Lbin.Price=0;Lbin.AuctionId=0;SLbin.Price=0;LastSale.Price=0";
+
+        // ============================================================================================================
+        // Serialization + assertion: pin every PriceEstimate field a read-path rewrite could perturb.
+        // ============================================================================================================
+
+        /// <summary>
+        /// Stable, order-fixed serialization of every <see cref="PriceEstimate"/> field R3-READ could perturb. The
+        /// Lbin/SLbin/LastSale <c>AuctionId</c> values are randomized by <see cref="Dupplicate"/> (idCounter), so for
+        /// those structs we pin the deterministic <c>Price</c> and only the *presence* of an AuctionId (=0 vs !=0),
+        /// not its exact id — every price/median/key field that the search determines is pinned exactly.
+        /// </summary>
+        private static string SerializeEstimate(PriceEstimate e)
+        {
+            string AuctionIdPresence(long id) => id == 0 ? "=0" : "!=0";
+            return string.Join(";", new[]
+            {
+                $"Median={e.Median}",
+                $"Volume={e.Volume.ToString("0.####", CultureInfo.InvariantCulture)}",
+                $"Volatility={e.Volatility}",
+                $"AvgSellTime={e.AvgSellTime}",
+                $"MedianKey={e.MedianKey}",
+                $"LbinKey={e.LbinKey}",
+                $"ItemKey={e.ItemKey}",
+                $"Lbin.Price={e.Lbin.Price}",
+                $"Lbin.AuctionId{AuctionIdPresence(e.Lbin.AuctionId)}",
+                $"SLbin.Price={e.SLbin.Price}",
+                $"LastSale.Price={e.LastSale.Price}",
+            });
+        }
+
+        private void AssertGoldenEstimate(string name, PriceEstimate live, string golden)
+        {
+            live.Should().NotBeNull($"GetPrice must return an estimate for fixture {name}");
+            var actual = SerializeEstimate(live);
+            // Always print so a DISCOVER=true run can harvest the line; the assert below is what actually gates.
+            TestContext.Out.WriteLine($"[GOLD {name}] {actual}");
+            if (DISCOVER)
+                return;
+            actual.Should().Be(golden,
+                $"GetPrice result for fixture '{name}' must stay bit-identical (gates R3-READ); " +
+                "if this is an intended change, regenerate with DISCOVER=true and paste the printed line");
+        }
+
+        // ---------- helpers (mirror ValuationFinders.Tests.cs / SniperService.Tests.cs) ----------
+
+        private void DrivePublic(SaveAuction a)
+        {
+            var toTest = Dupplicate(a);
+            service.FinishedUpdate();
+            service.State = SniperState.FullyLoaded;
+            service.TestNewAuction(toTest);
+            service.FinishedUpdate();
+        }
+
+        private void AddVolume(SaveAuction toAdd, int count = 4)
+        {
+            for (int i = 0; i < count; i++)
+                service.AddSoldItem(Dupplicate(toAdd));
+            service.FinishedUpdate();
+        }
+
+        private static SaveAuction Base() => new SaveAuction
+        {
+            Tag = "PRICE_TEST",
+            FlatenedNBT = new Dictionary<string, string> { { "skin", "bear" } },
+            StartingBid = 1000,
+            HighestBidAmount = 1000,
+            Category = Category.ARMOR,
+            UId = 5,
+            AuctioneerId = "12c144",
+            Count = 1,
+        };
+
+        private static SaveAuction Dupplicate(SaveAuction origin) => new SaveAuction(origin)
+        {
+            Uuid = (idCounter++).ToString().PadRight(8, '0'),
+            UId = idCounter++,
+            AuctioneerId = ((short)(idCounter++ % 20000)).ToString().PadRight(8, '0'),
+            FlatenedNBT = new Dictionary<string, string>(origin.FlatenedNBT),
+            Enchantments = origin.Enchantments == null ? null : new List<Enchantment>(origin.Enchantments),
+        };
+
+        private void SetBazaarPrice(string tag, int value, int buyValue = 0)
+        {
+            var sellOrder = new List<SellOrder>();
+            if (value > 0)
+                sellOrder.Add(new SellOrder { PricePerUnit = value });
+            var buyOrder = new List<BuyOrder>();
+            if (buyValue > 0)
+                buyOrder.Add(new BuyOrder { PricePerUnit = buyValue });
+            service.UpdateBazaar(new()
+            {
+                Products = new()
+                {
+                    new() { ProductId = tag, SellSummary = sellOrder, BuySummery = buyOrder }
+                }
+            });
+        }
+    }
+}

--- a/Services/InternalDataLoader.cs
+++ b/Services/InternalDataLoader.cs
@@ -36,6 +36,10 @@ namespace Coflnet.Sky.Sniper.Services
         private readonly ILogger<InternalDataLoader> logger;
         private IProducer<string, LowPricedAuction> FlipProducer;
         private readonly SemaphoreSlim persistenceLock = new(1, 1);
+        // R2-PAR: long-lived tag-shard dispatcher that processes each Kafka batch across N worker threads. Created once
+        // in ConsumeNewAuctions (not per batch) and disposed on shutdown. See ShardedAuctionDispatcher for the
+        // one-worker-per-resolved-group-tag invariant that makes the parallel snipe set bit-identical to single-threaded.
+        private ShardedAuctionDispatcher snipeDispatcher;
 
         readonly Prometheus.Counter foundFlipCount = Prometheus.Metrics
                     .CreateCounter("sky_sniper_found_flips", "Number of flips found");
@@ -149,40 +153,123 @@ namespace Coflnet.Sky.Sniper.Services
             foundFlipCount.Inc();
         }
 
+        /// <summary>
+        /// Resolves the number of shard workers for <see cref="snipeDispatcher"/>. Configurable via
+        /// <c>SNIPER:SHARDS</c>; otherwise defaults to the host's logical processor count (the dispatcher scales with
+        /// cores, capped only by hot-tag imbalance). Always at least 1.
+        /// </summary>
+        private int ResolveShardCount()
+        {
+            if (int.TryParse(config["SNIPER:SHARDS"], out var configured) && configured >= 1)
+                return configured;
+            return Math.Max(1, Environment.ProcessorCount);
+        }
+
         private async Task ConsumeNewAuctions(CancellationToken stoppingToken)
         {
             while (sniper.State < SniperState.Ready)
                 await Task.Delay(1000);
-            while (!stoppingToken.IsCancellationRequested)
-                try
-                {
-                    logger.LogInformation("consuming new ");
-                    await Kafka.KafkaConsumer.ConsumeBatch<SaveAuction>(ConsumerConfig, new string[] { config["TOPICS:NEW_AUCTION"] }, auctions =>
+
+            // R2-PAR: create the tag-shard dispatcher ONCE (not per batch) and reuse it for the lifetime of the
+            // consumer. Each Kafka batch is fanned out across the workers by resolved group tag; the same tag always
+            // lands on the same worker so its PriceLookup is never mutated concurrently (snipe set bit-identical to
+            // single-threaded — proven by the SNIPE_REPLAY_SHARDS parity harness).
+            var shardCount = ResolveShardCount();
+            snipeDispatcher = new ShardedAuctionDispatcher(sniper, shardCount);
+            logger.LogInformation("snipe dispatcher started with {shards} shard workers (cores: {cores})",
+                shardCount, Environment.ProcessorCount);
+            try
+            {
+                while (!stoppingToken.IsCancellationRequested)
+                    try
                     {
-                        foreach (var a in auctions)
+                        logger.LogInformation("consuming new ");
+                        await Kafka.KafkaConsumer.ConsumeBatch<SaveAuction>(ConsumerConfig, new string[] { config["TOPICS:NEW_AUCTION"] }, auctions =>
                         {
-                            auctionsReceived.Inc();
-                            if (!a.Bin)
-                                continue;
-                            if (a.Context != null)
-                                a.Context["frec"] = (DateTime.UtcNow - a.FindTime).ToString();
+                            // Phase 1: select the auctions this batch will actually process (bins only) and stamp
+                            // receive-latency context, preserving the original per-auction bookkeeping. We materialize
+                            // the kept list so we can (a) feed it to the dispatcher and (b) run CheckForPartial over it
+                            // afterwards on this (consumer) thread.
+                            var kept = new List<SaveAuction>();
+                            foreach (var a in auctions)
+                            {
+                                auctionsReceived.Inc();
+                                if (!a.Bin)
+                                    continue;
+                                if (a.Context != null)
+                                    a.Context["frec"] = (DateTime.UtcNow - a.FindTime).ToString();
+                                kept.Add(a);
+                            }
+
+                            // WS-D: measure the intra-batch parse duplication on the REAL kept Kafka batch (re-lists /
+                            // stack-splits put many same-content auctions in one batch). distinct-vs-total here is the
+                            // genuine production dup number the synthetic replay cannot represent. Pure telemetry behind
+                            // SNIPER_BATCH_DUP_COUNT; off in production by default (one HashSet build per batch).
+                            if (SniperService.BatchDupCount)
+                                SniperService.MeasureBatchDup(kept);
+
+                            // Phase 2: process the whole batch across the shard workers and BLOCK until every kept
+                            // auction has been fully processed (TestNewAuction returned). This callback must not return
+                            // before the batch fully drains: KafkaConsumer commits the offset immediately after the
+                            // callback completes (EnableAutoCommit=false, manual Commit per batch), so returning early
+                            // would commit an offset for auctions still in flight — breaking at-least-once. On
+                            // cancellation ProcessBatchAndWait throws OperationCanceledException, which propagates out of
+                            // the callback so the offset is NOT committed and Kafka re-delivers the batch (no loss).
                             try
                             {
-                                sniper.TestNewAuction(a);
-                                CheckForPartial(a);
+                                snipeDispatcher.ProcessBatchAndWait(kept, stoppingToken);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                throw; // shutdown: do not commit this batch
                             }
                             catch (Exception e)
                             {
-                                logger.LogError(e, "testing new auction failed " + a.Uuid);
+                                // A worker faulted on some auction in the batch. Log and let the offset commit (the
+                                // single-threaded path also swallowed per-auction failures); the snipe set for the
+                                // other auctions is correct because each tag is serialized on its own worker.
+                                logger.LogError(e, "shard worker failed processing a new-auction batch");
                             }
-                        }
-                        return Task.CompletedTask;
-                    }, stoppingToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    logger.LogError(e, "consuming new auction");
-                }
+
+                            // Phase 3: CheckForPartial runs HERE — on the consumer thread, after the batch has fully
+                            // drained — NOT on the shard workers. Rationale (threading decision): CheckForPartial calls
+                            // the ML flip finder (flipFinder.EstimateAsync) and writes to the shared Kafka FlipProducer
+                            // via Produceflip; neither is contended-safe to run from N worker threads, and its blocking
+                            // .GetAwaiter().GetResult() would stall a shard worker (serializing that worker's whole tag
+                            // queue and killing throughput scaling). It is also OFF the snipe-finding path the dispatcher
+                            // parallelizes, so keeping it single-threaded here preserves both its original semantics and
+                            // the bit-exact snipe-set parity. It runs strictly after drain, so prices it reads from the
+                            // sniper reflect this batch's writes — identical ordering to the original foreach.
+                            foreach (var a in kept)
+                            {
+                                try
+                                {
+                                    CheckForPartial(a);
+                                }
+                                catch (Exception e)
+                                {
+                                    logger.LogError(e, "CheckForPartial failed " + a.Uuid);
+                                }
+                            }
+                            return Task.CompletedTask;
+                        }, stoppingToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        break; // clean shutdown
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(e, "consuming new auction");
+                    }
+            }
+            finally
+            {
+                // Clean shutdown: drain any items already enqueued on the workers (Dispose joins the threads after
+                // CompleteAdding) so nothing in flight is dropped or double-processed, then release the threads/queues.
+                snipeDispatcher?.Dispose();
+                snipeDispatcher = null;
+            }
             logger.LogError("done with consuming");
         }
 

--- a/Services/IsHigherValue.Tests.cs
+++ b/Services/IsHigherValue.Tests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using AwesomeAssertions;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// Proves the de-LINQ'd <see cref="SniperService.IsHigherValue"/> is boolean-bit-exact with the original LINQ
+    /// implementation (<see cref="SniperService.IsHigherValueReference"/>) across randomized keys exercising every
+    /// branch: tier/count, numeric &gt;/&lt; (inverted keys), comma-substring containment, new_years_cake/ImportantCakeYears,
+    /// exp + petItem TIER_BOOST, and the PET_SPIRIT tag rule.
+    /// </summary>
+    public class IsHigherValueTests
+    {
+        private SniperService service = null!;
+
+        [SetUp]
+        public void Setup()
+            => service = new SniperService(new HypixelItemService(null, NullLogger<HypixelItemService>.Instance), null, NullLogger<SniperService>.Instance, null);
+
+        [Test]
+        public void Fuzz_BoolExact_DeLinq_VsReference()
+        {
+            int mismatches = 0; string first = "";
+            string[] tags = { "SOME_ITEM", "PET_SPIRIT", "PET_ENDER_DRAGON", "NEW_YEAR_CAKE" };
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                var tag = tags[rng.Next(tags.Length)];
+                var a = AuctionKeyFuzz.RandomKeyAndBreakdown(rng).key;
+                var b = AuctionKeyFuzz.RandomKeyAndBreakdown(rng).key;
+                bool expected = service.IsHigherValueReference(tag, a, b);
+                bool actual = service.IsHigherValue(tag, a, b);
+                if (expected != actual)
+                {
+                    if (mismatches == 0)
+                        first = $"seed={seed} tag={tag} expected={expected} actual={actual}\n  base={Describe(a)}\n  check={Describe(b)}";
+                    mismatches++;
+                }
+            }
+            mismatches.Should().Be(0, $"de-LINQ must equal the reference over 40000 pairs. First: {first}");
+        }
+
+        [Test]
+        public void Edge_Cases_Match_Reference()
+        {
+            // numeric greater / inverted, comma-substring, cake years, exp+tierboost, enchant level dominance.
+            var cases = new (string tag, AuctionKey a, AuctionKey b)[]
+            {
+                ("I", Key(1,1, mods: M(("kills","3"))), Key(1,1, mods: M(("kills","5")))),                 // numeric greater
+                ("I", Key(1,1, mods: M(("edition","5"))), Key(1,1, mods: M(("edition","2")))),             // inverted: lower is higher
+                ("I", Key(1,1, mods: M(("edition","5"))), Key(1,1)),                                       // inverted + absent
+                ("I", Key(1,1, mods: M(("unlocked_slots","1,2"))), Key(1,1, mods: M(("unlocked_slots","0,1,2,3")))), // comma substring
+                ("NEW_YEAR_CAKE", Key(1,1, mods: M(("new_years_cake","69"))), Key(1,1, mods: M(("new_years_cake","420")))), // important years
+                ("PET_X", Key(3,1, mods: M(("exp","100"))), Key(5,1, mods: M(("exp","200"),("petItem","TIER_BOOST")))),     // exp + tierboost
+                ("PET_SPIRIT", Key(1,1), Key((int)Tier.LEGENDARY,1)),                                      // PET_SPIRIT legendary rule
+                ("I", Key(1,1, ench: E((EnchantmentType.sharpness,6))), Key(1,1, ench: E((EnchantmentType.sharpness,7)))),  // enchant level
+                ("I", Key(1,1, ench: E((EnchantmentType.sharpness,7))), Key(1,1, ench: E((EnchantmentType.sharpness,6)))),  // enchant level lower
+                // additional explicit cases requested for the columnar kernel:
+                ("I", Key(1,1, mods: M(("candyUsed","3"))), Key(1,1)),                                     // inverted key absent -> excused via exception
+                ("I", Key(1,1, mods: M(("captured_player","RUBY"))), Key(1,1, mods: M(("captured_player","GEM RUBY")))), // base value is substring of space check value
+                ("I", Key(1,1, mods: M(("kills","5"))), Key(1,1, mods: M(("kills","3")))),                 // both-numeric, check lower -> not covered
+            };
+            foreach (var (tag, a, b) in cases)
+            {
+                bool reference = service.IsHigherValueReference(tag, a, b);
+                service.IsHigherValue(tag, a, b).Should().Be(reference,
+                    $"de-LINQ: tag={tag} base={Describe(a)} check={Describe(b)}");
+                // The columnar kernel must also match the oracle on every explicit case.
+                var interner = new ClosestScoreKernel.Interner();
+                DominatorIndex.Dominates(DominatorIndex.BuildDomKey(a, interner), DominatorIndex.BuildDomKey(b, interner), tag == "PET_SPIRIT")
+                    .Should().Be(reference, $"columnar kernel: tag={tag} base={Describe(a)} check={Describe(b)}");
+            }
+        }
+
+        [Test]
+        public void Fuzz_ColumnarKernel_VsReference()
+        {
+            int mismatches = 0; string first = "";
+            int prefilterViolations = 0; string firstViolation = "";
+            string[] tags = { "SOME_ITEM", "PET_SPIRIT", "PET_ENDER_DRAGON", "NEW_YEAR_CAKE" };
+            var interner = new ClosestScoreKernel.Interner(); // single shared id space across all built DomKeys
+            for (int seed = 1; seed <= 40_000; seed++)
+            {
+                var rng = new Random(seed);
+                var tag = tags[rng.Next(tags.Length)];
+                var a = AuctionKeyFuzz.RandomKeyAndBreakdown(rng).key;
+                var b = AuctionKeyFuzz.RandomKeyAndBreakdown(rng).key;
+                bool expected = service.IsHigherValueReference(tag, a, b);
+                var domA = DominatorIndex.BuildDomKey(a, interner);
+                var domB = DominatorIndex.BuildDomKey(b, interner);
+                bool actual = DominatorIndex.Dominates(domA, domB, tag == "PET_SPIRIT");
+                if (expected != actual)
+                {
+                    if (mismatches == 0)
+                        first = $"seed={seed} tag={tag} expected={expected} actual={actual}\n  base={Describe(a)}\n  check={Describe(b)}";
+                    mismatches++;
+                }
+                // Prefilter soundness: when a dominates b (base=a), the mask test must hold (never false-rejects).
+                if (expected)
+                {
+                    bool maskOk = (domA.RequiredMask & domB.ProvidedMask) == domA.RequiredMask;
+                    if (!maskOk)
+                    {
+                        if (prefilterViolations == 0)
+                            firstViolation = $"seed={seed} tag={tag} required=0x{domA.RequiredMask:x} provided=0x{domB.ProvidedMask:x}\n  base={Describe(a)}\n  check={Describe(b)}";
+                        prefilterViolations++;
+                    }
+                }
+            }
+            mismatches.Should().Be(0, $"columnar kernel must equal the reference over 40000 pairs. First: {first}");
+            prefilterViolations.Should().Be(0, $"mask prefilter must never false-reject a true dominance over 40000 pairs. First: {firstViolation}");
+        }
+
+        // ---- generators ----
+        // The random (AuctionKey) generator is the shared AuctionKeyFuzz.RandomKeyAndBreakdown (F2); only its key is
+        // consumed here (IsHigherValue ignores the priced breakdown). Tag selection stays local to this harness.
+        private static AuctionKey Key(int tier, int count, List<KeyValuePair<string, string>> mods = null, List<Enchant> ench = null)
+            => new(ench ?? new(), ItemReferences.Reforge.Any, mods ?? new(), (Tier)tier, (byte)count);
+        private static List<KeyValuePair<string, string>> M(params (string k, string v)[] kv)
+        {
+            var l = new List<KeyValuePair<string, string>>();
+            foreach (var (k, v) in kv) l.Add(new(k, v));
+            return l;
+        }
+        private static List<Enchant> E(params (EnchantmentType t, byte lvl)[] es)
+        {
+            var l = new List<Enchant>();
+            foreach (var (t, lvl) in es) l.Add(new Enchant { Type = t, Lvl = lvl });
+            return l;
+        }
+        private static string Describe(AuctionKey k)
+            => $"t{k.Tier} c{k.Count} mods=[{string.Join(",", k.Modifiers.ConvertToString())}] ench=[{string.Join(",", k.Enchants.EnchToString())}]";
+    }
+
+    internal static class IsHigherValueTestExtensions
+    {
+        public static IEnumerable<string> ConvertToString(this System.Collections.ObjectModel.ReadOnlyCollection<KeyValuePair<string, string>> mods)
+        {
+            foreach (var m in mods) yield return m.Key + "=" + m.Value;
+        }
+        public static IEnumerable<string> EnchToString(this System.Collections.ObjectModel.ReadOnlyCollection<Enchant> ench)
+        {
+            foreach (var e in ench) yield return e.Type + ":" + e.Lvl;
+        }
+    }
+}

--- a/Services/KeyExtraction.Reference.cs
+++ b/Services/KeyExtraction.Reference.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// Bit-exactness oracle for WS-B (zero-alloc / de-LINQ key extraction).
+    ///
+    /// These <c>*Reference</c> methods are <b>verbatim copies of the original (pre-optimization) key-extraction
+    /// pipeline</b> — <see cref="SniperService.DetailedKeyFromSaveAuction"/>, <c>SelectValuable</c>, <c>CapKeyLength</c>
+    /// (with its inner <c>SortCombined</c>/<c>GetOrdered</c>), <c>ComparisonValue</c> and <c>AddReforgeValue</c>. They are
+    /// retained <b>only</b> as the oracle the de-LINQ'd production methods are fuzzed against (see
+    /// <c>KeyExtraction.Tests.cs</c>); do not call them from production. The post-processing in
+    /// <see cref="DetailedKeyFromSaveAuctionReference"/> (rarity/tier/attribute handling) is identical to production —
+    /// only the three hot helpers were rewritten, so only those need a reference twin.
+    ///
+    /// Everything they touch that is shared, read-only service state (caches, lookups, mapper, itemService) is used as-is
+    /// so the reference path produces exactly what production produced before WS-B. The caches are content-addressed by
+    /// the same keys, so running the reference path first does not change what the optimized path computes.
+    /// </summary>
+    public partial class SniperService
+    {
+        internal KeyWithValueBreakdown DetailedKeyFromSaveAuctionReference(SaveAuction auction, bool fastMode = false, int limit = 5)
+        {
+            var shouldIncludeReforge = Constants.RelevantReforges.Contains(auction.Reforge);
+            long valueSubstracted = 0;
+            bool removedRarity = false;
+            List<RankElem> rankElems = [];
+            List<Enchant> enchants;
+            List<KeyValuePair<string, string>> modifiers;
+            (enchants, modifiers) = SelectValuableReference(auction, fastMode);
+
+            (valueSubstracted, removedRarity, shouldIncludeReforge, rankElems) = CapKeyLengthReference(enchants, modifiers, auction, limit);
+
+            if (enchants == null)
+                enchants = new List<Enchant>();
+            var tier = auction.Tier;
+            if (auction.Tag == "ENCHANTED_BOOK")
+            {
+                // rarities don't matter for enchanted books and often used for scamming
+                tier = Tier.UNCOMMON;
+            }
+            if (auction.Tag == "PANDORAS_BOX")
+                // pandoras box tier gets set based on the player
+                tier = Tier.COMMON;
+            // Reduce tier if PET_ITEM_TIER_BOOST was present (it's now removed from key)
+            if (auction.FlatenedNBT?.TryGetValue("heldItem", out var heldItemValue) == true && heldItemValue == "PET_ITEM_TIER_BOOST")
+            {
+                tier = ReduceRarity(tier);
+            }
+            if (removedRarity)
+            {
+                tier = ReduceRarity(tier);
+            }
+            var reducedEnchants = RemoveNoEffectEnchants(auction, enchants);
+            if (reducedEnchants.Count < enchants.Count)
+            {
+                rankElems = rankElems.Where(r => r.Enchant.Type == default || reducedEnchants.Any(re => re.Type == r.Enchant.Type)).ToList();
+                enchants = reducedEnchants;
+            }
+            if (auction.Tag != null && AttributeToIgnoreOnLookup.TryGetValue(auction.Tag, out var ignore))
+            {
+                modifiers.RemoveAll(m => ignore.Contains(m.Key));
+            }
+            if (modifiers.Any(m => m.Key == "rarity_upgrades") && !Constants.DoesRecombMatter(auction.Category, auction.Tag))
+            {
+                modifiers.RemoveAll(m => m.Key == "rarity_upgrades");
+                if (!IsRune(auction.Tag))
+                    tier = ReduceRarity(tier);
+            }
+            // Remove PET_ITEM_TIER_BOOST if it somehow got into modifiers (it shouldn't be in the key)
+            modifiers.RemoveAll(m => m.Value == "TIER_BOOST");
+
+            return Constructkey(auction, enchants, modifiers, shouldIncludeReforge, valueSubstracted, rankElems, tier);
+        }
+
+        private (List<Enchant> enchants, List<KeyValuePair<string, string>> modifiers) SelectValuableReference(SaveAuction auction, bool fastMode = false)
+        {
+            var enchants = auction.Enchantments
+                            ?.Where(e => MinEnchantMap.TryGetValue(e.Type, out byte value) && e.Level >= value)
+                            .OrderBy(e => e.Type)
+                            .Select(e => new Models.Enchant() { Lvl = e.Level, Type = e.Type }).ToList();
+            var flatNbt = auction.FlatenedNBT;
+
+            var modifiers = new Dictionary<string, string>(5);
+            if (flatNbt != null)
+                foreach (var item in flatNbt)
+                {
+                    if (!IncludeKeys.Contains(item.Key) && item.Value != "PERFECT" && !IsRune(item.Key) && !IsSoul(item))
+                    {
+                        continue;
+                    }
+                    var normalized = NormalizeData(item, auction.Tag, flatNbt);
+                    if (normalized.Key != Ignore.Key)
+                        modifiers.Add(normalized.Key, normalized.Value);
+                }
+            if (auction.ItemCreatedAt < UnlockedIntroduction
+                // safe guard for when the creation date is wrong
+                && flatNbt != null
+                && !flatNbt.ContainsKey("unlocked_slots"))
+            {
+                var allUnlockable = itemService?.GetUnlockableSlots(auction.Tag).ToList();
+                if (flatNbt.TryGetValue("gemstone_slots", out var countString) && int.TryParse(countString, out var count))
+                {
+                    allUnlockable = allUnlockable.Take(count).ToList();
+                    modifiers.Remove("gemstone_slots");
+                }
+                if (allUnlockable?.Count > 0)
+                    modifiers.Add("unlocked_slots", string.Join(",", allUnlockable.OrderBy(s => s)));
+            }
+            var result = modifiers.ToList();
+            return (enchants, result);
+        }
+
+        private (long valueSubstracted, bool removedRarity, bool includeReforge, List<RankElem> ranked) CapKeyLengthReference(
+            List<Enchant> enchants, List<KeyValuePair<string, string>> modifiers, SaveAuction auction, long threshold = 500000, int elements = 5)
+        {
+            long underlyingItemValue = GetCleanItemValue(auction, ref threshold);
+            long valueSubstracted = HandleGems(modifiers, auction);
+            IEnumerable<RankElem> combined = ComparisonValueReference(enchants, modifiers, auction.Tag, auction.FlatenedNBT);
+
+            bool includeReforge = AddReforgeValueReference(auction.Reforge, ref combined);
+            combined = SortCombined(combined);
+
+            var modifierSum = underlyingItemValue + combined?.Select(m => m.IsEstimate ? m.Value / 20 : m.Value).DefaultIfEmpty(0).Sum() ?? 0;
+            threshold = Math.Max(threshold, modifierSum / 22);
+            var percentDiff = (double)auction.HighestBidAmount / modifierSum;
+            if (auction.HighestBidAmount == 0 || percentDiff > 1)
+                percentDiff = 1;
+            // remove all but the top 5
+            List<RankElem> toRemove = GetItemsToRemove(threshold, combined);
+            bool removedRarity = false;
+            foreach (var item in toRemove)
+            {
+                // use percentage of full value
+                var adjustedRemoveValue = (long)(item.Value * percentDiff);
+                // remove all but the top 5
+                if (item.Enchant.Type != 0)
+                {
+                    if (enchants.Remove(item.Enchant))
+                        valueSubstracted += adjustedRemoveValue;
+                }
+                else if (item.Reforge != ItemReferences.Reforge.None)
+                {
+                    includeReforge = false;
+                }
+                else
+                {
+                    if (item.Modifier.Key == "exp")
+                        continue; // even if its valued at very little this needs to stay
+                    if (adjustedRemoveValue > 50_000_000 && Constants.AttributeKeys.Contains(item.Modifier.Key))
+                        adjustedRemoveValue -= 50_000_000;
+                    if (item.IsEstimate)
+                        adjustedRemoveValue /= 10;
+                    if (modifiers.Remove(item.Modifier))
+                        valueSubstracted += adjustedRemoveValue;
+                    if (item.Modifier.Key == "skin")
+                        modifiers.RemoveAll(m => m.Key == "candyUsed");
+                    if (item.Modifier.Key == "rarity_upgrades")
+                        removedRarity = true;
+                }
+            }
+            List<RankElem> ordered = GetOrdered(elements, combined);
+            return (valueSubstracted, removedRarity, includeReforge, ordered);
+
+            static IEnumerable<RankElem> SortCombined(IEnumerable<RankElem> combined)
+            {
+                var list = combined as ICollection<RankElem> ?? combined.ToList();
+                var filtered = new List<RankElem>(list.Count);
+                foreach (var c in list)
+                {
+                    if (c.Value != 0)
+                        filtered.Add(c);
+                }
+                filtered.Sort((a, b) => b.Value.CompareTo(a.Value));
+                return filtered;
+            }
+
+            static List<RankElem> GetOrdered(int elements, IEnumerable<RankElem> combined)
+            {
+                return combined.Where(c => c.Value == 0).Concat(combined.Take(elements)).ToList();
+            }
+
+            // Verbatim copy of the original GetItemsToRemove (kept local so the reference does not depend on the
+            // production helper, whose signature WS-B changed to a List<RankElem>).
+            static List<RankElem> GetItemsToRemove(long threshold, IEnumerable<RankElem> combined)
+            {
+                var toRemove = new List<RankElem>(5);
+                int i = 0;
+                foreach (var c in combined)
+                {
+                    if ((i >= 5 && c.Value > 0)
+                        || (i >= 1 && i < 5 && c.Value > 0 && c.Value < threshold)
+                        || (i < 1 && c.Value > 0 && (c.Value < 500_000 || c.Value < threshold / 4)))
+                    {
+                        toRemove.Add(c);
+                    }
+                    i++;
+                }
+                return toRemove;
+            }
+        }
+
+        bool AddReforgeValueReference(ItemReferences.Reforge reforge, ref IEnumerable<RankElem> combined)
+        {
+            bool includeReforge = Constants.RelevantReforges.Contains(reforge);
+            if (includeReforge)
+            {
+                if (ReforgeValueLookup.TryGetValue(reforge, out var value))
+                {
+                    combined = combined.Append(value.Item1);
+                    return includeReforge;
+                }
+                long reforgeValue = GetReforgeValue(reforge);
+                var element = new RankElem(reforge, reforgeValue);
+                combined = combined.Append(element);
+                if (reforgeValue > 0)
+                    ReforgeValueLookup[reforge] = (element, DateTime.UtcNow);
+            }
+
+            return includeReforge;
+        }
+
+        internal IEnumerable<RankElem> ComparisonValueReference(IEnumerable<Enchant> enchants, IList<KeyValuePair<string, string>> modifiers, string tag, Dictionary<string, string> flatNbt)
+        {
+            var valuePerEnchant = enchants?.Select(item => new RankElem(item, mapper.EnchantValue(new Core.Enchantment(item.Type, item.Lvl), null, BazaarPrices, tag)));
+
+            List<RankElem> valuePerModifier = null;
+            if (modifiers != null)
+            {
+                var relevant = new Dictionary<string, string>(modifiers.Count);
+                foreach (var rm in modifiers)
+                    relevant.TryAdd(rm.Key, rm.Value);
+
+                valuePerModifier = new List<RankElem>(modifiers.Count);
+                for (int mi = 0; mi < modifiers.Count; mi++)
+                {
+                    var m = modifiers[mi];
+                    try
+                    {
+                        var lookupKey = new ModifierLookupKey() { ItemTag = tag, Modifier = m, RelevantModifiers = relevant };
+                        if (ModifierValueLookup.TryGetValue(lookupKey, out var value))
+                        {
+                            valuePerModifier.Add(value.Item1);
+                            continue;
+                        }
+                        var calculated = ModifierEstimate(modifiers, tag, flatNbt, m);
+                        if (calculated.Value > 0)
+                            ModifierValueLookup[lookupKey] = (calculated, DateTime.UtcNow);
+                        valuePerModifier.Add(calculated);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogInformation($"Error when calculating value for {m.Key} {m.Value} {tag}\n" + e);
+                        valuePerModifier.Add(new RankElem(m, 0));
+                    }
+                }
+            }
+            IEnumerable<RankElem> combined = null;
+            if (valuePerEnchant != null && valuePerModifier != null)
+                combined = valuePerEnchant.Concat(valuePerModifier);
+            else if (valuePerEnchant != null)
+                combined = valuePerEnchant;
+            else if (valuePerModifier != null)
+                combined = valuePerModifier;
+            return combined;
+        }
+
+        /// <summary>
+        /// Verbatim copy of the original (pre-de-LINQ) <see cref="KeyWithValueBreakdown.GetReduced"/> — the LINQ
+        /// <c>.Where(...)</c> + <c>new([.. ...])</c> form. Oracle for the de-LINQ'd production GetReduced; fuzzed against
+        /// it in <c>KeyExtraction.Tests.cs</c> over randomized breakdowns / heavy-drop cases (test-only, Release-excluded).
+        /// </summary>
+        internal static AuctionKeyWithValue GetReducedReference(KeyWithValueBreakdown self, int level)
+        {
+            if (level == 0)
+                return new AuctionKeyWithValue(self.Key) { ValueSubstract = self.SubstractedValue };
+            IEnumerable<KeyValuePair<string, string>> modifiers = self.Key.Modifiers;
+            IEnumerable<Enchant> enchants = self.Key.Enchants;
+            var modifierchanged = false;
+            var enchantChanged = false;
+            var reforge = self.Key.Reforge;
+            var tier = self.Key.Tier;
+            var valueSubstracted = self.SubstractedValue;
+            var breakdown = self.ValueBreakdown;
+            for (int idx = (breakdown?.Count ?? 0) - 1, taken = 0; idx >= 0 && taken < level; idx--)
+            {
+                var item = breakdown[idx];
+                taken++;
+                if (NeverDrop.Contains(item.Modifier.Key))
+                    continue;
+                if (item.Enchant.Type != 0)
+                {
+                    enchants = enchants.Where(x => x.Type != item.Enchant.Type);
+                    valueSubstracted -= item.Value;
+                    enchantChanged = true;
+                }
+                else if (item.Reforge != ItemReferences.Reforge.None)
+                {
+                    reforge = ItemReferences.Reforge.Any;
+                }
+                else
+                {
+                    var adjustedRemoveValue = item.Value;
+                    modifiers = modifiers.Where(x => x.Key != item.Modifier.Key);
+                    modifierchanged = true;
+                    if (adjustedRemoveValue > 50_000_000 && Constants.AttributeKeys.Contains(item.Modifier.Key))
+                        adjustedRemoveValue -= 50_000_000;
+                    if (item.IsEstimate)
+                        adjustedRemoveValue /= 10;
+                    if (!InvertedValueKey.Contains(item.Modifier.Key))
+                        valueSubstracted += adjustedRemoveValue;
+                    if (item.Modifier.Key == "rarity_upgrades")
+                        tier = ReduceRarity(tier);
+                    if (item.Modifier.Value == TierBoostShorthand)
+                    {
+                        tier = ReduceRarity(tier);
+                        valueSubstracted -= item.Value * 2;
+                    }
+                }
+            }
+            return new AuctionKeyWithValue()
+            {
+                Enchants = enchantChanged ? new([.. enchants]) : self.Key.Enchants,
+                Modifiers = modifierchanged ? new([.. modifiers]) : self.Key.Modifiers,
+                Reforge = reforge,
+                Tier = tier,
+                Count = self.Key.Count,
+                ValueSubstract = valueSubstracted
+            };
+        }
+    }
+}

--- a/Services/KeyExtraction.Tests.cs
+++ b/Services/KeyExtraction.Tests.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// WS-B bit-exactness gate. Proves the de-LINQ'd / pooled key-extraction pipeline
+    /// (<see cref="SniperService.DetailedKeyFromSaveAuction"/> -> <c>SelectValuable</c> / <c>CapKeyLength</c> /
+    /// <c>ComparisonValue</c>) produces an <b>identical</b> <see cref="KeyWithValueBreakdown"/> — the <see cref="AuctionKey"/>
+    /// at every reduction level (<c>GetReduced(0..3)</c>), the substracted value, AND the per-item value breakdown — vs the
+    /// verbatim original kept as <see cref="SniperService.DetailedKeyFromSaveAuctionReference"/> (see
+    /// <c>KeyExtraction.Reference.cs</c>).
+    ///
+    /// Coverage: every real Mock fixture's priced buckets (boots / HYPERION / juju / midas_sword), reconstructed into
+    /// SaveAuctions, plus a randomized SaveAuction fuzzer hitting many-modifier / many-enchant items, unlocked_slots
+    /// (the in-place-mutation gotcha), attributes (godroll), reforge, pets/exp + TIER_BOOST, recomb (rarity_upgrades),
+    /// candyUsed, comma/space substring values, cake years and PET_SPIRIT.
+    /// </summary>
+    public class KeyExtractionTests
+    {
+        private SniperService service = null!;
+
+        private class MockCraftCostService : ICraftCostService
+        {
+            public Dictionary<string, double> Costs { get; } = new();
+            public Dictionary<string, Category> ItemCategories { get; set; } = new();
+            public void AddCostForSpecialItems() { }
+            public bool TryGetCost(string itemId, out double cost) => Costs.TryGetValue(itemId, out cost);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            // Shift the epoch forward so AddLookupData keeps the (historical) loaded references, matching the harness.
+            SniperService.StartTime = new DateTime(2021, 9, 25) + TimeSpan.FromDays(10_000);
+            var itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, new MockCraftCostService());
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        // ---------- real-fixture parity (production-shaped data) ----------
+
+        [TestCase("boots.json", "WISE_WITHER_BOOTS")]
+        [TestCase("HYPERION.json", "HYPERION")]
+        [TestCase("juju.json", "JUJU_SHORTBOW")]
+        [TestCase("midas_sword.json", "MIDAS_SWORD")]
+        public void RealFixtures_BitExact_VsReference(string mockFile, string tag)
+        {
+            if (!File.Exists($"Mock/{mockFile}"))
+                Assert.Ignore($"fixture {mockFile} not present");
+            var lookup = LoadLookupMock(mockFile);
+            service.AddLookupData(tag, lookup);
+            var live = service.Lookups.TryGetValue(tag, out var stored) ? stored : lookup;
+
+            int checked_ = 0, mismatches = 0; string first = "";
+            foreach (var key in live.Lookup.Keys.ToList())
+            {
+                var auction = AuctionFromKey(tag, key);
+                if (!Compare(auction, out var why))
+                {
+                    if (mismatches == 0) first = why;
+                    mismatches++;
+                }
+                checked_++;
+            }
+            checked_.Should().BeGreaterThan(0, "fixture should yield buckets to check");
+            mismatches.Should().Be(0, $"{mockFile}: {mismatches}/{checked_} buckets diverged. First: {first}");
+        }
+
+        // ---------- randomized fuzz over every special branch ----------
+
+        [Test]
+        public void Fuzz_BitExact_VsReference()
+        {
+            // Prime a couple of lookups so GetCleanItemValue / ModifierEstimate cross-item paths have data to read,
+            // exactly as production would; the parity must hold regardless.
+            if (File.Exists("Mock/boots.json"))
+                service.AddLookupData("WISE_WITHER_BOOTS", LoadLookupMock("boots.json"));
+
+            string[] tags =
+            {
+                "WISE_WITHER_BOOTS", "HYPERION", "SOME_SWORD", "PET_SPIRIT", "PET_ENDER_DRAGON",
+                "NEW_YEAR_CAKE", "ENCHANTED_BOOK", "PANDORAS_BOX", "ATTRIBUTE_SHARD", "DIVAN_HELMET",
+            };
+
+            int mismatches = 0; string first = "";
+            for (int seed = 1; seed <= 25_000; seed++)
+            {
+                var rng = new Random(seed);
+                var tag = tags[rng.Next(tags.Length)];
+                var auction = RandomAuction(rng, tag);
+                if (!Compare(auction, out var why))
+                {
+                    if (mismatches == 0) first = $"seed={seed} {why}";
+                    mismatches++;
+                }
+            }
+            mismatches.Should().Be(0, $"de-LINQ key extraction must equal the reference over 25000 fuzzed auctions. First: {first}");
+        }
+
+        // ---------- GetReduced de-LINQ parity (vs the verbatim LINQ reference) ----------
+
+        /// <summary>
+        /// Fuzzes the de-LINQ'd <see cref="KeyWithValueBreakdown.GetReduced"/> against the verbatim original
+        /// (<see cref="SniperService.GetReducedReference"/>, the <c>.Where(...)</c>+<c>new([..])</c> form) over randomized
+        /// breakdowns at every reduction level — including heavy-drop cases (many enchant/modifier breakdown entries,
+        /// duplicate types/keys, NeverDrop / InvertedValueKey / AttributeKeys / rarity_upgrades / TIER_BOOST / reforge
+        /// entries). Proves the reduced AuctionKey (enchants, modifiers, reforge, tier, count) AND the ValueSubstract are
+        /// byte-identical. This is the dedicated gate for the GetReduced rewrite (the RealFixtures/Fuzz tests above run
+        /// GetReduced on both sides but use the same — new — method, so they cannot catch a GetReduced regression).
+        /// </summary>
+        [Test]
+        public void GetReduced_BitExact_VsReference()
+        {
+            int mismatches = 0; string first = "";
+            for (int seed = 1; seed <= 50_000; seed++)
+            {
+                var rng = new Random(seed);
+                var bk = RandomBreakdown(rng);
+                for (int level = 0; level <= 5; level++)
+                {
+                    var refKey = SniperService.GetReducedReference(bk, level);
+                    var newKey = bk.GetReduced(level);
+                    if (!KeyEqual(refKey, newKey, out var kw) || refKey.ValueSubstract != newKey.ValueSubstract)
+                    {
+                        if (mismatches == 0)
+                            first = $"seed={seed} level={level} {kw} subRef={refKey.ValueSubstract} subNew={newKey.ValueSubstract}\n  ref={refKey}\n  new={newKey}";
+                        mismatches++;
+                    }
+                }
+            }
+            mismatches.Should().Be(0, $"de-LINQ'd GetReduced must equal the verbatim LINQ reference over 50000 fuzzed breakdowns. First: {first}");
+        }
+
+        /// <summary>Builds a randomized <see cref="KeyWithValueBreakdown"/>: a Key with random enchants/modifiers/reforge/
+        /// tier/count and a ValueBreakdown whose entries (enchant / modifier / reforge RankElems, with deliberate
+        /// duplicate types/keys and NeverDrop / InvertedValueKey / Attribute / rarity_upgrades / TIER_BOOST entries) drive
+        /// every GetReduced branch and heavy-drop overlap.</summary>
+        private static KeyWithValueBreakdown RandomBreakdown(Random rng)
+        {
+            // small pools that overlap with NeverDrop / InvertedValueKey / AttributeKeys / special-cased keys
+            string[] modKeys = { "exp", "rarity_upgrades", SniperService.PetItemKey, "skin", "kills", "edition", "color", "MAGMA_LORD", "FROZEN_BLAZE", "art_of_war_count", "winning_bid" };
+            EnchantmentType[] enchTypes = { EnchantmentType.sharpness, EnchantmentType.growth, EnchantmentType.critical, EnchantmentType.ultimate_wise, EnchantmentType.scavenger };
+            var attribOver = Constants.AttributeKeys.Take(2).ToArray();
+
+            var enchants = new List<Enchant>();
+            int ec = rng.Next(0, 5);
+            for (int i = 0; i < ec; i++)
+                enchants.Add(new Enchant { Type = enchTypes[rng.Next(enchTypes.Length)], Lvl = (byte)rng.Next(1, 8) });
+            var modifiers = new List<KeyValuePair<string, string>>();
+            int mc = rng.Next(0, 5);
+            for (int i = 0; i < mc; i++)
+            {
+                var k = modKeys[rng.Next(modKeys.Length)];
+                modifiers.Add(new KeyValuePair<string, string>(k, rng.Next(2) == 0 ? SniperService.TierBoostShorthand : rng.Next(1, 5).ToString()));
+            }
+            var key = new AuctionKey
+            {
+                Enchants = enchants.AsReadOnly(),
+                Modifiers = modifiers.AsReadOnly(),
+                Reforge = ReforgePool[rng.Next(ReforgePool.Length)],
+                Tier = (Tier)rng.Next(0, 12),
+                Count = (byte)rng.Next(1, 6),
+            };
+
+            // breakdown: some entries reference the key's enchants/modifiers (so they drop), some don't; include reforge,
+            // attribute (>50M to hit the -50M branch), rarity_upgrades, TIER_BOOST and NeverDrop entries.
+            var breakdown = new List<SniperService.RankElem>();
+            int bc = rng.Next(0, 9);
+            for (int i = 0; i < bc; i++)
+            {
+                switch (rng.Next(6))
+                {
+                    case 0: // enchant entry (often matching a key enchant -> drop)
+                        var et = enchants.Count > 0 && rng.Next(2) == 0 ? enchants[rng.Next(enchants.Count)].Type : enchTypes[rng.Next(enchTypes.Length)];
+                        breakdown.Add(new SniperService.RankElem(new Enchant { Type = et, Lvl = (byte)rng.Next(1, 8) }, rng.Next(0, 200) * 1_000_000L));
+                        break;
+                    case 1: // modifier entry (often matching a key modifier -> drop)
+                        var mk = modifiers.Count > 0 && rng.Next(2) == 0 ? modifiers[rng.Next(modifiers.Count)].Key : modKeys[rng.Next(modKeys.Length)];
+                        breakdown.Add(new SniperService.RankElem(new KeyValuePair<string, string>(mk, rng.Next(1, 5).ToString()), rng.Next(0, 200) * 1_000_000L) { IsEstimate = rng.Next(2) == 0 });
+                        break;
+                    case 2: // reforge entry
+                        breakdown.Add(new SniperService.RankElem(ReforgePool[rng.Next(ReforgePool.Length)], rng.Next(0, 50) * 1_000_000L));
+                        break;
+                    case 3: // attribute entry with a large value to hit the >50M attribute branch
+                        breakdown.Add(new SniperService.RankElem(new KeyValuePair<string, string>(attribOver.Length > 0 ? attribOver[rng.Next(attribOver.Length)] : "MAGMA_LORD", rng.Next(1, 5).ToString()), 60_000_000L + rng.Next(0, 100) * 1_000_000L) { IsEstimate = rng.Next(2) == 0 });
+                        break;
+                    case 4: // TIER_BOOST modifier entry
+                        breakdown.Add(new SniperService.RankElem(new KeyValuePair<string, string>(SniperService.PetItemKey, SniperService.TierBoostShorthand), rng.Next(0, 50) * 1_000_000L));
+                        break;
+                    default: // rarity_upgrades modifier entry
+                        breakdown.Add(new SniperService.RankElem(new KeyValuePair<string, string>("rarity_upgrades", "1"), rng.Next(0, 50) * 1_000_000L));
+                        break;
+                }
+            }
+            return new KeyWithValueBreakdown { Key = key, ValueBreakdown = breakdown, SubstractedValue = rng.Next(-50, 200) * 1_000_000L };
+        }
+
+        // ---------- comparison core ----------
+
+        /// <summary>
+        /// Runs the reference first, the optimized second (caches are content-addressed, so order does not change the
+        /// result), and asserts full equality of the breakdown + the key at every reduction level the snipe/query path
+        /// uses (GetReduced 0..3).
+        /// </summary>
+        private bool Compare(SaveAuction auction, out string why)
+        {
+            why = "";
+            // distinct auction clones so list mutation inside one path can never leak into the other
+            var refKey = service.DetailedKeyFromSaveAuctionReference(Clone(auction));
+            var newKey = service.ValueKeyForTest(Clone(auction));
+
+            if (refKey.SubstractedValue != newKey.SubstractedValue)
+            { why = $"SubstractedValue ref={refKey.SubstractedValue} new={newKey.SubstractedValue} [{Describe(auction)}]"; return false; }
+            if (!BreakdownEqual(refKey.ValueBreakdown, newKey.ValueBreakdown, out var bw))
+            { why = $"breakdown {bw} [{Describe(auction)}]"; return false; }
+
+            for (int level = 0; level <= 3; level++)
+            {
+                var a = refKey.GetReduced(level);
+                var b = newKey.GetReduced(level);
+                if (!KeyEqual(a, b, out var kw))
+                { why = $"GetReduced({level}) {kw}\n  ref={a}\n  new={b}\n  [{Describe(auction)}]"; return false; }
+                if (a.ValueSubstract != b.ValueSubstract)
+                { why = $"GetReduced({level}).ValueSubstract ref={a.ValueSubstract} new={b.ValueSubstract} [{Describe(auction)}]"; return false; }
+            }
+            return true;
+        }
+
+        private static bool KeyEqual(AuctionKey a, AuctionKey b, out string why)
+        {
+            why = "";
+            if (a.Reforge != b.Reforge) { why = $"reforge {a.Reforge}!={b.Reforge}"; return false; }
+            if (a.Tier != b.Tier) { why = $"tier {a.Tier}!={b.Tier}"; return false; }
+            if (a.Count != b.Count) { why = $"count {a.Count}!={b.Count}"; return false; }
+            // Enchants: order-sensitive (production sorts by type via OrderBy; we must preserve the exact sequence)
+            if (a.Enchants.Count != b.Enchants.Count) { why = $"ench count {a.Enchants.Count}!={b.Enchants.Count}"; return false; }
+            for (int i = 0; i < a.Enchants.Count; i++)
+                if (a.Enchants[i].Type != b.Enchants[i].Type || a.Enchants[i].Lvl != b.Enchants[i].Lvl)
+                { why = $"ench[{i}] {a.Enchants[i].Type}={a.Enchants[i].Lvl} != {b.Enchants[i].Type}={b.Enchants[i].Lvl}"; return false; }
+            // Modifiers: order-sensitive too (key construction must reproduce the exact modifier sequence)
+            if (a.Modifiers.Count != b.Modifiers.Count) { why = $"mod count {a.Modifiers.Count}!={b.Modifiers.Count}"; return false; }
+            for (int i = 0; i < a.Modifiers.Count; i++)
+                if (a.Modifiers[i].Key != b.Modifiers[i].Key || a.Modifiers[i].Value != b.Modifiers[i].Value)
+                { why = $"mod[{i}] {a.Modifiers[i].Key}={a.Modifiers[i].Value} != {b.Modifiers[i].Key}={b.Modifiers[i].Value}"; return false; }
+            return true;
+        }
+
+        private static bool BreakdownEqual(List<SniperService.RankElem> a, List<SniperService.RankElem> b, out string why)
+        {
+            why = "";
+            if ((a == null) != (b == null)) { why = $"null mismatch ref={(a == null)} new={(b == null)}"; return false; }
+            if (a == null) return true;
+            if (a.Count != b.Count) { why = $"count {a.Count}!={b.Count}"; return false; }
+            for (int i = 0; i < a.Count; i++)
+            {
+                var x = a[i]; var y = b[i];
+                if (x.Value != y.Value || x.IsEstimate != y.IsEstimate
+                    || x.Enchant.Type != y.Enchant.Type || x.Enchant.Lvl != y.Enchant.Lvl
+                    || x.Modifier.Key != y.Modifier.Key || x.Modifier.Value != y.Modifier.Value
+                    || x.Reforge != y.Reforge)
+                { why = $"[{i}] ref=({x}) new=({y})"; return false; }
+            }
+            return true;
+        }
+
+        // ---------- fuzzer ----------
+
+        // Modifier keys spanning the value branches and the special handlers: the in-place-mutation unlocked_slots /
+        // gemstone_slots pair, attributes (godroll), recomb, pet exp + tier-boost, candy, cake years, edition, runes,
+        // souls, plain numeric kill counters and a couple of non-key noise modifiers.
+        private static readonly string[] ModKeyPool =
+        {
+            "exp", "candyUsed", "skin", "color", "ability_scroll", SniperService.PetItemKey,
+            "kills", "logs_cut", "rarity_upgrades", "winning_bid", "edition", "new_years_cake",
+            "unlocked_slots", "gemstone_slots", "captured_player", "art_of_war_count", "dye_item",
+            "talisman_enrichment", "mana_disintegrator_count", "MAGMA_LORD", "FROZEN_BLAZE", "heldItem",
+            "MINOS_INQUISITOR_750", "mana_pool", "veteran",
+        };
+        private static readonly EnchantmentType[] EnchPool =
+        {
+            EnchantmentType.sharpness, EnchantmentType.growth, EnchantmentType.protection,
+            EnchantmentType.critical, EnchantmentType.ultimate_wise, EnchantmentType.scavenger,
+            EnchantmentType.ultimate_legion, EnchantmentType.snipe,
+        };
+        private static readonly ItemReferences.Reforge[] ReforgePool =
+        {
+            ItemReferences.Reforge.Any, ItemReferences.Reforge.Gilded, ItemReferences.Reforge.None,
+            ItemReferences.Reforge.jaded, ItemReferences.Reforge.Necrotic, ItemReferences.Reforge.warped_on_aote,
+        };
+
+        /// <summary>Realistic value for a given modifier key — production never feeds e.g. "edition" a non-integer, and a
+        /// thrown <see cref="FormatException"/> can't be compared, so the fuzzer mirrors the production value shapes per
+        /// key while still hitting every special branch (TIER_BOOST only on petItem, comma-substrings on slot lists, etc.).</summary>
+        private static string ValueFor(string key, Random rng)
+        {
+            switch (key)
+            {
+                case "exp": return new[] { "0", "1000000", "5000000", "25900000", "100", "0.3", "0.6" }[rng.Next(7)];
+                case "candyUsed": return new[] { "0", "1", "5", "10" }[rng.Next(4)];
+                case "edition": return new[] { "1", "50", "99", "500", "5000", "50000", "120" }[rng.Next(7)];
+                case "new_years_cake": return new[] { "1", "9", "69", "120", "400", "420" }[rng.Next(6)];
+                case "winning_bid": return new[] { "100", "5000000", "25000000", "100000000" }[rng.Next(4)];
+                case "kills":
+                case "art_of_war_count":
+                case "mana_disintegrator_count":
+                case "mana_pool":
+                case "veteran": return new[] { "1", "2", "5", "10", "100", "1000" }[rng.Next(6)];
+                case "logs_cut": return new[] { "200000", "5", "100" }[rng.Next(3)];
+                case "rarity_upgrades": return "1";
+                case SniperService.PetItemKey:
+                    return rng.Next(2) == 0 ? SniperService.TierBoostShorthand
+                        : new[] { "MINING_SPREAD", "TEXTBOOK", "BIGGER_SCROLL" }[rng.Next(3)];
+                case "heldItem":
+                    return new[] { "PET_ITEM_TIER_BOOST", "MINOS_RELIC", "QUICK_CLAW" }[rng.Next(3)];
+                case "unlocked_slots": return new[] { "0", "0,1", "0,1,2", "1,2,3,4", "COMBAT_0,COMBAT_1" }[rng.Next(5)];
+                case "gemstone_slots": return new[] { "1", "2", "3", "4" }[rng.Next(4)];
+                case "color": return new[] { "0:0:0", "255:128:64", "::" }[rng.Next(3)];
+                case "skin": return new[] { "bear", "PANDA", "FROG" }[rng.Next(3)];
+                case "dye_item": return new[] { "DYE_HOLLOW", "DYE_NECRON" }[rng.Next(2)];
+                case "ability_scroll": return new[] { "IMPLOSION_SCROLL", "WITHER_SHIELD_SCROLL" }[rng.Next(2)];
+                case "captured_player": return "abc123";
+                case "talisman_enrichment": return new[] { "CRITICAL", "STRENGTH" }[rng.Next(2)];
+                case "MAGMA_LORD":
+                case "FROZEN_BLAZE": return new[] { "1", "5", "10" }[rng.Next(3)]; // attributes
+                case "MINOS_INQUISITOR_750": return new[] { "1", "2", "3" }[rng.Next(3)]; // soul
+                default: return new[] { "1", "true", "PERFECT", "5" }[rng.Next(4)];
+            }
+        }
+
+        private static SaveAuction RandomAuction(Random rng, string tag)
+        {
+            var enchants = new List<Enchantment>();
+            int enchCount = rng.Next(0, 7);
+            var usedTypes = new HashSet<EnchantmentType>();
+            for (int i = 0; i < enchCount; i++)
+            {
+                var t = EnchPool[rng.Next(EnchPool.Length)];
+                if (!usedTypes.Add(t)) continue;
+                enchants.Add(new Enchantment(t, (byte)rng.Next(1, 11)));
+            }
+
+            var nbt = new Dictionary<string, string>();
+            int modCount = rng.Next(0, 8);
+            for (int i = 0; i < modCount; i++)
+            {
+                var k = ModKeyPool[rng.Next(ModKeyPool.Length)];
+                nbt[k] = ValueFor(k, rng);
+            }
+
+            var reforge = ReforgePool[rng.Next(ReforgePool.Length)];
+            var auction = new SaveAuction
+            {
+                Tag = tag,
+                Tier = (Tier)rng.Next(0, 12),
+                Reforge = reforge,
+                Count = (byte)rng.Next(1, 6),
+                Category = rng.Next(3) == 0 ? Category.ARMOR : Category.UNKNOWN,
+                FlatenedNBT = nbt,
+                Enchantments = enchants,
+                StartingBid = rng.Next(0, 2) == 0 ? 0 : rng.Next(1, 100) * 1_000_000L,
+                HighestBidAmount = rng.Next(0, 2) == 0 ? 0 : rng.Next(1, 100) * 1_000_000L,
+            };
+            // ItemCreatedAt left at default (0001) < UnlockedIntroduction so the unlocked_slots in-place-mutation path runs.
+            return auction;
+        }
+
+        private static SaveAuction AuctionFromKey(string tag, AuctionKey key)
+        {
+            var nbt = new Dictionary<string, string>();
+            foreach (var m in key.Modifiers)
+                nbt[m.Key] = m.Value;
+            var a = new SaveAuction
+            {
+                Tag = tag,
+                Tier = key.Tier,
+                Reforge = key.Reforge,
+                Count = Math.Max((int)key.Count, 1),
+                Category = Category.UNKNOWN,
+                FlatenedNBT = nbt,
+                Enchantments = key.Enchants.Select(e => new Enchantment(e.Type, e.Lvl)).ToList(),
+                StartingBid = 1000,
+                HighestBidAmount = 1000,
+            };
+            return a;
+        }
+
+        private static SaveAuction Clone(SaveAuction a)
+        {
+            var nbt = a.FlatenedNBT == null ? null : new Dictionary<string, string>(a.FlatenedNBT);
+            var clone = new SaveAuction
+            {
+                Tag = a.Tag,
+                Tier = a.Tier,
+                Reforge = a.Reforge,
+                Count = a.Count,
+                Category = a.Category,
+                FlatenedNBT = nbt,
+                Enchantments = a.Enchantments == null ? null : a.Enchantments.Select(e => new Enchantment(e.Type, e.Level)).ToList(),
+                StartingBid = a.StartingBid,
+                HighestBidAmount = a.HighestBidAmount,
+                ItemCreatedAt = a.ItemCreatedAt,
+                ItemName = a.ItemName,
+            };
+            return clone;
+        }
+
+        private static string Describe(SaveAuction a)
+            => $"tag={a.Tag} tier={a.Tier} reforge={a.Reforge} count={a.Count} cat={a.Category} hb={a.HighestBidAmount} " +
+               $"nbt=[{string.Join(",", (a.FlatenedNBT ?? new()).Select(m => m.Key + "=" + m.Value))}] " +
+               $"ench=[{string.Join(",", (a.Enchantments ?? new()).Select(e => e.Type + ":" + e.Level))}]";
+
+        // ---------- mock loading (mirrors DropOff.Tests.cs) ----------
+
+        private static PriceLookup LoadLookupMock(string mockFileName)
+        {
+            var text = File.ReadAllText($"Mock/{mockFileName}");
+            var parsed = JsonConvert.DeserializeObject<LookupLoad>(text);
+            var dict = new Dictionary<AuctionKey, ReferenceAuctions>();
+            foreach (var entry in parsed.Lookup)
+            {
+                AuctionKey key;
+                try { key = ParseKey(entry); } catch { continue; }
+                dict[key] = entry.Value;
+            }
+            return new PriceLookup
+            {
+                Lookup = new System.Collections.Concurrent.ConcurrentDictionary<AuctionKey, ReferenceAuctions>(dict),
+                CleanPricePerDay = parsed.CleanPricePerDay,
+                CleanKey = parsed.CleanKey
+            };
+        }
+
+        private static AuctionKey ParseKey(KeyValuePair<string, ReferenceAuctions> e)
+        {
+            var parts = e.Key.Replace(", ", ",").Split(' ');
+            return new AuctionKey
+            {
+                Enchants = new(parts[0].Split(',').Where(s => !string.IsNullOrWhiteSpace(s)).Select(s =>
+                {
+                    var eparts = s.Split('=');
+                    return new Enchant { Type = Enum.Parse<EnchantmentType>(eparts.First()), Lvl = byte.Parse(eparts.Last()) };
+                }).ToArray()),
+                Reforge = Enum.Parse<ItemReferences.Reforge>(parts[1]),
+                Tier = Enum.Parse<Tier>(parts.Reverse().Skip(1).First()),
+                Count = byte.Parse(parts.Last()),
+                Modifiers = new(parts.Skip(2).First().Split("],[").Select(s =>
+                {
+                    var mparts = s.Split(',', 2);
+                    return new KeyValuePair<string, string>(mparts.First().TrimStart('['), mparts.Last().TrimEnd(']'));
+                }).Where(m => !string.IsNullOrEmpty(m.Key)).ToList())
+            };
+        }
+
+        public class LookupLoad
+        {
+            public Dictionary<string, ReferenceAuctions> Lookup { get; set; }
+            public Dictionary<short, long> CleanPricePerDay { get; set; } = new();
+            public AuctionKey CleanKey { get; set; }
+        }
+    }
+}

--- a/Services/ModifierLookupKey.cs
+++ b/Services/ModifierLookupKey.cs
@@ -1,18 +1,36 @@
+using System;
 using System.Collections.Generic;
 
 namespace Coflnet.Sky.Sniper.Services
 {
-    public class ModifierLookupKey
+    /// <summary>
+    /// Cache key for <c>ModifierValueLookup</c>. A <b>readonly struct</b> (was a class): on the hot key-extraction path
+    /// this is built once per modifier purely to probe the cache, so a heap allocation per modifier per auction was pure
+    /// waste. As a struct the probe is allocation-free; it implements <see cref="IEquatable{T}"/> so the
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/> compares it without boxing.
+    /// <para>Equality semantics are unchanged from the original class: tag + modifier KVP + the (order-independent)
+    /// contents of <see cref="RelevantModifiers"/>. The struct holds a reference to the shared per-call
+    /// <c>RelevantModifiers</c> dictionary, exactly as the class did, so a stored key keeps that dictionary alive the
+    /// same way.</para>
+    /// </summary>
+    public readonly struct ModifierLookupKey : IEquatable<ModifierLookupKey>
     {
-        public string ItemTag;
-        public KeyValuePair<string, string> Modifier;
-        public Dictionary<string, string> RelevantModifiers;
+        public string ItemTag { get; init; }
+        public KeyValuePair<string, string> Modifier { get; init; }
+        public Dictionary<string, string> RelevantModifiers { get; init; }
 
-        public override bool Equals(object obj)
+        /// <summary>
+        /// R10: pre-computed order-independent hash of <see cref="RelevantModifiers"/> (Σ HashCode.Combine(k,v)). The
+        /// hot caller (<c>ComparisonValue</c>) builds the same <c>RelevantModifiers</c> for ALL M modifier probes in a
+        /// call, so iterating it inside every probe's <see cref="GetHashCode"/> is O(M²) per auction even on cache hits.
+        /// Computing the sum once and stamping it here makes each probe O(1). 0 = "not pre-computed" → fall back to
+        /// iterating (other callers / the reference oracle). Bit-exact: the stamped value equals the iteration result,
+        /// so the final hash — and thus every cache hit/miss placement — is identical.
+        /// </summary>
+        public int RelevantHash { get; init; }
+
+        public bool Equals(ModifierLookupKey other)
         {
-            if (obj is not ModifierLookupKey other)
-                return false;
-
             // Compare ItemTag
             if (ItemTag != other.ItemTag)
                 return false;
@@ -39,21 +57,22 @@ namespace Coflnet.Sky.Sniper.Services
             return true;
         }
 
+        public override bool Equals(object obj) => obj is ModifierLookupKey other && Equals(other);
+
         public override int GetHashCode()
         {
-            int hash = 17;
-            hash = hash * 23 + (ItemTag?.GetHashCode() ?? 0);
-            hash = hash * 23 + Modifier.GetHashCode();
-
-            if (RelevantModifiers != null)
+            // Order-independent: RelevantModifiers is a dictionary (equality compares contents regardless of order),
+            // so the per-entry contributions are summed. Avoids the previous multiplicative mix, which collapsed to a
+            // poorly-distributed value (any zero element hash annihilated it) and drove excessive Equals comparisons.
+            // R10: use the caller-stamped RelevantHash when present (non-zero); fall back to iterating otherwise. The
+            // stamped value IS this same sum, so the result is bit-identical either way.
+            var entries = RelevantHash;
+            if (entries == 0 && RelevantModifiers != null)
             {
                 foreach (var modifier in RelevantModifiers)
-                {
-                    hash = hash * 23 *  modifier.Key.GetHashCode() * (modifier.Value?.GetHashCode() ?? 1);
-                }
+                    entries += System.HashCode.Combine(modifier.Key, modifier.Value);
             }
-
-            return hash;
+            return System.HashCode.Combine(ItemTag, Modifier.Key, Modifier.Value, entries);
         }
     }
 }

--- a/Services/ParseMemo.Tests.cs
+++ b/Services/ParseMemo.Tests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R7/WS-A bit-exactness gate for the (contentHash, pricingEpoch) parse memo + the content-hash machinery.
+    ///
+    /// <para><b>Hash correctness</b> is the #1 risk (a wrong NonContentKeys exclusion → under-miss → wrong serve, and a
+    /// weak commutative combine → a content collision → wrong serve). These tests prove the static
+    /// <see cref="SniperService.BatchContentHash"/>: (a) DISTINGUISHES every distinct fixture content (no collision over
+    /// all priced buckets) — the regression test for the commutative-sum collision the parity guard caught (two distinct
+    /// {scroll_count,upgrade_level} contents summed equal before the splitmix finalizer); (b) is ORDER-INDEPENDENT (the
+    /// flatNbt dict iteration order must not change the hash); (c) is SENSITIVE to each hashed field (tier/reforge/count/
+    /// HighestBidAmount/an extra modifier all change the hash); (d) IGNORES per-instance uid keys (excluded from content).</para>
+    ///
+    /// <para><b>Memo bit-exactness</b>: over every priced bucket of the real fixtures, a memo store-then-serve roundtrip
+    /// at a stable epoch returns a value byte-equal (by the parse contract) to an independent fresh re-parse. This is the
+    /// in-process equivalent of the SNIPER_VERIFY_PARSE_MEMO replay guard.</para>
+    /// </summary>
+    public class ParseMemoTests
+    {
+        private SniperService service = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            SniperService.StartTime = new DateTime(2021, 9, 25) + TimeSpan.FromDays(10_000);
+            var itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, null);
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        private static readonly (string file, string tag)[] Fixtures =
+        {
+            ("boots.json", "WISE_WITHER_BOOTS"), ("HYPERION.json", "HYPERION"),
+            ("juju.json", "JUJU_SHORTBOW"), ("midas_sword.json", "MIDAS_SWORD"),
+        };
+
+        [Test]
+        public void BatchContentHash_NoCollisionOverAllFixtureBuckets()
+        {
+            var byHash = new Dictionary<ulong, string>();
+            int chec_ = 0, collisions = 0; string first = "";
+            foreach (var (file, tag) in Fixtures)
+            {
+                if (!File.Exists($"Mock/{file}")) continue;
+                var lookup = LoadLookupMock(file);
+                foreach (var key in lookup.Lookup.Keys)
+                {
+                    var a = AuctionFromKey(tag, key);
+                    var canon = Canonical(a);
+                    var h = SniperService.BatchContentHash(a);
+                    if (byHash.TryGetValue(h, out var existing) && existing != canon)
+                    {
+                        if (collisions == 0) first = $"hash {h}: [{existing}] vs [{canon}]";
+                        collisions++;
+                    }
+                    else byHash[h] = canon;
+                    chec_++;
+                }
+            }
+            chec_.Should().BeGreaterThan(0, "fixtures should yield buckets");
+            collisions.Should().Be(0, $"distinct contents must hash distinctly. First collision: {first}");
+        }
+
+        [Test]
+        public void BatchContentHash_IsOrderIndependent()
+        {
+            var nbtA = new Dictionary<string, string> { { "scroll_count", "3" }, { "upgrade_level", "7" }, { "rarity_upgrades", "1" } };
+            // a different insertion order -> the Dictionary may enumerate differently; the hash must be identical.
+            var nbtB = new Dictionary<string, string> { { "rarity_upgrades", "1" }, { "upgrade_level", "7" }, { "scroll_count", "3" } };
+            var a = Mk("HYPERION", Tier.LEGENDARY, nbtA);
+            var b = Mk("HYPERION", Tier.LEGENDARY, nbtB);
+            SniperService.BatchContentHash(a).Should().Be(SniperService.BatchContentHash(b));
+        }
+
+        [Test]
+        public void BatchContentHash_DistinguishesEveryField()
+        {
+            var baseNbt = new Dictionary<string, string> { { "upgrade_level", "5" } };
+            var b0 = Mk("HYPERION", Tier.LEGENDARY, baseNbt, hb: 1000, count: 1, reforge: ItemReferences.Reforge.None);
+            var h0 = SniperService.BatchContentHash(b0);
+
+            SniperService.BatchContentHash(Mk("NECRON_BLADE", Tier.LEGENDARY, baseNbt)).Should().NotBe(h0, "tag");
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.EPIC, baseNbt)).Should().NotBe(h0, "tier");
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.LEGENDARY, baseNbt, count: 2)).Should().NotBe(h0, "count");
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.LEGENDARY, baseNbt, reforge: ItemReferences.Reforge.Spicy)).Should().NotBe(h0, "reforge");
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.LEGENDARY, baseNbt, hb: 2000)).Should().NotBe(h0, "HighestBidAmount");
+            var withVal = new Dictionary<string, string> { { "upgrade_level", "6" } };
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.LEGENDARY, withVal)).Should().NotBe(h0, "modifier value");
+            var withExtra = new Dictionary<string, string> { { "upgrade_level", "5" }, { "scroll_count", "3" } };
+            SniperService.BatchContentHash(Mk("HYPERION", Tier.LEGENDARY, withExtra)).Should().NotBe(h0, "extra modifier");
+            var withEnch = Mk("HYPERION", Tier.LEGENDARY, baseNbt);
+            withEnch.Enchantments = new List<Enchantment> { new(EnchantmentType.sharpness, 6) };
+            SniperService.BatchContentHash(withEnch).Should().NotBe(h0, "enchant");
+        }
+
+        [Test]
+        public void BatchContentHash_IgnoresPerInstanceUidKeys()
+        {
+            var nbt = new Dictionary<string, string> { { "upgrade_level", "5" } };
+            var clean = Mk("HYPERION", Tier.LEGENDARY, new Dictionary<string, string>(nbt));
+            var withUid = Mk("HYPERION", Tier.LEGENDARY, new Dictionary<string, string>(nbt) { { "uid", "abc123" }, { "uuid", "deadbeef" } });
+            SniperService.BatchContentHash(withUid).Should().Be(SniperService.BatchContentHash(clean),
+                "per-instance uid/uuid keys are excluded from the content hash");
+        }
+
+        [Test]
+        public void ParseMemo_BitExact_OverFixtures()
+        {
+            int chec_ = 0, mismatches = 0; string firstTag = "";
+            foreach (var (file, tag) in Fixtures)
+            {
+                if (!File.Exists($"Mock/{file}")) continue;
+                service.AddLookupData(tag, LoadLookupMock(file));
+                var live = service.Lookups[tag];
+                foreach (var key in live.Lookup.Keys.ToList())
+                {
+                    var a = AuctionFromKey(tag, key);
+                    if (!service.ParseMemoRoundtripEqualsForTest(a))
+                    {
+                        if (mismatches == 0) firstTag = $"{tag} {key}";
+                        mismatches++;
+                    }
+                    chec_++;
+                }
+            }
+            chec_.Should().BeGreaterThan(0, "fixtures should yield buckets");
+            mismatches.Should().Be(0, $"memo store-then-serve must be bit-exact vs a fresh parse. First: {firstTag}");
+        }
+
+        private static SaveAuction Mk(string tag, Tier tier, Dictionary<string, string> nbt,
+            long hb = 1000, int count = 1, ItemReferences.Reforge reforge = ItemReferences.Reforge.None)
+            => new()
+            {
+                Tag = tag, Tier = tier, Reforge = reforge, Count = count, HighestBidAmount = hb,
+                FlatenedNBT = nbt, Enchantments = new List<Enchantment>(), StartingBid = hb,
+            };
+
+        private static string Canonical(SaveAuction a)
+        {
+            var nbt = string.Join(",", (a.FlatenedNBT ?? new()).Where(m => !m.Key.Contains("uid")).Select(m => m.Key + "=" + m.Value).OrderBy(x => x));
+            var ench = string.Join(",", (a.Enchantments ?? new()).Select(e => e.Type + ":" + e.Level).OrderBy(x => x));
+            return $"{a.Tag}|{a.Tier}|{a.Reforge}|{a.Count}|{a.HighestBidAmount}|N[{nbt}]|E[{ench}]";
+        }
+
+        private static SaveAuction AuctionFromKey(string tag, AuctionKey key)
+        {
+            var nbt = new Dictionary<string, string>();
+            foreach (var m in key.Modifiers) nbt[m.Key] = m.Value;
+            return new SaveAuction
+            {
+                Tag = tag, Tier = key.Tier, Reforge = key.Reforge, Count = Math.Max((int)key.Count, 1),
+                Category = Category.UNKNOWN, FlatenedNBT = nbt,
+                Enchantments = key.Enchants.Select(e => new Enchantment(e.Type, e.Lvl)).ToList(),
+                StartingBid = 1000, HighestBidAmount = 1000,
+            };
+        }
+
+        private static PriceLookup LoadLookupMock(string mockFileName)
+        {
+            var text = File.ReadAllText($"Mock/{mockFileName}");
+            var parsed = JsonConvert.DeserializeObject<LookupLoad>(text);
+            var dict = new Dictionary<AuctionKey, ReferenceAuctions>();
+            foreach (var entry in parsed.Lookup)
+            {
+                AuctionKey key;
+                try { key = ParseKey(entry); } catch { continue; }
+                dict[key] = entry.Value;
+            }
+            return new PriceLookup
+            {
+                Lookup = new System.Collections.Concurrent.ConcurrentDictionary<AuctionKey, ReferenceAuctions>(dict),
+                CleanPricePerDay = parsed.CleanPricePerDay,
+                CleanKey = parsed.CleanKey
+            };
+        }
+
+        private static AuctionKey ParseKey(KeyValuePair<string, ReferenceAuctions> e)
+        {
+            var parts = e.Key.Replace(", ", ",").Split(' ');
+            return new AuctionKey
+            {
+                Enchants = new(parts[0].Split(',').Where(s => !string.IsNullOrWhiteSpace(s)).Select(s =>
+                {
+                    var eparts = s.Split('=');
+                    return new Enchant { Type = Enum.Parse<EnchantmentType>(eparts.First()), Lvl = byte.Parse(eparts.Last()) };
+                }).ToArray()),
+                Reforge = Enum.Parse<ItemReferences.Reforge>(parts[1]),
+                Tier = Enum.Parse<Tier>(parts.Reverse().Skip(1).First()),
+                Count = byte.Parse(parts.Last()),
+                Modifiers = new(parts.Skip(2).First().Split("],[").Select(s =>
+                {
+                    var mparts = s.Split(',', 2);
+                    return new KeyValuePair<string, string>(mparts.First().TrimStart('['), mparts.Last().TrimEnd(']'));
+                }).Where(m => !string.IsNullOrEmpty(m.Key)).ToList())
+            };
+        }
+
+        public class LookupLoad
+        {
+            public Dictionary<string, ReferenceAuctions> Lookup { get; set; }
+            public Dictionary<short, long> CleanPricePerDay { get; set; } = new();
+            public AuctionKey CleanKey { get; set; }
+        }
+    }
+}

--- a/Services/ParseMemo.cs
+++ b/Services/ParseMemo.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using Coflnet.Sky.Sniper.Models;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R7/WS-A — the entry-epoch-stamped <c>(contentHash, pricingEpoch)</c> memo for
+    /// <c>SniperService.DetailedKeyFromSaveAuction</c>. A service-wide, lifetime-stable, in-memory memo of the WHOLE
+    /// parse output (<see cref="KeyWithValueBreakdown"/> = the capped <see cref="AuctionKey"/> + the value breakdown),
+    /// keyed by an FNV-1a content hash of the immutable item content and validated by a per-ENTRY pricing-epoch stamp.
+    ///
+    /// <para><b>Why an entry stamp (the warm fix / clean3 lesson).</b> The parse key SHAPE is market-dependent —
+    /// <c>CapKeyLength</c> drops low-value modifiers/enchants by a live market threshold — so the memo MUST key on
+    /// <c>(contentHash, pricingEpoch)</c>, not content alone (a pure-content hit would be wrong after a price move).
+    /// The naive realization (realloc the dict whenever the epoch changes) regresses warm, where <c>pricingEpoch</c>
+    /// is bumped on ~every auction (ingest / <c>UpdateMedian</c>): it would re-allocate the whole dict every auction.
+    /// This memo keeps ONE dict for the service lifetime and stamps each ENTRY with the epoch it was computed at. A read
+    /// whose entry epoch != the current pricing epoch is a MISS — re-parse and OVERWRITE the entry with the fresh
+    /// value+stamp. So warm degrades to a no-op (entries always stale → re-parse) with ZERO dict realloc; cold/rare keep
+    /// the intra-epoch cross-auction hits.</para>
+    ///
+    /// <para><b>Bit-exactness (the pricingEpoch rail).</b> A hit only occurs within one epoch, where <c>CapKeyLength</c>
+    /// would compute the identical threshold/drops, so the cached <see cref="KeyWithValueBreakdown"/> is byte-for-byte
+    /// what a fresh parse would produce — proven by the <c>SNIPER_VERIFY_PARSE_MEMO</c> guard (every call recomputes
+    /// fresh and asserts equality). The cached value is READ-ONLY downstream: the dispatch loop only calls
+    /// <see cref="KeyWithValueBreakdown.GetReduced"/> (which allocates fresh reduced keys and never mutates its source)
+    /// and reads <c>ValueBreakdown</c>; <c>CapKeyLength</c>'s in-place modifier mutation happens INSIDE the memoized
+    /// parse body, before <c>Constructkey</c> snapshots the lists — so the stored entry is immutable post-store.</para>
+    ///
+    /// <para><b>Content hash (what enters it).</b> The immutable item content only: every <c>FlatenedNBT</c> entry minus
+    /// a CONSERVATIVE per-instance exclusion set (only keys containing <c>"uid"</c>/<c>"uuid"</c> — the codebase's own
+    /// proven per-instance marker), the filtered <c>Enchantments</c> (Type+Lvl), <c>Tier</c>, <c>Reforge</c>,
+    /// <c>Count</c>, <c>Tag</c>, AND <c>HighestBidAmount</c> (which feeds <c>CapKeyLength.percentDiff</c> and so the
+    /// substracted value — a per-instance value that genuinely affects the output, so included for correctness:
+    /// over-miss is safe, under-miss is a correctness bug). When in doubt a key is INCLUDED in the hash → over-miss.</para>
+    ///
+    /// <para><b>Concurrency.</b> Auctions for different tags evaluate concurrently on the shard workers. The dict is a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/>; each entry is a small struct stored/read atomically through its
+    /// striping lock. A stale-stamp miss re-parses and OVERWRITES the entry (last-writer-wins); within one epoch the
+    /// parse is deterministic for fixed content, so a concurrent writer for the same (hash, epoch) stores an equivalent
+    /// value and the race is harmless. Never serialized — a derived in-memory acceleration structure.</para>
+    /// </summary>
+    public sealed class ParseMemo
+    {
+        /// <summary>One memoized parse output plus the pricing epoch it was computed at. A value-type so the
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> stores it inline (no per-entry boxing) and a slot overwrite
+        /// is a single locked struct copy. <see cref="Value"/> is the (reference-typed) <see cref="KeyWithValueBreakdown"/>
+        /// parse output, read-only downstream.</summary>
+        public readonly struct Entry
+        {
+            public readonly KeyWithValueBreakdown Value;
+            public readonly long Epoch;
+
+            public Entry(KeyWithValueBreakdown value, long epoch)
+            {
+                Value = value;
+                Epoch = epoch;
+            }
+        }
+
+        /// <summary>Memoized parse outputs, keyed by the FNV-1a content hash, each carrying its pricing-epoch stamp.
+        /// ONE dict for the service's whole lifetime — never re-allocated on an epoch bump (the warm fix). A stale-stamp
+        /// read overwrites the slot in place.</summary>
+        public readonly ConcurrentDictionary<ulong, Entry> Values = new();
+    }
+}

--- a/Services/PotentialSnipePercentile.Tests.cs
+++ b/Services/PotentialSnipePercentile.Tests.cs
@@ -1,0 +1,152 @@
+using System;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R8 WS-CHURN-A (partial selection) bit-exactness gate for the divided-price 25th-percentile order statistic.
+    ///
+    /// <para>
+    /// <b>What is under test.</b> <see cref="SniperService.PotentialSnipeQuarterPercentile(long[],int,long)"/> selects
+    /// the <c>count/4</c>-th smallest VALUE of the thread-static divided-price buffer filled by
+    /// <c>PotentialSnipeHigherValueScan</c>. WS-CHURN-A replaces the original full <see cref="Array.Sort"/> with an
+    /// in-place quickselect (nth_element). Because the result is a scalar order statistic over a <c>long[]</c>, the
+    /// k-th smallest value is uniquely defined regardless of duplicates, so the partial selection must return the
+    /// <b>identical</b> long as the full-sort oracle
+    /// <see cref="SniperService.PotentialSnipeQuarterPercentileReference(long[],int,long)"/> for every input.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Why the heavy-tie emphasis.</b> A median-of-three Lomuto quickselect is the place divergence would hide: on
+    /// dense ties / all-equal / already-sorted / reverse-sorted inputs a naive partition can mis-place the boundary or
+    /// degrade. This fuzz therefore drives <b>50,000</b> seeds across narrow value ranges, all-equal buffers, many
+    /// duplicates, negatives, and counts NOT divisible by 4, over lengths 0..2000, and asserts 0 mismatches.
+    /// The buffer is also over-provisioned with a randomized stale tail beyond <c>count</c> (mirroring the reused
+    /// <c>[ThreadStatic]</c> field) to prove only <c>[0, count)</c> is consulted.
+    /// </para>
+    /// </summary>
+    public class PotentialSnipePercentileTests
+    {
+        [Test]
+        public void Fuzz_QuickSelect_BitExact_VsFullSortReference_HeavyTies()
+        {
+            const int seeds = 50_000;
+            int mismatches = 0;
+            string first = "";
+            long maxLen = 0;
+            int heavyTieCases = 0;     // narrow-range / all-equal cases actually generated
+            int notDivBy4Cases = 0;    // count % 4 != 0 cases (the floor of count/4 boundary)
+            int negativeCases = 0;     // buffers that contained at least one negative
+
+            for (int seed = 1; seed <= seeds; seed++)
+            {
+                var rng = new Random(seed);
+                int count = rng.Next(0, 2001); // length 0..2000
+
+                // Pick a generation mode so we span all-equal -> narrow ties -> wide-distinct, with negatives.
+                int mode = rng.Next(7);
+                long[] data = new long[count];
+                bool sawNegative = false;
+                bool narrowOrEqual = false;
+                switch (mode)
+                {
+                    case 0: // all equal (heaviest tie)
+                        {
+                            long v = rng.Next(-50, 50);
+                            for (int i = 0; i < count; i++) data[i] = v;
+                            narrowOrEqual = true;
+                            sawNegative = v < 0;
+                            break;
+                        }
+                    case 1: // tiny range, includes negatives (dense ties)
+                        for (int i = 0; i < count; i++) { data[i] = rng.Next(-3, 3); if (data[i] < 0) sawNegative = true; }
+                        narrowOrEqual = true;
+                        break;
+                    case 2: // small range, many duplicates
+                        for (int i = 0; i < count; i++) data[i] = rng.Next(0, 5);
+                        narrowOrEqual = true;
+                        break;
+                    case 3: // already sorted ascending (quickselect adversary)
+                        for (int i = 0; i < count; i++) { data[i] = i - count / 2; if (data[i] < 0) sawNegative = true; }
+                        break;
+                    case 4: // reverse sorted (quickselect adversary)
+                        for (int i = 0; i < count; i++) { data[i] = (count - i) - count / 2; if (data[i] < 0) sawNegative = true; }
+                        break;
+                    case 5: // wide distinct-ish, full long span (includes negatives)
+                        for (int i = 0; i < count; i++)
+                        {
+                            data[i] = ((long)rng.Next(int.MinValue, int.MaxValue) << 1) ^ rng.Next();
+                            if (data[i] < 0) sawNegative = true;
+                        }
+                        break;
+                    default: // medium range with negatives
+                        for (int i = 0; i < count; i++) { data[i] = rng.Next(-100_000, 100_000); if (data[i] < 0) sawNegative = true; }
+                        break;
+                }
+
+                // Over-provision the buffer beyond `count` with a randomized stale tail: the selection must only ever
+                // read/permute [0, count) so this tail must not affect the result (mirrors the reused ThreadStatic).
+                int cap = count + rng.Next(0, 6);
+                long[] live = new long[cap];
+                long[] oracle = new long[cap];
+                for (int i = 0; i < count; i++) { live[i] = data[i]; oracle[i] = data[i]; }
+                for (int i = count; i < cap; i++) { long t = rng.Next(-9, 9); live[i] = t; oracle[i] = t; }
+
+                long fallback = rng.Next(-1_000, 1_000);
+
+                long got = SniperService.PotentialSnipeQuarterPercentile(live, count, fallback);
+                long want = SniperService.PotentialSnipeQuarterPercentileReference(oracle, count, fallback);
+
+                if (got != want)
+                {
+                    if (mismatches == 0)
+                        first = $"seed={seed} count={count} mode={mode} got={got} want={want}";
+                    mismatches++;
+                }
+
+                if (count > maxLen) maxLen = count;
+                if (narrowOrEqual && count >= 8) heavyTieCases++;
+                if (count % 4 != 0) notDivBy4Cases++;
+                if (sawNegative) negativeCases++;
+            }
+
+            // The generator must actually have exercised the regimes this gate exists to protect.
+            heavyTieCases.Should().BeGreaterThan(1_000, "the heavy-tie generator must produce many dense-tie buffers");
+            notDivBy4Cases.Should().BeGreaterThan(1_000, "many counts must NOT be divisible by 4 (floor boundary)");
+            negativeCases.Should().BeGreaterThan(1_000, "negatives must be exercised");
+            maxLen.Should().BeGreaterThan(1_800, "the fuzz must cover large buffers up to ~2000");
+
+            mismatches.Should().Be(0,
+                $"quickselect 25th-percentile must be bit-exact with the full-sort reference over {seeds} heavy-tie "
+              + $"seeds (maxLen={maxLen}). First mismatch: {first}");
+        }
+
+        [Test]
+        public void EdgeCases_Match_Reference()
+        {
+            var cases = new (long[] buf, int count, long fallback)[]
+            {
+                (Array.Empty<long>(), 0, 777),                       // empty -> fallback
+                (new long[] { 5 }, 1, 0),                            // single element, k=0
+                (new long[] { 5, 5, 5, 5 }, 4, 0),                   // all equal, k=1
+                (new long[] { 9, 1, 9, 1, 9 }, 5, 0),               // ties, count%4 != 0 (k=1)
+                (new long[] { -3, -1, -2, 0, 4, 2 }, 6, 0),         // negatives, k=1
+                (new long[] { 3, 2, 1 }, 3, 0),                      // reverse, k=0
+                (new long[] { 1, 2, 3 }, 3, 0),                      // sorted, k=0
+                (new long[] { 7, 7 }, 2, 0),                         // two equal, k=0
+                (new long[] { 10, 20, 30, 40, 50, 60, 70, 80 }, 8, 0), // distinct, k=2
+                (new long[] { 5, 4, 3, 2, 1, 0, 0, 0, 0 }, 9, 0),   // heavy zeros tail, k=2
+            };
+
+            foreach (var (buf, count, fallback) in cases)
+            {
+                var live = (long[])buf.Clone();
+                var oracle = (long[])buf.Clone();
+                long got = SniperService.PotentialSnipeQuarterPercentile(live, count, fallback);
+                long want = SniperService.PotentialSnipeQuarterPercentileReference(oracle, count, fallback);
+                got.Should().Be(want, $"count={count}");
+            }
+        }
+    }
+}

--- a/Services/ReferenceSnapshot.Tests.cs
+++ b/Services/ReferenceSnapshot.Tests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R3 Phase 0 / F2 bit-exactness soak for the <see cref="ReferenceAuctions.References"/> cached snapshot
+    /// (<c>benchmarks/COMPUTE_FLOOR_SPEC_R3.md</c> §4-F2 + §5 R3-REFS).
+    ///
+    /// <para>
+    /// <b>Why.</b> R3-REFS is the headline lever: it adds an <c>[IgnoreMember]</c> cached <c>ReferencePrice[]</c>
+    /// snapshot to <see cref="ReferenceAuctions"/>, atomic-ref published and invalidated by a version bumped at every
+    /// <c>References</c> mutation, and converts the per-candidate hot reads (<c>CheckLowerKeyFull</c>,
+    /// <c>GetCleanItemPrice</c>, <c>PotentialSnipe*</c>, <c>AddMedianSample</c>, <c>UpdateMedian</c>) from
+    /// <c>foreach (var r in bucket.References)</c> (which allocates a <c>ConcurrentQueue&lt;T&gt;</c> enumerator each
+    /// call) to a zero-alloc array/span read. The <b>invariant that change must preserve</b> is:
+    /// </para>
+    ///
+    /// <para><b>the snapshot iterates element-for-element, FIFO-identical to a fresh
+    /// <c>ConcurrentQueue&lt;ReferencePrice&gt;</c> enumeration, after every mutation.</b></para>
+    ///
+    /// <para>
+    /// A missed mutation site = a stale snapshot = a silent price/tier/snipe drift. This test encodes that invariant
+    /// directly: it builds a <see cref="ReferenceAuctions"/>, performs many interleaved Enqueue / TryDequeue /
+    /// whole-queue-reassignment operations, and after EACH asserts the snapshot accessor matches a fresh queue
+    /// enumeration. Since the snapshot accessor does not exist yet, <see cref="SnapshotForTest"/> currently returns the
+    /// live queue contents (so the test is GREEN against current code and pins the reference semantics); when R3-REFS
+    /// lands, swap that ONE helper to call the new accessor and this same soak directly validates it.
+    /// </para>
+    ///
+    /// <para>
+    /// See <see cref="ReferenceMutationSiteMap"/> for the exhaustive, grep-verified list of every codebase site that
+    /// mutates a <c>ReferenceAuctions.References</c> — R3-REFS must bump the snapshot version at each of those.
+    /// </para>
+    /// </summary>
+    public class ReferenceSnapshotTests
+    {
+        // ============================================================================================================
+        // The snapshot accessor seam. TODO(R3-REFS): swap the body to the new zero-alloc snapshot accessor
+        // (e.g. `bucket.ReferenceSnapshot()` returning ReferencePrice[] / ReadOnlySpan<ReferencePrice> in FIFO order).
+        // Everything below this line then validates the real accessor unchanged. Until then it returns the live queue
+        // contents, which IS the reference semantics the snapshot must reproduce.
+        // ============================================================================================================
+        private static IEnumerable<ReferencePrice> SnapshotForTest(ReferenceAuctions bucket)
+        {
+            // R3-REFS: now validates the real zero-alloc cached snapshot accessor.
+            return bucket.ReferenceSnapshot();
+        }
+
+        /// <summary>A fresh ConcurrentQueue enumeration — the FIFO reference the snapshot must match element-for-element.</summary>
+        private static List<ReferencePrice> FreshQueueEnumeration(ReferenceAuctions bucket)
+        {
+            var list = new List<ReferencePrice>();
+            foreach (var r in bucket.References) // ConcurrentQueue enumerates in FIFO (enqueue) order
+                list.Add(r);
+            return list;
+        }
+
+        /// <summary>
+        /// Asserts the snapshot accessor yields exactly the fresh-queue enumeration: same length, same elements, same
+        /// order. This is the R3-REFS gate predicate, checked after every mutation in the soak.
+        /// </summary>
+        private static void AssertSnapshotMatchesQueue(ReferenceAuctions bucket, string after)
+        {
+            var snapshot = SnapshotForTest(bucket).ToList();
+            var fresh = FreshQueueEnumeration(bucket);
+            snapshot.Should().Equal(fresh,
+                $"the cached References snapshot must iterate FIFO-identical to a fresh ConcurrentQueue enumeration "
+                + $"after [{after}] (gates R3-REFS; a mismatch means a mutation site did not invalidate the snapshot)");
+        }
+
+        // ============================================================================================================
+        // The soak: many interleaved Enqueue / TryDequeue / whole-queue reassignment ops, assert after each.
+        // ============================================================================================================
+
+        [Test]
+        public void ReferencesSnapshot_FifoIdentical_UnderInterleavedMutations()
+        {
+            var bucket = new ReferenceAuctions();
+            var rng = new Random(12345); // deterministic
+            short day = 100;
+            long auctionId = 1;
+
+            AssertSnapshotMatchesQueue(bucket, "init (empty)");
+
+            for (int step = 0; step < 5000; step++)
+            {
+                int op = rng.Next(0, 100);
+                if (op < 55)
+                {
+                    // Enqueue (the AddAuctionToBucket / UpdateBazaar / Move-target shape) — via the encapsulated method.
+                    bucket.EnqueueReference(new ReferencePrice
+                    {
+                        AuctionId = auctionId++,
+                        Price = rng.Next(1, 1_000_000),
+                        Day = day,
+                        Seller = (short)rng.Next(0, 20000),
+                        Buyer = (short)rng.Next(0, 20000),
+                    });
+                    AssertSnapshotMatchesQueue(bucket, $"Enqueue step={step}");
+                }
+                else if (op < 80)
+                {
+                    // TryDequeue (the CapBucketSize / CombineBuckets-trim shape) — via the encapsulated method.
+                    bucket.TryDequeueReference(out _);
+                    AssertSnapshotMatchesQueue(bucket, $"TryDequeue step={step}");
+                }
+                else if (op < 92)
+                {
+                    // Whole-queue reassignment (the AddLookupData / Move-source / Reassign / CombineBuckets shape):
+                    // a filtered+reordered new ConcurrentQueue replaces the field entirely — via the encapsulated method.
+                    var filtered = bucket.References
+                        .Where(r => r.Price > 0)
+                        .OrderBy(r => r.Day)
+                        .ThenBy(r => r.AuctionId)
+                        .ToList();
+                    bucket.SetReferences(filtered);
+                    AssertSnapshotMatchesQueue(bucket, $"Reassign(filter+order) step={step}");
+                }
+                else
+                {
+                    // Reassign to an empty queue (the new-bucket / cleared-bucket shape) — via the encapsulated method.
+                    bucket.SetReferences(Array.Empty<ReferencePrice>());
+                    AssertSnapshotMatchesQueue(bucket, $"Reassign(empty) step={step}");
+                }
+
+                if (step % 500 == 0)
+                    day++;
+            }
+
+            // a final burst of enqueues then a full drain, asserting throughout
+            for (int i = 0; i < 50; i++)
+            {
+                bucket.EnqueueReference(new ReferencePrice { AuctionId = auctionId++, Price = i + 1, Day = day });
+                AssertSnapshotMatchesQueue(bucket, $"final-burst enqueue {i}");
+            }
+            while (bucket.TryDequeueReference(out _))
+                AssertSnapshotMatchesQueue(bucket, "final-drain dequeue");
+            AssertSnapshotMatchesQueue(bucket, "fully drained");
+        }
+
+        /// <summary>
+        /// Reassignment-with-Concat shape from <c>CombineBuckets</c> (existing refs concatenated with incoming,
+        /// de-duplicated by AuctionId, ordered by Day): the snapshot must follow the new queue's FIFO order exactly.
+        /// </summary>
+        [Test]
+        public void ReferencesSnapshot_FifoIdentical_AfterConcatDistinctReassign()
+        {
+            var bucket = new ReferenceAuctions();
+            for (short d = 1; d <= 12; d++)
+                bucket.EnqueueReference(new ReferencePrice { AuctionId = d, Price = d * 1000, Day = d });
+            AssertSnapshotMatchesQueue(bucket, "seeded");
+
+            var incoming = Enumerable.Range(8, 10)
+                .Select(i => new ReferencePrice { AuctionId = i, Price = i * 1000, Day = (short)i })
+                .ToList();
+
+            bucket.SetReferences(
+                bucket.References.Concat(incoming).ToList()
+                    .DistinctBy(r => r.AuctionId)
+                    .OrderBy(r => r.Day));
+            AssertSnapshotMatchesQueue(bucket, "concat+distinct+order reassign");
+
+            // trim from the front (the CombineBuckets / CapBucketSize trailing dequeue loop)
+            while (bucket.References.Count > 7 && bucket.TryDequeueReference(out _))
+                AssertSnapshotMatchesQueue(bucket, "trim dequeue");
+            AssertSnapshotMatchesQueue(bucket, "trimmed");
+        }
+
+        /// <summary>
+        /// Empty-bucket and single-element edge cases — common FIFO snapshot off-by-ones live here.
+        /// </summary>
+        [Test]
+        public void ReferencesSnapshot_FifoIdentical_EdgeCases()
+        {
+            var bucket = new ReferenceAuctions();
+            AssertSnapshotMatchesQueue(bucket, "empty");
+
+            bucket.EnqueueReference(new ReferencePrice { AuctionId = 1, Price = 1, Day = 1 });
+            AssertSnapshotMatchesQueue(bucket, "single");
+
+            bucket.TryDequeueReference(out _);
+            AssertSnapshotMatchesQueue(bucket, "emptied-by-dequeue");
+
+            bucket.TryDequeueReference(out _); // dequeue on empty (no-op)
+            AssertSnapshotMatchesQueue(bucket, "dequeue-on-empty");
+
+            bucket.SetReferences(new[]
+            {
+                new ReferencePrice { AuctionId = 7, Price = 7, Day = 7 },
+            });
+            AssertSnapshotMatchesQueue(bucket, "reassign-single");
+        }
+
+        // ============================================================================================================
+        // ReferenceMutationSiteMap — EXHAUSTIVE list of every site that mutates a ReferenceAuctions.References.
+        //
+        // R3-REFS MUST bump the cached-snapshot version at every one of these (Enqueue / TryDequeue / whole-queue
+        // `new ConcurrentQueue` reassignment). Derived from `grep -rn "\.References" --include="*.cs"` then filtered to
+        // mutating operations (assignment, .Enqueue, .TryDequeue). Read-only iterations (foreach / LINQ / .Count /
+        // .TryPeek / .First / .Reverse etc.) are NOT version-bump sites and are deliberately excluded.
+        //
+        // ---- PRODUCTION (these are the version-bump sites R3-REFS owns) ----
+        //
+        //   Services/SniperService.cs
+        //     L1270  Move()                 oldBucket.References = new ConcurrentQueue<ReferencePrice>(newList);   (reassign, source bucket)
+        //     L1273  Move()                 newBucket.References.Enqueue(toChange);                                (enqueue, target bucket)
+        //     L1320  AddLookupData()        item.Value.References = new ConcurrentQueue<ReferencePrice>(...);      (reassign, filter+order)
+        //     L1336  AddLookupData()        item.Value.References = new ConcurrentQueue<ReferencePrice>(...);      (reassign, filter+order)
+        //     L1361  AddLookupData()        tocheck.References = new(...);                                         (reassign, dedup by id)
+        //     L1378  CombineBuckets()       existingBucket.References = item.Value.References;                     (reassign, adopt incoming queue ref)
+        //     L1381  CombineBuckets()       existingBucket.References = new(existingRef.Concat(...)...);           (reassign, concat+distinct+order)
+        //     L1403  CombineBuckets()       existingBucket.References.TryDequeue(out _);                           (dequeue, front-trim loop)
+        //     L1490  CapBucketSize()        bucket.References.TryDequeue(out _);                                   (dequeue, size-cap loop)
+        //     L1573  AddAuctionToBucket()   bucket.References.Enqueue(reference);                                  (enqueue, the primary ingest path)
+        //     L4591  UpdateBazaar()         bucket.References.Enqueue(new() {...});                                (enqueue, bazaar reference)
+        //
+        //   Controllers/ApiController.cs
+        //     L376   Migrate()             newBucket.References.Enqueue(reference);                                (enqueue, migration)
+        //     L487   DeleteReferencesBetween()  lookup.Value.References = new(... .Where(day filter));            (reassign, day-range delete)
+        //
+        //   Services/MinioPersistanceManager.cs
+        //     L213   CreateSerializableReferenceAuctionsCopy()  new ReferenceAuctions { References = new ConcurrentQueue<...>(bucket.References) ... }
+        //            NOTE: this is an object-INITIALIZER on a freshly-constructed *copy* ReferenceAuctions, not an
+        //            in-place mutation of a live bucket. A snapshot is per-instance and this new instance starts with
+        //            no cached snapshot, so it is benign for invalidation — but it IS a place the queue is populated,
+        //            so R3-REFS should confirm the copy either has no live snapshot or builds a fresh one. Listed for
+        //            completeness so the audit is exhaustive.
+        //
+        // ---- TESTS (mutate References directly; not production version-bump sites, but R3-REFS must keep them
+        //            compiling/green and they exercise the same operations) ----
+        //
+        //   Services/MedianCalc.Tests.cs   L40 (reassign new), L45/L259/L260/L261 (Enqueue)
+        //   Services/DropOff.Tests.cs      L1433 (reassign new ConcurrentQueue)
+        //   Services/ReferenceSnapshot.Tests.cs (this file)  — the F2 soak's own Enqueue/TryDequeue/reassign ops.
+        //
+        // If you add/remove a `.References` mutation, update this map AND the soak above.
+        // ============================================================================================================
+        private const string ReferenceMutationSiteMap = "see comment above";
+    }
+}

--- a/Services/Saletime.Tests.cs
+++ b/Services/Saletime.Tests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
 using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace Coflnet.Sky.Sniper.Services;
@@ -17,7 +19,7 @@ public class SaletimeTests
         SniperService.StartTime = new DateTime(2021, 9, 25);
         // console logger
         var factory = LoggerFactory.Create(builder => builder.AddConsole());
-        service = new SniperService(new(null, null), null, factory.CreateLogger<SniperService>(), null);
+        service = new SniperService(new HypixelItemService(null, NullLogger<HypixelItemService>.Instance), null, factory.CreateLogger<SniperService>(), null);
     }
     [Test]
     public void TwoMinutes()

--- a/Services/ShardedAuctionDispatcher.cs
+++ b/Services/ShardedAuctionDispatcher.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Coflnet.Sky.Core;
+using Prometheus;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// WS-D — tag-shard dispatcher in front of <see cref="SniperService.TestNewAuction"/> for throughput scaling.
+    ///
+    /// <para><b>Why this is safe.</b> <c>TestNewAuctionInternal</c> resolves the incoming tag to a <em>group tag</em>
+    /// via <see cref="SniperService.GetAuctionGroupTag"/> and then mutates exactly one per-tag
+    /// <see cref="Models.PriceLookup"/> (<c>Lookups.GetOrAdd(groupTag, …)</c>): bucket adds, lbin enqueues, the
+    /// per-bucket <c>HitsSinceCalculating++</c> and <c>ScoreVecCache</c>. Different group tags touch <em>disjoint</em>
+    /// PriceLookup objects, so two different tags can run concurrently with no shared mutation. The only state shared
+    /// across tags on the snipe path is already concurrency-safe: <c>Lookups</c> / <c>ComparisonValueLookup</c> /
+    /// <c>ScoreVecLookup</c> are <see cref="ConcurrentDictionary{TKey,TValue}"/>, the score interner uses
+    /// GetOrAdd + Interlocked, the <c>pricingEpoch</c> is Interlocked, the WS-A <c>CandidateIndex</c> is an immutable
+    /// snapshot published by a single atomic reference write (concurrent rebuilds produce identical content), and
+    /// <c>Logs</c>/<c>LbinUpdates</c> are <see cref="ConcurrentQueue{T}"/>.</para>
+    ///
+    /// <para>The one rule that makes the bucket-level mutations race-free is: <b>a given group tag is ALWAYS handled by
+    /// exactly one worker.</b> We hash the resolved group tag to a fixed worker index, so all auctions of that tag are
+    /// serialized through one queue/thread. Two workers never mutate the same PriceLookup. Different tags run in
+    /// parallel; per-auction latency is unchanged.</para>
+    ///
+    /// <para><b>Determinism / parity.</b> The snipe set is independent of worker count: each tag's auctions are
+    /// processed in the same submission order on its single worker (FIFO queue), and the snipe-finding path emits all
+    /// of an auction's snipes synchronously within its own <c>TestNewAuction</c> call (the risky closest finder is
+    /// awaited when <c>MIN_TARGET == 0</c>). The <em>cross-tag</em> interleaving is non-deterministic, but the
+    /// shared structures it touches are commutative reads/idempotent caches, so the multiset of snipes (by finder,
+    /// by auction) is bit-identical to single-threaded. See <c>ShardedReplay</c> in the harness for the parity assert.</para>
+    ///
+    /// <para><b>R8 WS-SHARD-OBS — shard-balance observability (additive, no behavior change).</b> The suspected capacity
+    /// bottleneck is shard balance: under per-tag serialization a few hot tags can skew most of the load onto one worker.
+    /// To make that measurable, this class exports two Prometheus metrics, both labelled by <c>shard</c> (the worker
+    /// index, <c>0..WorkerCount-1</c>):
+    /// <list type="bullet">
+    /// <item><c>sky_sniper_shard_processed_total</c> (Counter): per-worker count of auctions handed to
+    /// <c>TestNewAuction</c> (incremented in <see cref="WorkerLoop"/> alongside — but additional to — the existing
+    /// global <see cref="Processed"/> counter, which is left exactly as-is for the harness parity assert). A skewed
+    /// split of this counter across shards is the hot-tag-skew signal.</item>
+    /// <item><c>sky_sniper_shard_queue_depth</c> (Gauge): current in-flight backlog per shard, incremented on every
+    /// enqueue (<see cref="Enqueue"/> and the <see cref="ProcessBatchAndWait"/> enqueue loop) and decremented once per
+    /// item after it is dequeued+processed in <see cref="WorkerLoop"/>. A persistently deep queue on one shard is the
+    /// backlog side of the same skew.</item>
+    /// </list>
+    /// The metric declarations are <c>static readonly</c> (process-global by name+labels; registering the same name
+    /// twice returns the same metric, so multiple dispatcher instances share them and the <c>shard</c> label keeps
+    /// shards distinct within a process). To keep the snipe hot path allocation-free, the per-shard <c>Child</c> handles
+    /// are pre-resolved once into instance arrays in the constructor — no <c>WithLabels</c> call per auction. These
+    /// metrics are purely observational; they do not touch routing, serialization, the countdown/batch logic, fault
+    /// handling, or which auctions produce which snipes.</para>
+    /// </summary>
+    public sealed class ShardedAuctionDispatcher : IDisposable
+    {
+        /// <summary>
+        /// A unit of work on a shard queue: the auction to process plus an optional <see cref="CountdownEvent"/> that the
+        /// worker signals once this auction's <c>TestNewAuction</c> has fully returned. The countdown is how
+        /// <see cref="ProcessBatchAndWait"/> knows a whole batch has drained without ever calling
+        /// <c>CompleteAdding</c> (which is terminal). When <see cref="batch"/> is null the item is fire-and-forget
+        /// (the legacy <see cref="Enqueue"/> path); the same struct serves both so routing/serialization is identical.
+        /// </summary>
+        private readonly struct WorkItem
+        {
+            public readonly SaveAuction Auction;
+            public readonly CountdownEvent Batch;
+            public WorkItem(SaveAuction auction, CountdownEvent batch)
+            {
+                Auction = auction;
+                Batch = batch;
+            }
+        }
+
+        private readonly SniperService service;
+        private readonly BlockingCollection<WorkItem>[] queues;
+        private readonly Thread[] workers;
+        private readonly bool triggerEvents;
+        private readonly bool fastMode;
+        private long processed;
+        private volatile Exception workerError;
+
+        // --- R8 WS-SHARD-OBS: shard-balance observability (see class summary) ---
+        // Process-global metric declarations (static readonly, declared once; same name+labels returns the same metric
+        // across dispatcher instances — the per-shard label disambiguates shards within one process).
+        private static readonly Counter ShardProcessedTotal = Metrics.CreateCounter(
+            "sky_sniper_shard_processed_total",
+            "Per-shard-worker count of auctions handed to TestNewAuction (shard-balance / hot-tag-skew signal)",
+            new CounterConfiguration { LabelNames = new[] { "shard" } });
+        private static readonly Gauge ShardQueueDepth = Metrics.CreateGauge(
+            "sky_sniper_shard_queue_depth",
+            "Current in-flight queue backlog per shard worker (inc on enqueue, dec after dequeue+process)",
+            new GaugeConfiguration { LabelNames = new[] { "shard" } });
+
+        // Per-instance, pre-resolved per-shard child handles (indexed by worker idx) so the snipe hot path never calls
+        // WithLabels per auction. Built in the constructor loop where the queues/workers are created.
+        private readonly Counter.Child[] perShardProcessed;
+        private readonly Gauge.Child[] perShardDepth;
+
+        /// <summary>Number of shard workers (and queues).</summary>
+        public int WorkerCount { get; }
+
+        /// <summary>Total auctions drained and handed to <see cref="SniperService.TestNewAuction"/> across all workers.</summary>
+        public long Processed => Interlocked.Read(ref processed);
+
+        /// <param name="service">The single shared service. Its cross-tag structures are already concurrent; only one
+        /// worker ever mutates a given tag's PriceLookup because routing is by resolved group tag.</param>
+        /// <param name="workerCount">Number of parallel shard workers.</param>
+        /// <param name="triggerEvents">Forwarded to <c>TestNewAuction</c> (the snipe-finding hot path uses true).</param>
+        /// <param name="fastMode">Forwarded to <c>TestNewAuction</c>.</param>
+        /// <param name="queueBound">Optional per-queue bound for back-pressure; 0/unset = unbounded.</param>
+        public ShardedAuctionDispatcher(SniperService service, int workerCount, bool triggerEvents = true,
+            bool fastMode = false, int queueBound = 0)
+        {
+            if (workerCount < 1) throw new ArgumentOutOfRangeException(nameof(workerCount));
+            this.service = service ?? throw new ArgumentNullException(nameof(service));
+            this.triggerEvents = triggerEvents;
+            this.fastMode = fastMode;
+            WorkerCount = workerCount;
+
+            queues = new BlockingCollection<WorkItem>[workerCount];
+            workers = new Thread[workerCount];
+            // R8 WS-SHARD-OBS: pre-resolve per-shard metric children once (no per-auction WithLabels on the hot path).
+            perShardProcessed = new Counter.Child[workerCount];
+            perShardDepth = new Gauge.Child[workerCount];
+            for (int i = 0; i < workerCount; i++)
+            {
+                queues[i] = queueBound > 0
+                    ? new BlockingCollection<WorkItem>(queueBound)
+                    : new BlockingCollection<WorkItem>();
+                perShardProcessed[i] = ShardProcessedTotal.WithLabels(i.ToString());
+                perShardDepth[i] = ShardQueueDepth.WithLabels(i.ToString());
+            }
+            for (int i = 0; i < workerCount; i++)
+            {
+                int idx = i;
+                workers[i] = new Thread(() => WorkerLoop(idx))
+                {
+                    IsBackground = true,
+                    Name = $"snipe-shard-{idx}"
+                };
+                workers[i].Start();
+            }
+        }
+
+        /// <summary>
+        /// Routes <paramref name="auction"/> to the worker that owns its resolved group tag. Blocks only if the target
+        /// queue is bounded and full. The same group tag always lands on the same worker, so its PriceLookup is never
+        /// mutated by two threads.
+        /// </summary>
+        public void Enqueue(SaveAuction auction)
+        {
+            int shard = ShardFor(auction.Tag);
+            // R8 WS-SHARD-OBS: count this item into the target shard's backlog before it is added (dec'd after process).
+            perShardDepth[shard].Inc();
+            queues[shard].Add(new WorkItem(auction, null));
+        }
+
+        /// <summary>
+        /// Enqueues an entire Kafka batch across the shard workers (each auction routed to the worker that owns its
+        /// resolved group tag, exactly as <see cref="Enqueue"/>) and BLOCKS until every auction in the batch has been
+        /// fully processed by its worker. This is the production batch primitive: the caller (the Kafka batch callback)
+        /// must not return until the batch has drained, otherwise the offset would commit before processing — breaking
+        /// at-least-once. Unlike <see cref="Complete"/>/<see cref="WaitForCompletion"/> this does NOT terminate the
+        /// queues, so the same dispatcher instance is reused for every batch for the lifetime of the consumer.
+        ///
+        /// <para>The per-tag-serial invariant is unchanged: items still route by resolved group tag, so a given tag is
+        /// processed by exactly one worker in submission order. Within a batch, two auctions of the same tag keep their
+        /// relative submission order (single queue, FIFO), so the snipe set is bit-identical to single-threaded —
+        /// the only non-determinism is the cross-tag interleaving, which touches commutative/idempotent shared state.</para>
+        ///
+        /// <para>On cancellation (<paramref name="cancellationToken"/>), this returns early WITHOUT having waited for the
+        /// full drain; the caller must then NOT let the offset commit (it propagates the cancellation by throwing). Items
+        /// already enqueued keep being processed by the workers — clean <see cref="Dispose"/> joins them so nothing is
+        /// dropped mid-flight; the uncommitted offset means Kafka re-delivers the batch (at-least-once).</para>
+        /// </summary>
+        /// <param name="auctions">The auctions in this Kafka batch.</param>
+        /// <param name="cancellationToken">Cancelled on shutdown; aborts the wait (the batch must then not commit).</param>
+        /// <returns><c>true</c> if the whole batch drained (safe to commit); <c>false</c> if cancelled before drain.</returns>
+        public bool ProcessBatchAndWait(IEnumerable<SaveAuction> auctions, CancellationToken cancellationToken = default)
+        {
+            if (auctions == null) throw new ArgumentNullException(nameof(auctions));
+            // Materialize so we know the exact count and can route each item; the count seeds the countdown.
+            var list = auctions as IReadOnlyList<SaveAuction> ?? new List<SaveAuction>(auctions);
+            if (list.Count == 0)
+                return true;
+
+            // +1 initial count so we can enqueue all items before any worker can drive the countdown to zero; we
+            // Signal() once after enqueueing to remove the guard. Workers Signal() once per processed auction.
+            // NOTE: not a `using` — on cancellation, workers still hold WorkItems referencing this countdown and will
+            // Signal() it after we return. We only Dispose() once we KNOW the batch fully drained (no in-flight item
+            // can touch it); on the cancellation path we leave it for finalization (the worker Signal() is guarded).
+            var done = new CountdownEvent(list.Count + 1);
+            for (int i = 0; i < list.Count; i++)
+            {
+                int shard = ShardFor(list[i].Tag);
+                // R8 WS-SHARD-OBS: count this item into the target shard's backlog before it is added (dec'd after process).
+                perShardDepth[shard].Inc();
+                queues[shard].Add(new WorkItem(list[i], done));
+            }
+            done.Signal(); // remove the enqueue guard; now only worker completions remain
+
+            // Block until every item is processed, or until cancellation. Surface a worker fault so a partial (wrong)
+            // batch never commits — and CLEAR it (per-batch scoped) so a single bad auction does not poison every
+            // subsequent batch for the lifetime of the long-lived production dispatcher.
+            bool drained;
+            try
+            {
+                drained = done.Wait(Timeout.Infinite, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancelled mid-drain: do NOT dispose `done` (in-flight workers still Signal it). The batch did not
+                // fully drain on this call; the caller must not commit. Re-throw so the consumer treats it as cancel.
+                throw;
+            }
+            if (drained)
+                done.Dispose();
+            var fault = Interlocked.Exchange(ref workerError, null);
+            if (fault != null)
+                throw new AggregateException("A shard worker faulted", fault);
+            return drained;
+        }
+
+        /// <summary>The worker index that owns <paramref name="tag"/> (after group-tag resolution). Public so the
+        /// harness can pre-bucket a workload and assert routing stability.</summary>
+        public int ShardFor(string tag)
+        {
+            var groupTag = service.GetAuctionGroupTag(tag).tag;
+            // FNV-1a over the resolved group tag: stable across runs/processes, no dependence on string.GetHashCode's
+            // per-process randomization, so the same tag deterministically maps to the same shard.
+            uint hash = 2166136261u;
+            for (int i = 0; i < groupTag.Length; i++)
+            {
+                hash ^= groupTag[i];
+                hash *= 16777619u;
+            }
+            return (int)(hash % (uint)WorkerCount);
+        }
+
+        /// <summary>Signals that no more auctions will be enqueued. After this, drain with
+        /// <see cref="WaitForCompletion"/>.</summary>
+        public void Complete()
+        {
+            foreach (var q in queues)
+                q.CompleteAdding();
+        }
+
+        /// <summary>Joins all worker threads (call after <see cref="Complete"/>). Rethrows the first worker exception,
+        /// if any, so failures never silently produce a wrong (partial) snipe set.</summary>
+        public void WaitForCompletion()
+        {
+            foreach (var t in workers)
+                t.Join();
+            if (workerError != null)
+                throw new AggregateException("A shard worker faulted", workerError);
+        }
+
+        private void WorkerLoop(int idx)
+        {
+            // R8 WS-SHARD-OBS: cache this worker's pre-resolved per-shard metric children once per loop (no per-auction
+            // WithLabels resolution on the hot path). The global `processed`/`Processed` counter below is left exactly
+            // as-is; these are additive, observation-only increments.
+            var shardProcessed = perShardProcessed[idx];
+            var shardDepth = perShardDepth[idx];
+            foreach (var item in queues[idx].GetConsumingEnumerable())
+            {
+                try
+                {
+                    service.TestNewAuction(item.Auction, triggerEvents, fastMode);
+                    Interlocked.Increment(ref processed);
+                    shardProcessed.Inc(); // R8 WS-SHARD-OBS: per-worker throughput (in addition to the global counter)
+                }
+                catch (Exception e)
+                {
+                    // First fault wins; surfaced from WaitForCompletion / ProcessBatchAndWait. We DON'T abandon the loop:
+                    // the production consumer reuses this dispatcher across batches, and a single bad auction must not
+                    // permanently kill a worker (which would silently drop every future auction routed to its tags).
+                    // Record the error and keep processing; ProcessBatchAndWait rethrows it so the offending batch never
+                    // commits. We still count it as processed so the per-batch countdown can complete and the consumer
+                    // can surface the fault instead of hanging.
+                    Interlocked.CompareExchange(ref workerError, e, null);
+                    Interlocked.Increment(ref processed);
+                    shardProcessed.Inc(); // R8 WS-SHARD-OBS: count the faulted-but-counted item on this shard too
+                }
+                finally
+                {
+                    // R8 WS-SHARD-OBS: this item has left the queue and been processed — drop it from the shard's
+                    // in-flight backlog (mirrors the inc-on-enqueue; runs once per item even on a TestNewAuction fault).
+                    shardDepth.Dec();
+                    // Always signal the batch countdown — even on a TestNewAuction fault — so ProcessBatchAndWait never
+                    // deadlocks waiting on an item that threw. Guard against a disposed countdown (only possible if a
+                    // batch was both drained-and-disposed and somehow still had an in-flight item; defensive).
+                    try { item.Batch?.Signal(); } catch (ObjectDisposedException) { }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            // Best-effort: ensure adding is completed so worker threads can exit even if the caller forgot Complete().
+            foreach (var q in queues)
+            {
+                try { if (!q.IsAddingCompleted) q.CompleteAdding(); } catch { /* already disposed */ }
+            }
+            foreach (var t in workers)
+            {
+                if (t.IsAlive) t.Join();
+            }
+            foreach (var q in queues)
+                q.Dispose();
+        }
+    }
+}

--- a/Services/SniperService.Tests.cs
+++ b/Services/SniperService.Tests.cs
@@ -88,7 +88,7 @@ namespace Coflnet.Sky.Sniper
             craftCost = new CraftCostMock();
             // console logger
             var factory = LoggerFactory.Create(builder => builder.AddConsole());
-            itemService = new(null, null);
+            itemService = new(null, NullLogger<HypixelItemService>.Instance);
             service = new SniperService(itemService, null, factory.CreateLogger<SniperService>(), craftCost);
 
             IdCounter = 100; // magic number
@@ -1398,6 +1398,52 @@ namespace Coflnet.Sky.Sniper
             a.StartingBid = 5;
             service.TestNewAuction(a);
             Assert.That(1000, Is.EqualTo(found.First().TargetPrice));
+        }
+
+        [Test]
+        public void ClosestCandidateIndex_SurvivesChurn_BitExact()
+        {
+            // WS-A soak: with the parity guard on, FindClosestTo cross-checks its contiguous-index arg-max against a
+            // fresh dict scan at the same instant and throws on any divergence. Drive build -> churn (a brand-new
+            // priced bucket appears, bumping the pricing epoch) -> rebuild, and prove the rebuilt index still contains
+            // every candidate (the new-bucket trap that the reverted dominance-set caching fell into).
+            SniperService.VerifyClosestIndex = true;
+            try
+            {
+                service.State = SniperState.FullyLoaded; // closest/risky finder only runs once Ready+
+                SetBazaarPrice("ENCHANTMENT_ULTIMATE_CHIMERA_1", 100_000_000);
+                SetBazaarPrice("ENCHANTMENT_SHARPNESS_6", 10_000_000);
+                SetBazaarPrice("ENCHANTMENT_GROWTH_6", 5_000_000);
+                var chimera = new Core.Enchantment(Enchantment.EnchantmentType.ultimate_chimera, 1);
+
+                var a = Dupplicate(highestValAuction);
+                a.Enchantments = new List<Core.Enchantment> { chimera };
+                for (int i = 0; i < 4; i++) service.AddSoldItem(Dupplicate(a));
+
+                // novel combo with no exact bucket -> routes through the closest search, building the candidate index
+                var q = Dupplicate(highestValAuction);
+                q.Enchantments = new List<Core.Enchantment> { chimera, new Core.Enchantment(Enchantment.EnchantmentType.sharpness, 6) };
+                q.StartingBid = 5;
+                service.TestNewAuction(q);
+
+                var lookup = service.Lookups.Values.FirstOrDefault(l => l.CandidateIndex != null);
+                Assert.That(lookup, Is.Not.Null, "closest search should have built a candidate index");
+                var countBefore = lookup.CandidateIndex.Count;
+
+                // churn: a brand-new priced bucket appears (epoch bump). The next closest search must rebuild and
+                // include it; if the rebuild dropped it, AssertClosestParity throws inside TestNewAuction below.
+                var b = Dupplicate(highestValAuction);
+                b.Enchantments = new List<Core.Enchantment> { chimera, new Core.Enchantment(Enchantment.EnchantmentType.growth, 6) };
+                for (int i = 0; i < 4; i++) service.AddSoldItem(Dupplicate(b));
+
+                var q2 = Dupplicate(q);
+                q2.StartingBid = 5;
+                service.TestNewAuction(q2);
+
+                Assert.That(lookup.CandidateIndex.Count, Is.GreaterThan(countBefore),
+                    "rebuilt index must include the newly-priced bucket");
+            }
+            finally { SniperService.VerifyClosestIndex = false; }
         }
 
         [Test]
@@ -3805,6 +3851,92 @@ namespace Coflnet.Sky.Sniper
                               $"drill-new: {drillNewMs:F1}ms ({drillNewMs * 1e6 / N:F0}ns/call)" +
                               $"  alias-overhead: {(nonDrillMs - drillOldMs) * 1e6 / N:F0}ns/call  sink={sink}");
             Assert.Fail("See console output above");
+        }
+
+        /// <summary>
+        /// R7 WS-TELEM bit-exactness gate. The per-auction telemetry string/JSON builds were tightened from
+        /// <c>activity != null</c> to <c>activity is { IsAllDataRequested: true }</c> so a non-recording
+        /// (propagation-only) listener pays ~0, while a recording listener emits the byte-identical event. With an
+        /// <see cref="ActivitySamplingResult.AllDataAndRecorded"/> listener attached, <c>IsAllDataRequested</c> is
+        /// true, so the gate opens exactly as the original <c>!= null</c> did and the captured "BaseKey value …"
+        /// event MUST equal the freshly-serialized breakdown (the same expression the production line builds).
+        /// </summary>
+        [Test]
+        public void TelemetryBaseKeyEventByteIdenticalWhenRecording()
+        {
+            using var source = new ActivitySource("ws-telem-test");
+            var captured = new List<Activity>();
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = s => s == source,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = captured.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var factory = LoggerFactory.Create(builder => builder.AddConsole());
+            var tracedService = new SniperService(itemService, source, factory.CreateLogger<SniperService>(), craftCost);
+            var tracedFound = new List<LowPricedAuction>();
+            tracedService.FoundSnipe += tracedFound.Add;
+
+            // Build a priced bucket then a below-market listing so TestNewAuctionInternal runs to completion and emits
+            // the terminal "BaseKey value {json}" event.
+            highestValAuction.FlatenedNBT = new();
+            highestValAuction.Enchantments = new List<Core.Enchantment>();
+            highestValAuction.Tag = "CRYPT_DREADLORD_SWORD";
+            highestValAuction.HighestBidAmount = 4_000_000;
+            highestValAuction.Enchantments.Add(new Core.Enchantment(Enchantment.EnchantmentType.scavenger, 5));
+            for (int i = 0; i < 4; i++)
+                tracedService.AddSoldItem(Dupplicate(highestValAuction));
+            foreach (var lookup in tracedService.Lookups)
+                foreach (var item in lookup.Value.Lookup)
+                    tracedService.UpdateMedian(item.Value, (lookup.Key, tracedService.GetBreakdownKey(item.Key, lookup.Key)));
+
+            var snipe = Dupplicate(highestValAuction);
+            snipe.StartingBid = 1_000;
+            snipe.HighestBidAmount = 1_000;
+            snipe.Bin = true;
+            snipe.End = DateTime.UtcNow + TimeSpan.FromDays(10);
+            tracedService.State = SniperState.FullyLoaded;
+
+            tracedService.TestNewAuction(snipe);
+
+            var tnaActivity = captured.LastOrDefault(a => a.OperationName == "TestNewAuction");
+            Assert.That(tnaActivity, Is.Not.Null, "TestNewAuction span must be created when a listener is attached");
+            var baseKeyEvent = tnaActivity.Events.FirstOrDefault(e =>
+                (e.Tags.FirstOrDefault(t => t.Key == "message").Value?.ToString() ?? "").StartsWith("BaseKey value "));
+            var emittedMessage = baseKeyEvent.Tags.FirstOrDefault(t => t.Key == "message").Value?.ToString();
+            Assert.That(emittedMessage, Is.Not.Null, "BaseKey value event must be emitted when recording");
+
+            // The exact string the (un-gated) production line would have built — proves byte-identity.
+            var expected = "BaseKey value " + JsonConvert.SerializeObject(tracedService.ValueKeyForTest(Dupplicate(snipe)).ValueBreakdown);
+            Assert.That(emittedMessage, Is.EqualTo(expected),
+                "Recording-path telemetry event must be byte-identical to the freshly-serialized breakdown");
+
+            // Non-recording (propagation-only) listener: IsAllDataRequested is false, so the gated string/JSON build
+            // must be skipped and no "BaseKey value …" event retained — the disabled-path-pays-nothing property.
+            using var source2 = new ActivitySource("ws-telem-test-noprop");
+            var captured2 = new List<Activity>();
+            using var listener2 = new ActivityListener
+            {
+                ShouldListenTo = s => s == source2,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.PropagationData,
+                ActivityStopped = captured2.Add
+            };
+            ActivitySource.AddActivityListener(listener2);
+            var nonRecService = new SniperService(itemService, source2, factory.CreateLogger<SniperService>(), craftCost);
+            nonRecService.FoundSnipe += _ => { };
+            for (int i = 0; i < 4; i++)
+                nonRecService.AddSoldItem(Dupplicate(highestValAuction));
+            foreach (var lookup in nonRecService.Lookups)
+                foreach (var item in lookup.Value.Lookup)
+                    nonRecService.UpdateMedian(item.Value, (lookup.Key, nonRecService.GetBreakdownKey(item.Key, lookup.Key)));
+            nonRecService.State = SniperState.FullyLoaded;
+            Assert.DoesNotThrow(() => nonRecService.TestNewAuction(Dupplicate(snipe)),
+                "Non-recording telemetry path must not throw");
+            Assert.That(captured2.SelectMany(a => a.Events).All(e =>
+                    !(e.Tags.FirstOrDefault(t => t.Key == "message").Value?.ToString() ?? "").StartsWith("BaseKey value ")),
+                Is.True, "Non-recording listener must retain no BaseKey value event (build skipped)");
         }
     }
 

--- a/Services/SniperService.cs
+++ b/Services/SniperService.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Logging;
 using System.Globalization;
 using System.Threading;
 using System.Runtime.CompilerServices;
+using System.Buffers;
+using System.Runtime.InteropServices;
 
 namespace Coflnet.Sky.Sniper.Services
 {
@@ -55,12 +57,122 @@ namespace Coflnet.Sky.Sniper.Services
         private readonly ConcurrentDictionary<(string, AuctionKey), (PriceEstimate result, DateTime addedAt)> ClosetMedianMapLookup = new();
         private readonly ConcurrentDictionary<(string, AuctionKey), (ReferencePrice result, DateTime addedAt)> HigherValueLbinMapLookup = new();
         private readonly ConcurrentDictionary<ModifierLookupKey, (RankElem, DateTime)> ModifierValueLookup = new();
+        private readonly ConcurrentDictionary<(string, AuctionKey), (List<RankElem> value, DateTime addedAt)> ComparisonValueLookup = new();
+        // Columnar/interned score vectors for the closest-match kernel, derived 1:1 from ComparisonValueForKey. One
+        // shared interner keeps ids consistent across every vec compared together. Swept on the same cadence as the
+        // value caches it derives from (see FinishedUpdate).
+        private readonly ClosestScoreKernel.Interner scoreInterner = new();
+        private readonly ConcurrentDictionary<(string, AuctionKey), (ClosestScoreKernel.ScoreVec vec, DateTime addedAt)> ScoreVecLookup = new();
+        // WS-A: monotonic "pricing epoch" bumped on every bucket price transition (the funnel is UpdateMedian, plus a
+        // few out-of-band writes). PriceLookup.CandidateIndex caches the epoch it was built at; a mismatch (or a dict
+        // Count change, or vec-TTL expiry) triggers a rebuild. Service-wide rather than per-lookup so the single bump
+        // in UpdateMedian — which doesn't have the owning PriceLookup on every branch — covers all tags; the snipe
+        // hot path never reprices, so the epoch is stable across the many FindClosestTo calls between sales.
+        private long pricingEpoch;
+        // Reuse window for BOTH the candidate index and the per-bucket vecs it captures (minutes). At half the 10-min vec
+        // freshness bound, reuse-window + index-TTL (<=8 min) stays under it, so a vec reused into the index is never
+        // older at use-time than what a fresh GetBucketScoreVec(now-10min) dict scan would have accepted — making the
+        // index bit-exact with the pre-WS-A per-call scan while avoiding the force-rebuild of every vec on each rebuild
+        // (the latter caused a rare-path allocation regression: novel keys churn the candidate set -> frequent rebuilds).
+        private const double CandidateIndexMaxAgeMinutes = 4;
+        // R6/MEMO2: TTL bound for the GetCleanItemPrice recompute-memo ENTRIES (CleanItemPriceMemo). Gated on the SAME
+        // triggers as the candidate index (pricing epoch + live dict Count + this TTL) PLUS lookup.Volume, applied
+        // PER-ENTRY (not per-window) so the dict is never re-allocated on an epoch bump. Kept identical to the candidate
+        // index so a fresh entry can never reflect a lookup state the candidate/dominator indexes would have rebuilt
+        // for. The memo caches only the PURE recompute output (deterministic for fixed inputs + a matching stamp), so
+        // serving an entry is bit-exact for force + non-force.
+        private const double CleanPriceMemoMaxAgeMinutes = CandidateIndexMaxAgeMinutes;
+        // R6/MEMO2: optional, OFF by default. When on, counts GetCleanItemPrice calls that took the recompute path (memo
+        // miss/build) vs those served by the memo, so the replay can report "recomputes eliminated per auction". Pure
+        // telemetry — never changes the returned value.
+        internal static readonly bool CleanPriceMemoCount
+            = Environment.GetEnvironmentVariable("SNIPER_CLEANPRICE_MEMO_COUNT") is "1" or "true" or "TRUE";
+        // R6/MEMO2 soak/test switch: when on, every memo HIT is cross-checked against a fresh recompute and throws on
+        // divergence (the parity guard, like SNIPER_VERIFY_CLOSEST_INDEX). Off in production (adds a full recompute/hit).
+        internal static readonly bool VerifyCleanPriceMemo
+            = Environment.GetEnvironmentVariable("SNIPER_VERIFY_CLEANPRICE_MEMO") is "1" or "true" or "TRUE";
+        internal static long CleanPriceMemoHits;
+        internal static long CleanPriceMemoRecomputes;
+        // R7/WS-A (+ folded R6 WS-PROBE) — the (contentHash, pricingEpoch) parse memo for DetailedKeyFromSaveAuction.
+        // ONE dict for the whole service lifetime; entries carry their epoch stamp (the R6/MEMO2 entry-epoch pattern —
+        // NEVER realloc the dict per epoch, the clean3-warm lesson). A stale-epoch (or absent) entry is a MISS. The
+        // pricingEpoch rail makes a hit provably bit-exact: CapKeyLength's drop SET is epoch-stable, so within one epoch
+        // the same content caps to the identical AuctionKey + breakdown. Bounded by the FinishedUpdate sweep + epoch.
+        private readonly ParseMemo parseMemo = new();
+        // WS-A: enable the cross-auction parse memo on the hot path. Default OFF (counting-only): the dup number + the
+        // warm A/B decide whether the cross-auction memo earns its keep (see the report). When OFF, the probe still
+        // measures distinct-vs-total + a rolling cross-auction hit-rate; the parse runs unmemoized (bit-identical to the
+        // pre-R7 path). When ON, DetailedKeyFromSaveAuction serves epoch-matching hits from parseMemo.
+        internal static readonly bool ParseMemoEnabled
+            = Environment.GetEnvironmentVariable("SNIPER_PARSE_MEMO") is "1" or "true" or "TRUE";
+        // WS-A/PROBE: count distinct content hashes vs total parses + a rolling-window cross-auction hit-rate (would-be
+        // hits at the current epoch). Pure telemetry; never changes the returned value. Like SNIPER_CLEANPRICE_MEMO_COUNT.
+        internal static readonly bool ParseMemoCount
+            = Environment.GetEnvironmentVariable("SNIPER_PARSE_MEMO_COUNT") is "1" or "true" or "TRUE";
+        // WS-A parity guard (the primary correctness contract): every DetailedKeyFromSaveAuction call computes BOTH the
+        // memoized and a fresh result and asserts equal AuctionKey + breakdown. Off in production (adds a full recompute
+        // per call). Green across COLD + WARM + RARE is the acceptance bar; catches a wrong NonContentKeys exclusion.
+        internal static readonly bool VerifyParseMemo
+            = Environment.GetEnvironmentVariable("SNIPER_VERIFY_PARSE_MEMO") is "1" or "true" or "TRUE";
+        internal static long ParseMemoHits;       // would-be (probe) or actual (enabled) epoch-matching memo hits
+        internal static long ParseMemoMisses;     // full parses run (distinct (hash,epoch) or memo-off)
+        internal static long ParseMemoCalls;      // total DetailedKeyFromSaveAuction invocations counted
+        // Whether ANY parse-memo machinery is active (enabled / counting / verify). When false (the shipped production
+        // default), the per-entry content hashing fused into SelectValuable's traversal is SKIPPED entirely, so the
+        // shipped path is byte-for-byte the pre-R7 parse (zero added hashing cost). When true, the hash shares the one
+        // traversal (the WS-A "fuse, no second pass" rail).
+        internal static readonly bool ParseMemoActive = ParseMemoEnabled || ParseMemoCount || VerifyParseMemo;
+        /// <summary>
+        /// Soak/test switch: when true, <see cref="FindClosestTo"/> cross-checks the contiguous-index arg-max against a
+        /// fresh dictionary scan (<c>FindClosestToReference</c>) and throws on divergence — proves the index never
+        /// drops/adds a candidate (the new-bucket trap) nor mis-scores. Off in production (adds a full extra scan).
+        /// </summary>
+        public static bool VerifyClosestIndex = Environment.GetEnvironmentVariable("SNIPER_VERIFY_CLOSEST_INDEX") == "1";
+        /// <summary>
+        /// R4 soak/test switch: when true, the finder dominator scans (<see cref="GetLbinCap"/>,
+        /// <c>PotentialSnipeHigherValueScan</c>, <c>CheckLowerKeyFull</c>, the median lower-value scan) cross-check their
+        /// flat-index dominator set against a fresh <see cref="IsHigherValue"/> dictionary filter and throw on divergence.
+        /// Off in production. Proves the <see cref="DominatorIndex"/> never drops/adds a candidate vs the live dict.
+        /// </summary>
+        public static bool VerifyDominatorIndex = Environment.GetEnvironmentVariable("SNIPER_VERIFY_DOMINATOR_INDEX") == "1";
         private readonly ConcurrentDictionary<ItemReferences.Reforge, (RankElem, DateTime)> ReforgeValueLookup = new();
         private readonly ConcurrentDictionary<(string, KeyValuePair<string, string>), (long, DateTime)> AttributeValueLookup = new();
 
         private readonly Counter sellClosestSearch = Metrics.CreateCounter("sky_sniper_sell_closest_search", "Number of searches for closest sell");
         private readonly Counter closestMedianBruteCounter = Metrics.CreateCounter("sky_sniper_closest_median_brute", "Number of brute force searches for closest median");
         private readonly Counter closestLbinBruteCounter = Metrics.CreateCounter("sky_sniper_closest_lbin_brute", "Number of brute force searches for closest median");
+
+        // --- Performance instrumentation (latency histograms for profiling/benchmarking) ---
+        // Exponential buckets from ~1µs to ~4s (factor 4, 12 buckets) so both cache hits and brute-force scans land in distinct buckets.
+        private static readonly double[] DurationBuckets = Histogram.ExponentialBuckets(0.000_001, 4, 12);
+        private readonly Histogram getPriceDuration = Metrics.CreateHistogram(
+            "sky_sniper_get_price_duration_seconds", "Wall-clock duration of SniperService.GetPrice",
+            new HistogramConfiguration { Buckets = DurationBuckets });
+        private readonly Histogram closestMedianSearchDuration = Metrics.CreateHistogram(
+            "sky_sniper_closest_median_search_duration_seconds", "Wall-clock duration of the brute-force closest-median search",
+            new HistogramConfiguration { Buckets = DurationBuckets });
+        private readonly Histogram closestLbinSearchDuration = Metrics.CreateHistogram(
+            "sky_sniper_closest_lbin_search_duration_seconds", "Wall-clock duration of the brute-force closest-lbin search",
+            new HistogramConfiguration { Buckets = DurationBuckets });
+        // Snipe-finding (ingest) path: latency of the per-auction find and its core finder, plus a throughput counter.
+        private readonly Histogram testNewAuctionDuration = Metrics.CreateHistogram(
+            "sky_sniper_test_new_auction_duration_seconds", "Wall-clock duration of TestNewAuction (snipe-finding per incoming auction)",
+            new HistogramConfiguration { Buckets = DurationBuckets });
+        private readonly Histogram findFlipDuration = Metrics.CreateHistogram(
+            "sky_sniper_find_flip_duration_seconds", "Wall-clock duration of FindFlip (the core matched-bucket finder)",
+            new HistogramConfiguration { Buckets = DurationBuckets });
+        private readonly Counter snipesFoundCounter = Metrics.CreateCounter(
+            "sky_sniper_snipes_found_total", "Snipes/flips emitted by FoundAFlip, labelled by finder type",
+            new CounterConfiguration { LabelNames = new[] { "finder" } });
+
+        /// <summary>
+        /// When enabled, <see cref="GetPrice"/> and the brute-force closest searches emit per-call timing logs.
+        /// Toggleable at runtime, or via the <c>SNIPER_PROFILE_VERBOSE=1</c> environment variable.
+        /// Intended for local/staging profiling; leave off in production to avoid log spam (timing always feeds the
+        /// Prometheus histograms and trace spans regardless of this flag).
+        /// </summary>
+        public static bool VerboseProfiling { get; set; }
+            = Environment.GetEnvironmentVariable("SNIPER_PROFILE_VERBOSE") is "1" or "true" or "TRUE";
         private IMayorService mayorService;
         private int pauseFlipFindingCount;
         private readonly ConcurrentDictionary<string, int> pausedFlipFindingTags = new(StringComparer.Ordinal);
@@ -135,8 +247,39 @@ namespace Coflnet.Sky.Sniper.Services
                     continue;
                 CapBucketSize(item.Value);
                 UpdateMedian(item.Value, (itemTag, GetBreakdownKey(item.Key, itemTag)));
-                GetLbinCap(itemTag, lookup.Lookup, item.Key);
+                GetLbinCap(itemTag, lookup, item.Key);
             }
+        }
+
+        /// <summary>
+        /// R5 P2 write-path benchmark entry point (used only by the SNIPE_REPLAY_WRITE replay mode). Runs the repricing
+        /// of a SINGLE bucket exactly as <see cref="RefreshLookup"/>'s loop body does — <c>CapBucketSize</c> +
+        /// <c>UpdateMedian(bucket, (tag, GetBreakdownKey(key, tag)))</c> + <c>GetLbinCap</c> — so the isolating harness
+        /// drives the real production repricing primitive rather than a copy of it. Behavior-neutral: it only re-runs
+        /// the same calls RefreshLookup already makes, so it changes no emitted snipe/price (it does not exist on any
+        /// production path). <paramref name="lookup"/> may be null (GetLbinCap is then skipped, as RefreshLookup never
+        /// passes null but the harness only resolves it best-effort).
+        /// </summary>
+        internal void UpdateMedian_DriveForBench(string itemTag, AuctionKey key, ReferenceAuctions bucket, PriceLookup lookup)
+        {
+            CapBucketSize(bucket);
+            UpdateMedian(bucket, (itemTag, GetBreakdownKey(key, itemTag)));
+            if (lookup != null)
+                GetLbinCap(itemTag, lookup, key);
+        }
+
+        /// <summary>
+        /// R6 WS-LOH benchmark entry point (used only by the deterministic LOH probe in the replay harness). Forces a
+        /// FULL <see cref="GetOrBuildCandidateIndex"/> rebuild — exactly the per-auction work a novel-key (rare-path)
+        /// auction triggers — by bumping the pricing epoch (the production invalidation trigger) before the build, so the
+        /// cache always misses and the columns are re-allocated. Returns the rebuilt index's <c>Count</c>. Behavior-
+        /// neutral: it only re-runs the same private build production already performs (it exists on no production path);
+        /// the epoch bump is the same one any out-of-band price write issues.
+        /// </summary>
+        internal int BuildCandidateIndex_DriveForBench(string itemTag, PriceLookup lookup)
+        {
+            Interlocked.Increment(ref pricingEpoch); // force a cache miss -> a real rebuild (the rare-path cost)
+            return GetOrBuildCandidateIndex(lookup, itemTag).Count;
         }
 
         public void MockFoundFlip(LowPricedAuction auction)
@@ -281,7 +424,7 @@ namespace Coflnet.Sky.Sniper.Services
             "candyUsed",
         };
 
-        private static readonly HashSet<string> ImportantCakeYears = new()
+        internal static readonly HashSet<string> ImportantCakeYears = new()
         { "69", "420", "400"};
 
         private readonly struct RemovableItemKey
@@ -404,6 +547,14 @@ namespace Coflnet.Sky.Sniper.Services
             {
                 ModifierValueLookup.TryRemove(item.Key, out _);
             }
+            foreach (var item in ComparisonValueLookup.Where(c => c.Value.addedAt < removeBefore).ToList())
+            {
+                ComparisonValueLookup.TryRemove(item.Key, out _);
+            }
+            foreach (var item in ScoreVecLookup.Where(c => c.Value.addedAt < removeBefore).ToList())
+            {
+                ScoreVecLookup.TryRemove(item.Key, out _);
+            }
             foreach (var item in AttributeValueLookup.Where(c => c.Value.Item2 < removeBefore).ToList())
             {
                 AttributeValueLookup.TryRemove(item.Key, out _);
@@ -421,6 +572,18 @@ namespace Coflnet.Sky.Sniper.Services
             foreach (var item in ReforgeValueLookup.Where(c => c.Value.Item2 < removeBefore).ToList())
             {
                 ReforgeValueLookup.TryRemove(item.Key, out _);
+            }
+            // WS-A: bound the parse memo. A stale-epoch entry is already a read-MISS (never served), so this is purely a
+            // memory bound — drop every entry whose epoch is no longer the current pricing epoch (it can never hit again
+            // until overwritten by a fresh parse, which the dict supports in place). One dict for the lifetime; never
+            // re-allocated (the clean3-warm lesson) — only its dead entries are pruned here on the 10-min cadence.
+            if (ParseMemoEnabled || VerifyParseMemo)
+            {
+                var currentEpoch = Interlocked.Read(ref pricingEpoch);
+                foreach (var item in parseMemo.Values.Where(c => c.Value.Epoch != currentEpoch).ToList())
+                {
+                    parseMemo.Values.TryRemove(item.Key, out _);
+                }
             }
         }
 
@@ -445,7 +608,7 @@ namespace Coflnet.Sky.Sniper.Services
                     item.SellTime = (short)(auction.Start - auction.End.Date).TotalMinutes;
                     bucket.Lbins.Add(item);
                     bucket.Lbins.Sort(ReferencePrice.Compare);
-                    if (bucket.Lbins.First().AuctionId == item.AuctionId)
+                    if (bucket.Lbins.First().AuctionId == item.AuctionId && (logger?.IsEnabled(LogLevel.Information) ?? false))
                     {
                         logger.LogInformation($"New lowest lbin {auction.Uuid} {auction.StartingBid} from {bucket.Lbins.Skip(1).FirstOrDefault().Price}");
                     }
@@ -455,7 +618,8 @@ namespace Coflnet.Sky.Sniper.Services
                     lookup.Category = auction.Category;
                 }
             }
-            logger.LogInformation($"Finished processing {count} lbin updates");
+            if (logger?.IsEnabled(LogLevel.Information) ?? false)
+                logger.LogInformation($"Finished processing {count} lbin updates");
         }
 
         private readonly Dictionary<string, string> ModifierItemPrefixes = new()
@@ -532,7 +696,8 @@ ORDER BY l.`AuctionId`  DESC;
         {
             this.FoundSnipe += la =>
             {
-                if (la.Finder == LowPricedAuction.FinderType.SNIPER && (float)la.Auction.StartingBid / la.TargetPrice < 0.8 && la.TargetPrice > 1_000_000)
+                if (la.Finder == LowPricedAuction.FinderType.SNIPER && (float)la.Auction.StartingBid / la.TargetPrice < 0.8 && la.TargetPrice > 1_000_000
+                    && (logger?.IsEnabled(LogLevel.Information) ?? false))
                     logger.LogInformation($"A: {la.Auction.Uuid} {la.Auction.StartingBid} -> {la.TargetPrice}  {KeyFromSaveAuction(la.Auction)}");
             };
             foreach (var item in AttributeCombos.ToList())
@@ -635,6 +800,30 @@ ORDER BY l.`AuctionId`  DESC;
 
         public PriceEstimate GetPrice(SaveAuction auction)
         {
+            using var activity = activitySource?.StartActivity("GetPrice", ActivityKind.Internal);
+            var startTimestamp = Stopwatch.GetTimestamp();
+            try
+            {
+                var result = GetPriceInternal(auction);
+                if (activity != null)
+                {
+                    activity.SetTag("sky.item_tag", auction?.Tag);
+                    activity.SetTag("sky.median", result?.Median);
+                    activity.SetTag("sky.volume", result?.Volume);
+                }
+                return result;
+            }
+            finally
+            {
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+                getPriceDuration.Observe(elapsed.TotalSeconds);
+                if (VerboseProfiling)
+                    logger?.LogInformation("[profile] GetPrice tag={Tag} took {Micros:F1}µs", auction?.Tag, elapsed.TotalMicroseconds);
+            }
+        }
+
+        private PriceEstimate GetPriceInternal(SaveAuction auction)
+        {
             if (auction == null || auction.Tag == null)
                 return null;
             if (BazaarPrices.TryGetValue(auction.Tag, out var bazaar))
@@ -689,7 +878,7 @@ ORDER BY l.`AuctionId`  DESC;
                 var now = DateTime.UtcNow;
                 var res = ClosetMedianMapLookup
                             .GetOrAdd(((string, AuctionKey))(auction.Tag, itemKey),
-                                      _ => GetEstimatedMedian(auction, result, l, detailedKey, gemVal, now));
+                                      _ => GetEstimatedMedian(auction, result, lookup, detailedKey, gemVal, now));
                 if (res.addedAt != now)
                 {
                     result.Median = res.result.Median;
@@ -710,7 +899,7 @@ ORDER BY l.`AuctionId`  DESC;
                     result.LbinKey = res.result.LbinKey;
                 }
             }
-            ReferencePrice lbinCap = GetLbinCap(tagGroup.tag, l, itemKey);
+            ReferencePrice lbinCap = GetLbinCap(tagGroup.tag, lookup, itemKey);
             if (lbinCap.Price != 0 && result.Lbin.Price > lbinCap.Price + fullRemovableVal)
             {
                 result.Lbin = new(lbinCap) { Price = lbinCap.Price + fullRemovableVal };
@@ -733,24 +922,84 @@ ORDER BY l.`AuctionId`  DESC;
             return result;
         }
 
-        public ReferencePrice GetLbinCap(string tag, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey)
+        public ReferencePrice GetLbinCap(string tag, PriceLookup lookup, AuctionKey itemKey)
         {
             var lbinCap = HigherValueLbinMapLookup.GetOrAdd((tag, itemKey), a =>
             {
-                var higherValue = l.Where(k => k.Value.Lbin.Price != 0
-                                    && IsHigherValue(tag, itemKey, k.Key) && k.Key.Reforge == itemKey.Reforge);
-                var MaxValue = higherValue.OrderBy(b => b.Value.Lbin.Price).FirstOrDefault();
-                if (MaxValue.Key == a.Item2)
+                // R4 WS-SHARE: replaces `l.Where(Lbin!=0 && IsHigherValue(itemKey,k) && reforge==).OrderBy(Lbin.Price)
+                // .FirstOrDefault()` with a flat scan of the shared DominatorIndex. Direction A: candidates that DOMINATE
+                // the query item (Dominates(query, cand)). The mask prefilter is a proven-sound necessary condition so it
+                // never drops a true dominator; the exact kernel decides survivors. Bit-exact: the qualifying set is
+                // identical, and a strict-'<' first-wins min over the index (same dict-enumeration order) reproduces the
+                // stable OrderBy(Lbin.Price).FirstOrDefault(). Lbin/reforge read so the result equals the LINQ one:
+                // reforge is key-derived (immutable, cached column); Lbin.Price is read LIVE off the bucket.
+                var index = GetOrBuildDominatorIndex(lookup);
+                var query = DominatorIndex.BuildDomKey(itemKey, scoreInterner);
+                ulong qReq = query.RequiredMask;
+                bool petSpirit = tag == "PET_SPIRIT";
+                int qReforge = (int)itemKey.Reforge;
+                AuctionKey bestKey = null;
+                ReferenceAuctions bestBucket = null;
+                long bestLbin = 0;
+                for (int i = 0; i < index.Count; i++)
+                {
+                    if (index.Reforge[i] != qReforge)
+                        continue;
+                    var bucket = index.Buckets[i];
+                    long lbin = bucket.Lbin.Price; // LIVE
+                    if (lbin == 0)
+                        continue;
+                    if ((qReq & index.ProvidedMask[i]) != qReq)
+                        continue; // sound presence prefilter
+                    if (!DominatorIndex.Dominates(in query, in index.Doms[i], petSpirit))
+                        continue;
+                    if (bestKey is null || lbin < bestLbin) // `is null`, NOT `== null`: AuctionKey.operator== is value
+                    {                                       // equality (returns false for null) — see AuctionKey.cs:408
+                        bestKey = index.Keys[i];
+                        bestBucket = bucket;
+                        bestLbin = lbin;
+                    }
+                }
+                if (VerifyDominatorIndex)
+                    AssertDominatorParity(lookup.Lookup, itemKey, tag, index, baseIsQuery: true);
+                if (bestKey is null)
+                    return (default, DateTime.UtcNow); // OrderBy.FirstOrDefault() of empty -> default KVP
+                if (bestKey == a.Item2)
                     return (default, DateTime.UtcNow); // best match is itself, skip
-                return (MaxValue.Value?.Lbin ?? default, DateTime.UtcNow);
+                return (bestBucket?.Lbin ?? default, DateTime.UtcNow);
             }).result;
             return lbinCap;
         }
 
-        private (PriceEstimate result, DateTime addedAt) GetEstimatedMedian(SaveAuction auction, PriceEstimate result, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, KeyWithValueBreakdown itemKey, long gemVal, DateTime now)
+        private (PriceEstimate result, DateTime addedAt) GetEstimatedMedian(SaveAuction auction, PriceEstimate result, PriceLookup lookup, KeyWithValueBreakdown itemKey, long gemVal, DateTime now)
         {
+            var l = lookup.Lookup;
             closestMedianBruteCounter.Inc();
-            foreach (var c in FindClosest(l, itemKey, auction.Tag))
+            using var searchActivity = activitySource?.StartActivity("ClosestMedianSearch", ActivityKind.Internal);
+            var searchStart = Stopwatch.GetTimestamp();
+            // The consumer takes the FIRST closest candidate that yields Median > 0 (almost always the single top-scored
+            // one). So try the top-1 via a zero-alloc arg-max first; only if it does not produce a positive median do we
+            // materialize+sort the full ordered candidate set (FindClosestOrdered) and continue from the SECOND element.
+            // Bit-exact: ProcessMedianCandidate is the identical per-candidate body, the arg-max top == FindClosestOrdered's
+            // first element (same score, stable first-wins), and the fallback iterates the same order skipping that first.
+            var top = FindClosestArgMax(l, itemKey, auction.Tag);
+            if (top.Key != null)
+            {
+                ProcessMedianCandidate(new KeyValuePair<AuctionKey, ReferenceAuctions>(top.Key, top.Value));
+                if (result.Median <= 0)
+                {
+                    bool skippedTop = false;
+                    foreach (var scored in FindClosestOrdered(l, itemKey, auction.Tag))
+                    {
+                        if (!skippedTop) { skippedTop = true; continue; } // first element already processed by the arg-max
+                        ProcessMedianCandidate(new KeyValuePair<AuctionKey, ReferenceAuctions>(scored.Key, scored.Value));
+                        if (result.Median > 0)
+                            break;
+                    }
+                }
+            }
+
+            void ProcessMedianCandidate(KeyValuePair<AuctionKey, ReferenceAuctions> c)
             {
                 AssignMedian(result, c.Key, c.Value, gemVal);
                 GetDifferenceSum(auction, result, itemKey, c, out var diffExp, out var changeAmount);
@@ -761,7 +1010,7 @@ ORDER BY l.`AuctionId`  DESC;
                     var cleanItemValue = GetCleanItemPrice(auction.Tag, itemKey, lookup);
                     if (changeAmount > result.Median / 4 * 3)
                     {
-                        var closestCraftCost = ComparisonValue(c.Key.Enchants, c.Key.Modifiers.ToList(), auction.Tag, null);
+                        IEnumerable<RankElem> closestCraftCost = ComparisonValueForKey(auction.Tag, c.Key);
                         AddReforgeValue(c.Key.Reforge, ref closestCraftCost);
                         var percentDiff = (float)(cleanItemValue + itemKey.ValueBreakdown.Sum(v => v.Value)) / (cleanItemValue + closestCraftCost.Sum(m => m.Value) + 1);
                         result.Median = (long)(result.Median * Math.Min(percentDiff, 1.5));
@@ -783,34 +1032,82 @@ ORDER BY l.`AuctionId`  DESC;
                         result.MedianKey = key.ToString();
                     }
                 }
-
-                if (Random.Shared.NextDouble() < 0.05)
-                    logger.LogInformation($"no match found for {auction.Tag} {itemKey.Key} options: {l.Count} {c.Key}");
-                if (result.Median > 0)
-                    break;
             }
             if (result.Median > 0)
             {
                 // check lower value keys
-                var lowerValue = l.Where(k => IsHigherValue(auction.Tag, k.Key, itemKey) && k.Key.Reforge == itemKey.Key.Reforge);
-                var MaxValue = lowerValue
-                    .OrderByDescending(b => b.Value.Price).FirstOrDefault();
-                if (MaxValue.Value?.Price > result.Median)
+                // R3-READ: single-pass arg-max over the live dict replaces l.Where(IsHigherValue && Reforge match)
+                //   .OrderByDescending(b => b.Value.Price).FirstOrDefault() — the consumer needs only the highest-priced
+                // higher-value bucket, so the Where/OrderBy/FirstOrDefault chain (predicate/selector closures, a full
+                // sort) is replaced by an arg-max. Bit-exact: same filter, same dict-enumeration order, OrderByDescending
+                // is stable so .FirstOrDefault() picks the first source candidate tied for the max Price, which a
+                // strict-'>' first-wins scan reproduces.
+                AuctionKey maxKey = null;
+                ReferenceAuctions maxBucket = null;
+                long maxPrice = 0;
+                // R4 WS-SHARE: flat scan of the shared DominatorIndex. Direction B: candidates DOMINATED BY the query
+                // (Dominates(cand, query) == IsHigherValue(tag, cand, itemKey)) — i.e. lower-value keys the full item
+                // contains. The implicit KeyWithValueBreakdown->AuctionKey conversion is hoisted once (was the dominant
+                // read-path allocator). Bit-exact: same filter (reforge== AND dominance) over the same dict-enumeration
+                // order, strict-'>' first-wins reproduces the stable OrderByDescending(Price).FirstOrDefault(). Price
+                // read LIVE off each bucket; reforge is the immutable cached column.
+                AuctionKey itemKeyAsKey = itemKey;
+                var index = GetOrBuildDominatorIndex(lookup);
+                var query = DominatorIndex.BuildDomKey(itemKeyAsKey, scoreInterner);
+                ulong qProv = query.ProvidedMask;
+                bool petSpirit = auction.Tag == "PET_SPIRIT";
+                int itemKeyReforge = (int)itemKey.Key.Reforge;
+                for (int i = 0; i < index.Count; i++)
                 {
-                    result.Median = MaxValue.Value.Price;
-                    result.MedianKey += $"+HV-{MaxValue.Key}";
-                    result.Median += itemKey.ValueBreakdown
-                        .Where(m => !MaxValue.Key.Modifiers.Contains(m.Modifier) && !MaxValue.Key.Enchants.Contains(m.Enchant))
-                        .Sum(m => m.IsEstimate ? m.Value / 20 : m.Value) / 9;
+                    if (index.Reforge[i] != itemKeyReforge)
+                        continue;
+                    if ((index.RequiredMask[i] & qProv) != index.RequiredMask[i])
+                        continue; // sound presence prefilter (candidate is the base side)
+                    if (!DominatorIndex.Dominates(in index.Doms[i], in query, petSpirit))
+                        continue;
+                    var bucket = index.Buckets[i];
+                    long price = bucket.Price; // LIVE
+                    if (maxKey is null || price > maxPrice)
+                    {
+                        maxKey = index.Keys[i];
+                        maxBucket = bucket;
+                        maxPrice = price;
+                    }
+                }
+                if (VerifyDominatorIndex)
+                    AssertDominatorParity(l, itemKeyAsKey, auction.Tag, index, baseIsQuery: false);
+                if (maxBucket != null && maxBucket.Price > result.Median)
+                {
+                    result.Median = maxBucket.Price;
+                    result.MedianKey += $"+HV-{maxKey}";
+                    // De-LINQ'd .Where(...).Sum(...): explicit loop over the value breakdown, skipping the modifier/enchant
+                    // already covered by the matched higher-value key. Bit-exact with the original LINQ accumulation.
+                    long add = 0;
+                    var breakdown = itemKey.ValueBreakdown;
+                    for (int bi = 0; bi < breakdown.Count; bi++)
+                    {
+                        var m = breakdown[bi];
+                        if (!maxKey.Modifiers.Contains(m.Modifier) && !maxKey.Enchants.Contains(m.Enchant))
+                            add += m.IsEstimate ? m.Value / 20 : m.Value;
+                    }
+                    result.Median += add / 9;
                 }
             }
+            RecordSearchDuration(closestMedianSearchDuration, searchStart, searchActivity, auction?.Tag, l.Count, "ClosestMedianSearch");
             return (result, now);
         }
 
         private (PriceEstimate result, DateTime addedAt) ClosestLbin(SaveAuction auction, PriceEstimate result, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKeyWithValue itemKey, DateTime now)
         {
             closestLbinBruteCounter.Inc();
-            var closest = GetClosestLbins(l, itemKey).FirstOrDefault();
+            using var searchActivity = activitySource?.StartActivity("ClosestLbinSearch", ActivityKind.Internal);
+            var searchStart = Stopwatch.GetTimestamp();
+            // R3-READ: only the top-1 closest lbin is consumed here, so a single-pass arg-max over the live dict avoids
+            // the LINQ Where().OrderByDescending() (full sort + boxed score keys + delegate closures) GetClosestLbins
+            // built only to take its first element. Byte-identical: OrderByDescending is stable and .FirstOrDefault()
+            // returns the first source element among those tied for the max score, which a strict-'>' first-wins scan
+            // reproduces (same filter, same dict-enumeration order, same float key Similarity(key)+Min(Volume,2)).
+            var closest = ClosestLbinArgMax(l, itemKey);
             if (closest.Key != default)
             {
                 result.Lbin = closest.Value.Lbin;
@@ -832,7 +1129,27 @@ ORDER BY l.`AuctionId`  DESC;
                     result.LbinKey += diffExp;
                 }
             }
+            RecordSearchDuration(closestLbinSearchDuration, searchStart, searchActivity, auction?.Tag, l.Count, "ClosestLbinSearch");
             return (result, now);
+        }
+
+        /// <summary>
+        /// Records the duration of a brute-force closest search to its Prometheus histogram, the active trace span and
+        /// (when <see cref="VerboseProfiling"/> is on) the log. <paramref name="bucketSize"/> is the number of candidate
+        /// keys scanned, which is the dominant cost driver for these O(n·log n) searches.
+        /// </summary>
+        private void RecordSearchDuration(Histogram histogram, long startTimestamp, Activity activity, string tag, int bucketSize, string label)
+        {
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            histogram.Observe(elapsed.TotalSeconds);
+            if (activity != null)
+            {
+                activity.SetTag("sky.item_tag", tag);
+                activity.SetTag("sky.bucket_size", bucketSize);
+                activity.SetTag("sky.duration_us", elapsed.TotalMicroseconds);
+            }
+            if (VerboseProfiling)
+                logger?.LogInformation("[profile] {Label} tag={Tag} buckets={Buckets} took {Micros:F1}µs", label, tag, bucketSize, elapsed.TotalMicroseconds);
         }
 
         public IEnumerable<(AuctionKey, ReferencePrice lbin)> ClosestLbinKeys(string tag, AuctionKey baseKey)
@@ -853,6 +1170,43 @@ ORDER BY l.`AuctionId`  DESC;
         {
             return l.Where(l => l.Key != null && l.Value?.Price > 0 && l.Value?.Lbin.Price > 0)
                             .OrderByDescending(m => itemKey.Similarity(m.Key) + Math.Min(m.Value.Volume, 2));
+        }
+
+        /// <summary>
+        /// R3-READ: zero-alloc single-pass arg-max equivalent of <c>GetClosestLbins(l, itemKey).FirstOrDefault()</c>.
+        /// <see cref="ClosestLbin"/> consumes only the top candidate, so building the whole ordered enumerable (a full
+        /// sort plus a boxed <see cref="float"/> score key and predicate/selector closures per candidate) is wasted.
+        /// Bit-exact with the LINQ form: same candidate filter (<c>Key != null &amp;&amp; Price &gt; 0 &amp;&amp; Lbin.Price &gt; 0</c>),
+        /// same per-candidate score (<c>itemKey.Similarity(key) + Math.Min(Volume, 2)</c>, computed in <see cref="float"/>
+        /// exactly as the LINQ selector), enumerated in the same dictionary order. <c>OrderByDescending</c> is a stable
+        /// sort and <c>.FirstOrDefault()</c> takes the first source element among those tied for the maximum, so a
+        /// strict-greater-than ("first wins") scan returns the identical <see cref="KeyValuePair{TKey,TValue}"/> — and
+        /// <c>default</c> (Key == null) for an empty/no-candidate set, matching <c>FirstOrDefault()</c>.
+        /// </summary>
+        private static KeyValuePair<AuctionKey, ReferenceAuctions> ClosestLbinArgMax(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKeyWithValue itemKey)
+        {
+            // NOTE: AuctionKey overloads operator==/!= to do a *value* compare that returns false for two null
+            // references, so `key == null` does NOT reliably detect a null reference. Use `is null` / `is not null`
+            // (reference checks the overload cannot intercept) for every nullity test here.
+            float bestScore = 0f;
+            AuctionKey bestKey = null;
+            ReferenceAuctions bestBucket = null;
+            foreach (var m in l)
+            {
+                var v = m.Value;
+                if (m.Key is null || !(v?.Price > 0) || !(v.Lbin.Price > 0))
+                    continue;
+                float score = itemKey.Similarity(m.Key) + Math.Min(v.Volume, 2);
+                if (bestKey is null || score > bestScore)
+                {
+                    bestScore = score;
+                    bestKey = m.Key;
+                    bestBucket = v;
+                }
+            }
+            return bestKey is null
+                ? default
+                : new KeyValuePair<AuctionKey, ReferenceAuctions>(bestKey, bestBucket);
         }
 
         private void GetDifferenceSum(SaveAuction auction, PriceEstimate result, AuctionKeyWithValue itemKey, KeyValuePair<AuctionKey, ReferenceAuctions> c, out string diffExp, out long changeAmount)
@@ -953,16 +1307,381 @@ ORDER BY l.`AuctionId`  DESC;
             return 0;
         }
 
-        private KeyValuePair<AuctionKey, ReferenceAuctions> FindClosestTo(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey, string itemTag)
+        /// <summary>
+        /// R4 — the bucket's cached interned <see cref="DomKey"/> for the dominance kernel, built lazily and reused (the
+        /// DomKey is a pure function of the immutable key, so it never goes stale — no TTL). Same cache the
+        /// <see cref="DominatorIndex"/> uses, so a finder scanning Lists (CheckCombined) and the index share one DomKey
+        /// per bucket. Atomic-ref publish (tear-safe).
+        /// </summary>
+        private DomKey GetBucketDomKey(ReferenceAuctions bucket, AuctionKey key)
         {
-            return FindClosest(l, itemKey, itemTag).FirstOrDefault();
+            var box = bucket.DomKeyCache;
+            if (box != null)
+                return box.Value;
+            var dom = DominatorIndex.BuildDomKey(key, scoreInterner);
+            bucket.DomKeyCache = new DomKeyBox(dom);
+            return dom;
+        }
+
+        /// <summary>
+        /// Cached <see cref="ComparisonValue"/> for a stable candidate/query <see cref="AuctionKey"/> on the
+        /// flatNbt-independent path. The brute-force closest searches price every candidate's enchants+modifiers once
+        /// per incoming auction; the keys are stable, so memoizing the breakdown (TTL-swept in
+        /// <see cref="FinishedUpdate"/> like the other value caches) removes the dominant per-candidate cost — and the
+        /// per-modifier <see cref="ModifierLookupKey"/> hashing along with it. The returned list must be treated as
+        /// read-only by callers (the closest searches only read/copy it).
+        /// </summary>
+        private List<RankElem> ComparisonValueForKey(string itemTag, AuctionKey key)
+        {
+            if (ComparisonValueLookup.TryGetValue((itemTag, key), out var cached))
+                return cached.value;
+            var computed = ComparisonValue(key.Enchants, key.Modifiers, itemTag, null)?.ToList() ?? new List<RankElem>();
+            ComparisonValueLookup[(itemTag, key)] = (computed, DateTime.UtcNow);
+            return computed;
+        }
+
+        /// <summary>
+        /// Interned, columnar <see cref="ClosestScoreKernel.ScoreVec"/> for a key, derived 1:1 from
+        /// <see cref="ComparisonValueForKey"/> so the kernel score is bit-exact with <c>AuctionKey.Similarity</c>.
+        /// Cached/TTL-swept like the value caches; uses the shared <see cref="scoreInterner"/> so ids are consistent.
+        /// </summary>
+        private ClosestScoreKernel.ScoreVec ScoreVecForKey(string itemTag, AuctionKey key)
+        {
+            if (ScoreVecLookup.TryGetValue((itemTag, key), out var cached))
+                return cached.vec;
+            var vec = ClosestScoreKernel.Build(key, ComparisonValueForKey(itemTag, key), scoreInterner);
+            ScoreVecLookup[(itemTag, key)] = (vec, DateTime.UtcNow);
+            return vec;
+        }
+
+        /// <summary>
+        /// Score vector for a candidate bucket, cached <b>on the bucket</b> so the closest-search scan reads it with no
+        /// per-candidate dictionary lookup. Rebuilt when older than <paramref name="cutoff"/> (the value-cache TTL) —
+        /// the vec depends only on (tag, key, cross-item prices), so this matches <see cref="ScoreVecForKey"/>'s
+        /// freshness exactly while avoiding the hash+lookup per candidate.
+        /// </summary>
+        private ClosestScoreKernel.ScoreVec GetBucketScoreVec(string itemTag, AuctionKey key, ReferenceAuctions bucket, DateTime cutoff)
+        {
+            var box = bucket.ScoreVecCache; // single atomic read of the reference
+            if (box != null && box.At >= cutoff)
+                return box.Vec;
+            var vec = ClosestScoreKernel.Build(key, ComparisonValueForKey(itemTag, key), scoreInterner);
+            bucket.ScoreVecCache = new ClosestScoreKernel.ScoreVecCache(vec, DateTime.UtcNow); // atomic ref publish
+            return vec;
+        }
+
+        private KeyValuePair<AuctionKey, ReferenceAuctions> FindClosestTo(PriceLookup lookup, AuctionKey itemKey, string itemTag, int maxAge = 8)
+        {
+            // WS-A: single-pass arg-max over a CONTIGUOUS candidate store instead of iterating the ConcurrentDictionary
+            // per auction. Bit-exact with the old dict scan: the index holds exactly the priced, non-virtual buckets a
+            // fresh filter would, each scored by the same ClosestScoreKernel.Score (built 1:1 from ComparisonValueForKey)
+            // with the same '> minDay ? 0 : -10' age adjustment applied at scan time. Strict '>' keeps the first max.
+            // The index is rebuilt only when the candidate set could have changed (pricing epoch or dict Count) or the
+            // vec TTL elapsed; the snipe hot path never reprices, so it is reused across calls — the proven ~2.2x scan
+            // (SoaScanBenchmarks) over the residual ~50-60 ns/bucket of dict-node + heap pointer-chasing.
+            var minDay = GetDay() - maxAge;
+            var queryVec = ScoreVecForKey(itemTag, itemKey); // query isn't a bucket -> small per-call cache
+            var index = GetOrBuildCandidateIndex(lookup, itemTag);
+
+            // WS-C: scalar branch-and-bound prefilter. For each candidate compute a cheap SOUND upper bound
+            // UB = PosCap(query) + PosCap(cand) − exact tier/exp/count penalties (+100·age folded in); if UB/100 can't
+            // beat the running best, the exact kernel can't either (exact ≤ UB), so skip it. Bit-exact with the plain
+            // scan: same first-wins arg-max, pruning only provable losers. Prunes ~46–96% of exact-score calls
+            // (WS-C-SIMD-FINDINGS.md: 2.3×–11× over the contiguous scan), zero extra allocation.
+            var bestScore = long.MinValue;
+            int bestIdx = -1;
+            // R6 WS-LOH: columns are now chunked (per-block <85 KB, off the LOH). The indexer / VecRef(i) hide the
+            // block-offset split; `in index.VecRef(i)` keeps the 112-byte ScoreVec read zero-copy, so the BnB scan is
+            // unchanged byte-for-byte — same age adjust, same upper bound, same first-wins arg-max.
+            int qTier = queryVec.Tier, qCount = queryVec.Count;
+            long qCap = ClosestScoreKernel.PosCap(in queryVec);
+            for (int i = 0; i < index.Count; i++)
+            {
+                ref readonly var vec = ref index.VecRef(i);
+                int age = index.OldestRef[i] > minDay ? 0 : -10;
+                long ub = qCap + index.Cap[i];
+                int dTier = qTier - vec.Tier; int adt = dTier < 0 ? -dTier : dTier;
+                ub -= (long)adt * 11_000_000;
+                if (adt > 0 && vec.HasExpModifier) ub -= 100_000_000;
+                int dc = qCount - vec.Count; ub -= (long)(dc < 0 ? -dc : dc) * 1_000_000;
+                ub += 100L * age; // fold age so ub/100 is an upper bound on Score()+age
+                if (ub / 100 <= bestScore) continue; // provably cannot beat best -> skip the exact kernel
+                long score = ClosestScoreKernel.Score(in queryVec, in vec) + age;
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestIdx = i;
+                }
+            }
+            var best = bestIdx < 0
+                ? default
+                : new KeyValuePair<AuctionKey, ReferenceAuctions>(index.Keys[bestIdx], index.Buckets[bestIdx]);
+
+            if (VerifyClosestIndex)
+                AssertClosestParity(lookup.Lookup, itemKey, itemTag, maxAge, index, bestScore);
+            return best;
+        }
+
+        /// <summary>
+        /// Returns the cached <see cref="ClosestCandidateIndex"/> for <paramref name="lookup"/>, rebuilding it when the
+        /// candidate set could have changed (pricing <see cref="pricingEpoch"/> or live dict Count) or the vec TTL
+        /// (10 min) elapsed. A rebuild force-publishes a fresh <see cref="ClosestScoreKernel.ScoreVec"/> to every
+        /// candidate bucket, all stamped with one build time, so a concurrent dict scan via
+        /// <see cref="GetBucketScoreVec"/> reads back the identical vec for the index's whole &lt;=10 min life — that is
+        /// what keeps the index scan bit-exact with the dict scan (and lets <see cref="AssertClosestParity"/> verify it).
+        /// </summary>
+        private ClosestCandidateIndex GetOrBuildCandidateIndex(PriceLookup lookup, string itemTag)
+        {
+            var l = lookup.Lookup;
+            var epoch = Interlocked.Read(ref pricingEpoch);
+            int liveCount = l.Count;
+            var now = DateTime.UtcNow;
+            var cached = lookup.CandidateIndex; // single atomic read of the reference
+            if (cached != null && cached.BuiltEpoch == epoch && cached.BuiltLookupCount == liveCount
+                && cached.BuiltAt > now.AddMinutes(-CandidateIndexMaxAgeMinutes))
+                return cached;
+
+            // Reuse each bucket's cached vec when it is fresh (<= CandidateIndexMaxAgeMinutes old), rebuilding only the
+            // stale ones — exactly GetBucketScoreVec's per-bucket lazy policy. A rebuild therefore costs ~one old-style
+            // dict scan (cache hits), not a full re-derivation of every vec; bit-exact because reuse-window + index-TTL
+            // keep every reused vec within the 10-min freshness a fresh dict scan would accept (see the const comment).
+            var vecCutoff = now.AddMinutes(-CandidateIndexMaxAgeMinutes);
+            // R6 WS-LOH: each column is built into BlockSize-element blocks (chunked) instead of one flat array. The flat
+            // ScoreVec[] (112 B/elem) crossed the ~85 KB LOH threshold on hot tags (>~759 buckets) and promoted to gen2
+            // every novel-key rebuild (the rare AllocLarge pause tail); the chunked blocks stay in the SOH and die in gen0.
+            // The builder auto-grows by appending fresh blocks, so a dict that grows mid-enumeration never drops a
+            // candidate (replacing the old Array.Resize). Membership / order / score / TTL are unchanged.
+            var vecsB = new ClosestCandidateIndex.Builder<ClosestScoreKernel.ScoreVec>(liveCount);
+            var keysB = new ClosestCandidateIndex.Builder<AuctionKey>(liveCount);
+            var bucketsB = new ClosestCandidateIndex.Builder<ReferenceAuctions>(liveCount);
+            var oldestB = new ClosestCandidateIndex.Builder<short>(liveCount);
+            var capB = new ClosestCandidateIndex.Builder<long>(liveCount);
+            int n = 0;
+            foreach (var m in l)
+            {
+                if (m.Key == null || m.Value?.References == null || !(m.Value.Price > 0) || m.Key.Modifiers.Any(mod => mod.Key == "virtual"))
+                    continue;
+                var vec = GetBucketScoreVec(itemTag, m.Key, m.Value, vecCutoff); // reuses fresh bucket caches, publishes rebuilds
+                vecsB.Add(in vec); keysB.Add(m.Key); bucketsB.Add(m.Value); oldestB.Add(m.Value.OldestRef);
+                capB.Add(ClosestScoreKernel.PosCap(in vec)); // WS-C: query-independent upper-bound cap, precomputed once
+                n++;
+            }
+            var index = new ClosestCandidateIndex(vecsB.Build(), keysB.Build(), bucketsB.Build(), oldestB.Build(),
+                capB.Build(), n, epoch, liveCount, now);
+            lookup.CandidateIndex = index; // atomic publish
+            return index;
+        }
+
+        /// <summary>
+        /// R4 — returns the cached <see cref="DominatorIndex"/> for <paramref name="lookup"/>, rebuilding it when the
+        /// candidate set could have changed (pricing <see cref="pricingEpoch"/> or live dict Count) or the TTL elapsed —
+        /// the SAME invalidation triggers as <see cref="GetOrBuildCandidateIndex"/>, the proven cached-snapshot pattern.
+        /// The index caches only the IMMUTABLE, key-derived data (the interned <c>DomKey</c> + dominance masks + Keys +
+        /// Buckets + Reforge/Tier); the finders that consume it read all MUTABLE bucket state (Price / Lbin / References)
+        /// LIVE off <c>Buckets[i]</c> during their scan, so the shared index never makes a finder act on stale prices or
+        /// references — it is bit-exact with the old per-finder <c>foreach (var x in l)</c> while removing the dict
+        /// enumeration + the per-candidate string <see cref="IsHigherValue"/>. Atomic-ref published (tear-safe).
+        /// </summary>
+        private DominatorIndex GetOrBuildDominatorIndex(PriceLookup lookup)
+        {
+            var l = lookup.Lookup;
+            var now = DateTime.UtcNow;
+            var ttlCutoff = now.AddMinutes(-CandidateIndexMaxAgeMinutes);
+            // NOTE: deliberately NOT gated on pricingEpoch (unlike GetOrBuildCandidateIndex). This index's membership is
+            // price-INDEPENDENT (all non-null buckets) and every column the finders read (Doms/masks/Reforge/Keys/Buckets)
+            // is immutable key-derived — the finders read all MUTABLE state (Price/Lbin/References) LIVE off the bucket.
+            // So a price transition changes neither membership nor any used column; rebuilding on it would be pure churn.
+            //
+            // R5c (idx-grow): the per-auction full rebuild (six fresh O(N) column arrays -> LOH -> gen2 AllocLarge, the #1
+            // rare-pause driver) is replaced with the append-amortized growable store. On the RARE path a novel key is
+            // ADDED every auction (Count +1) — an APPEND of just that bucket's row into doubling-capacity backing arrays,
+            // not a full re-alloc. The store falls back to a full rebuild only on a removal/replacement (a prior member is
+            // gone), a Count shrink, or the TTL — its per-bucket membership stamp lets it verify soundly (seenPrior ==
+            // priorCount) that the change is a PURE add, so an append is BIT-EXACT with a fresh Build (proven by
+            // AssertDominatorParity over the live dict in the soak). The Count-keyed HIT keeps the same TTL-bounded
+            // staleness contract as the old code on net-zero swaps/replacements.
+            var store = lookup.DominatorIndexStore;
+            if (store == null)
+            {
+                var created = new DominatorIndexStore();
+                // First writer wins; any loser uses the published instance (the store itself is internally synchronized).
+                store = Interlocked.CompareExchange(ref lookup.DominatorIndexStore, created, null) ?? created;
+            }
+            var index = store.GetOrBuild(l, scoreInterner, Interlocked.Read(ref pricingEpoch), now, ttlCutoff);
+            lookup.DominatorIndex = index; // keep the legacy field pointing at the latest view (back-compat / inspection)
+            return index;
+        }
+
+        /// <summary>
+        /// R4 parity guard (gated by <see cref="VerifyDominatorIndex"/>): asserts the flat-index dominator set produced by
+        /// scanning <paramref name="index"/> with the mask prefilter + <c>DominatorIndex.Dominates</c> equals a fresh
+        /// <see cref="IsHigherValue"/> filter over the live dict, in BOTH directions. Side-effect-free. <paramref
+        /// name="baseIsQuery"/> selects the direction: true = "candidates that dominate the query"
+        /// (<c>IsHigherValue(tag, query, cand)</c>, used by GetLbinCap / PotentialSnipe); false = "candidates dominated by
+        /// the query" (<c>IsHigherValue(tag, cand, query)</c>, used by CheckLowerKeyFull / the median lower-value scan).
+        /// </summary>
+        private void AssertDominatorParity(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey query,
+            string itemTag, DominatorIndex index, bool baseIsQuery)
+        {
+            bool petSpirit = itemTag == "PET_SPIRIT";
+            var q = DominatorIndex.BuildDomKey(query, scoreInterner);
+            // index dominator set (the exact predicate over the flat arrays; mask prefilter is proven sound by the fuzz
+            // so applying it here would only confirm it — the guard checks the EXACT scan vs the live dict)
+            var fromIndex = new HashSet<AuctionKey>();
+            for (int i = 0; i < index.Count; i++)
+            {
+                bool dom = baseIsQuery
+                    ? DominatorIndex.Dominates(in q, in index.Doms[i], petSpirit)
+                    : DominatorIndex.Dominates(in index.Doms[i], in q, petSpirit);
+                if (dom) fromIndex.Add(index.Keys[i]);
+            }
+            var fromDict = new HashSet<AuctionKey>();
+            foreach (var m in l)
+            {
+                if (m.Key == null || m.Value?.References == null) continue;
+                bool dom = baseIsQuery ? IsHigherValue(itemTag, query, m.Key) : IsHigherValue(itemTag, m.Key, query);
+                if (dom) fromDict.Add(m.Key);
+            }
+            if (!fromIndex.SetEquals(fromDict))
+                throw new InvalidOperationException(
+                    $"DominatorIndex parity violation for {itemTag} (baseIsQuery={baseIsQuery}): index={fromIndex.Count} vs dict={fromDict.Count}");
+        }
+
+        /// <summary>
+        /// Soak/test parity guard (gated by <see cref="VerifyClosestIndex"/>), side-effect-free so it faithfully reflects
+        /// production. Checks the two invariants that actually matter, without re-deriving vecs (which would mutate the
+        /// bucket caches and falsely flag the within-tolerance vec reuse):
+        ///   (1) <b>BnB correctness</b> — a FULL scan over the index's OWN vecs (no prefilter) reproduces the pruned
+        ///       arg-max; catches any wrongly-pruned winner.
+        ///   (2) <b>Membership</b> — a fresh dictionary filter yields the same candidate count as the index; catches a
+        ///       dropped/extra candidate, including a price flip (0&lt;-&gt;positive) that failed to bump the pricing epoch
+        ///       (the new-bucket trap). Per-element score correctness is covered by ClosestScoreKernelTests (20k fuzz)
+        ///       and the reuse-freshness invariant documented on <see cref="CandidateIndexMaxAgeMinutes"/>.
+        /// </summary>
+        private void AssertClosestParity(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey, string itemTag, int maxAge, ClosestCandidateIndex index, long indexBestScore)
+        {
+            var minDay = GetDay() - maxAge;
+            var queryVec = ScoreVecForKey(itemTag, itemKey);
+            long fullBest = long.MinValue;
+            for (int i = 0; i < index.Count; i++)
+            {
+                long score = ClosestScoreKernel.Score(in queryVec, in index.VecRef(i)) + (index.OldestRef[i] > minDay ? 0 : -10);
+                if (score > fullBest) fullBest = score;
+            }
+            int freshCount = 0;
+            foreach (var m in l)
+                if (m.Key != null && m.Value?.References != null && m.Value.Price > 0 && !m.Key.Modifiers.Any(mod => mod.Key == "virtual"))
+                    freshCount++;
+            if (fullBest != indexBestScore || freshCount != index.Count)
+                throw new InvalidOperationException(
+                    $"ClosestCandidateIndex parity violation for {itemTag}: BnB(score={indexBestScore}) vs full(score={fullBest}); index.Count={index.Count} vs fresh={freshCount}");
         }
         public IEnumerable<KeyValuePair<AuctionKey, ReferenceAuctions>> FindClosest(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey, string itemTag, int maxAge = 8)
         {
             var minDay = GetDay() - maxAge;
-            var values = ComparisonValue(itemKey.Enchants, itemKey.Modifiers.ToList(), itemTag, null).ToList();
+            var values = ComparisonValueForKey(itemTag, itemKey);
             return l.Where(l => l.Key != null && l.Value?.References != null && l.Value.Price > 0 && !l.Key.Modifiers.Any(m => m.Key == "virtual"))
-                            .OrderByDescending(m => itemKey.Similarity(m.Key, this, [.. ComparisonValue(m.Key.Enchants, m.Key.Modifiers, itemTag, null)], values) + (m.Value.OldestRef > minDay ? 0 : -10));
+                            .OrderByDescending(m => itemKey.Similarity(m.Key, this, ComparisonValueForKey(itemTag, m.Key), values) + (m.Value.OldestRef > minDay ? 0 : -10));
+        }
+
+        /// <summary>
+        /// R3-READ: buffer-materialized, bit-exact equivalent of <see cref="FindClosest"/> for the hot read-path
+        /// consumer (<see cref="GetEstimatedMedian"/>), which iterates the ordering with an early break. The LINQ form
+        /// allocates a <c>Where</c> + <c>OrderByDescending</c> pair (predicate/selector closures, lazy enumerators) and
+        /// re-invokes the score selector during the sort; this scans the dict once into pooled-shape local arrays, scores
+        /// each candidate once with the identical kernel (<c>itemKey.Similarity(key, this, ComparisonValueForKey(key),
+        /// values) + age</c>), and sorts descending. Bit-exact ordering: <c>OrderByDescending</c> is a STABLE sort, so
+        /// ties keep source (dict-enumeration) order; we sort on <c>(score desc, sourceIndex asc)</c> over candidates
+        /// collected in that same dict order, reproducing the exact sequence — including which candidate the consumer's
+        /// "first with Median &gt; 0" break selects. Returns the candidates in order (the consumer indexes/breaks).
+        /// </summary>
+        private Scored[] FindClosestOrdered(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey, string itemTag, int maxAge = 8)
+        {
+            var minDay = GetDay() - maxAge;
+            var values = ComparisonValueForKey(itemTag, itemKey);
+            // Single scored buffer (over-sized to dict count, trimmed to n) — one allocation instead of the LINQ
+            // Where+OrderBy machinery (predicate/selector closures + lazy enumerators + internal key/map buffers).
+            var buf = new Scored[l.Count];
+            int n = 0;
+            foreach (var m in l)
+            {
+                var v = m.Value;
+                if (m.Key == null || v?.References == null || !(v.Price > 0) || ModifiersContainVirtual(m.Key.Modifiers))
+                    continue;
+                if (n >= buf.Length) // dict grew during enumeration -> grow so a candidate is never dropped
+                    Array.Resize(ref buf, n + 8);
+                int score = itemKey.Similarity(m.Key, this, ComparisonValueForKey(itemTag, m.Key), values)
+                            + (v.OldestRef > minDay ? 0 : -10);
+                buf[n] = new Scored(score, n, m.Key, v);
+                n++;
+            }
+            // Stable descending order: Array.Sort is unstable, so the (score desc, sourceIndex asc) total order in
+            // Scored.CompareTo makes the result deterministic and identical to OrderByDescending's stable order (ties
+            // keep source/dict-enumeration order). Sort only the populated prefix [0, n).
+            Array.Sort(buf, 0, n);
+            if (n != buf.Length)
+                Array.Resize(ref buf, n);
+            return buf;
+        }
+
+        /// <summary>R3-READ scored candidate for <see cref="FindClosestOrdered"/>; sorts by (score desc, source index asc)
+        /// to reproduce <c>OrderByDescending</c>'s stable order with a single buffer and no comparison delegate.</summary>
+        private readonly struct Scored : IComparable<Scored>
+        {
+            public readonly int Score;
+            public readonly int Index;
+            public readonly AuctionKey Key;
+            public readonly ReferenceAuctions Value;
+            public Scored(int score, int index, AuctionKey key, ReferenceAuctions value)
+            { Score = score; Index = index; Key = key; Value = value; }
+            public int CompareTo(Scored o)
+            {
+                if (Score != o.Score) return o.Score.CompareTo(Score); // descending by score
+                return Index.CompareTo(o.Index);                       // ties: ascending source index (stable)
+            }
+        }
+
+        private static bool ModifiersContainVirtual(IReadOnlyList<KeyValuePair<string, string>> modifiers)
+        {
+            if (modifiers == null)
+                return false;
+            for (int i = 0; i < modifiers.Count; i++)
+                if (modifiers[i].Key == "virtual")
+                    return true;
+            return false;
+        }
+
+        /// <summary>
+        /// R3-READ: zero-alloc single-pass arg-max returning the SAME element <see cref="FindClosestOrdered"/> would put
+        /// first — the top-scored closest candidate. <see cref="GetEstimatedMedian"/> almost always consumes only this
+        /// one (it breaks on the first positive median), so the buffer+sort of FindClosestOrdered is avoided on the
+        /// common path. Bit-exact with FindClosestOrdered[0]: same filter, same score
+        /// (<c>itemKey.Similarity(key, this, ComparisonValueForKey(key), values) + age</c>), same dict-enumeration order;
+        /// the ordered array's first element is the max score with ties broken by lowest source index, which a strict-'>'
+        /// (first-wins) scan reproduces. Returns (null, null) when there is no candidate.
+        /// </summary>
+        private (AuctionKey Key, ReferenceAuctions Value) FindClosestArgMax(ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, AuctionKey itemKey, string itemTag, int maxAge = 8)
+        {
+            var minDay = GetDay() - maxAge;
+            var values = ComparisonValueForKey(itemTag, itemKey);
+            int bestScore = 0;
+            AuctionKey bestKey = null;
+            ReferenceAuctions bestValue = null;
+            foreach (var m in l)
+            {
+                var v = m.Value;
+                if (m.Key == null || v?.References == null || !(v.Price > 0) || ModifiersContainVirtual(m.Key.Modifiers))
+                    continue;
+                int score = itemKey.Similarity(m.Key, this, ComparisonValueForKey(itemTag, m.Key), values)
+                            + (v.OldestRef > minDay ? 0 : -10);
+                if (bestKey is null || score > bestScore)
+                {
+                    bestScore = score;
+                    bestKey = m.Key;
+                    bestValue = v;
+                }
+            }
+            return (bestKey, bestValue);
         }
 
         void AssignMedian(PriceEstimate result, AuctionKey key, ReferenceAuctions bucket, long gemVal)
@@ -982,10 +1701,10 @@ ORDER BY l.`AuctionId`  DESC;
 
             var toChange = oldBucket.References.Where(e => e.AuctionId == auctionId).First();
             var newList = oldBucket.References.Where(e => e.AuctionId != auctionId).ToList();
-            oldBucket.References = new ConcurrentQueue<ReferencePrice>(newList);
+            oldBucket.SetReferences(newList);
 
             if (!newBucket.References.Contains(toChange))
-                newBucket.References.Enqueue(toChange);
+                newBucket.EnqueueReference(toChange);
 
             UpdateMedian(oldBucket, (GetAuctionGroupTag(tag).tag, GetBreakdownKey(from, tag)));
             UpdateMedian(newBucket, (GetAuctionGroupTag(toTag).tag, GetBreakdownKey(to, tag)));
@@ -1032,7 +1751,7 @@ ORDER BY l.`AuctionId`  DESC;
             {
                 foreach (var item in loadedVal.Lookup)
                 {
-                    item.Value.References = new ConcurrentQueue<ReferencePrice>(item.Value.References.Where(r => r.Price > 0).OrderBy(r => r.Day));
+                    item.Value.SetReferences(item.Value.References.Where(r => r.Price > 0).OrderBy(r => r.Day));
                     if (item.Key.Count == 0 && item.Key.Tier == Tier.UNKNOWN && item.Value.References.Count == 0)
                         continue;
                     loadedVal.Lookup[item.Key] = item.Value;
@@ -1048,7 +1767,7 @@ ORDER BY l.`AuctionId`  DESC;
                 {
                     if (!value.Lookup.TryGetValue(item.Key, out ReferenceAuctions existingBucket))
                     {
-                        item.Value.References = new ConcurrentQueue<ReferencePrice>(item.Value.References.Where(r => r.Price > 0).OrderBy(r => r.Day));
+                        item.Value.SetReferences(item.Value.References.Where(r => r.Price > 0).OrderBy(r => r.Day));
                         if (item.Key.Count == 0 && item.Key.Tier == Tier.UNKNOWN && item.Value.References.Count == 0)
                             continue;
                         value.Lookup[item.Key] = item.Value;
@@ -1073,7 +1792,7 @@ ORDER BY l.`AuctionId`  DESC;
                     //Deduplicate(itemTag, current, item); probably not needed anymore
                     if (item.Modifiers.Count <= 1 && current.Lookup.TryGetValue(item, out var tocheck) && tocheck.References.Any(r => idLookup.Contains(r.AuctionId)))
                     {
-                        tocheck.References = new(tocheck.References.Where(r => !idLookup.Contains(r.AuctionId)));
+                        tocheck.SetReferences(tocheck.References.Where(r => !idLookup.Contains(r.AuctionId)).ToList());
                     }
                 }
                 catch (System.Exception e)
@@ -1090,10 +1809,10 @@ ORDER BY l.`AuctionId`  DESC;
             void CombineBuckets(KeyValuePair<AuctionKey, ReferenceAuctions> item, ReferenceAuctions existingBucket)
             {
                 var existingRef = existingBucket.References;
-                existingBucket.References = item.Value.References;
+                existingBucket.SetReferences(item.Value.References);
                 if (existingRef != null)
                 {
-                    existingBucket.References = new(existingRef.Concat(item.Value.References).ToList()
+                    existingBucket.SetReferences(existingRef.Concat(item.Value.References).ToList()
                         .DistinctBy(d => d.AuctionId)
                         .OrderBy(r => r.Day));
 
@@ -1115,11 +1834,12 @@ ORDER BY l.`AuctionId`  DESC;
                         }
                         while (existingBucket.References.Count > 7 && existingBucket.References.TryPeek(out r) && r.Day < today - 30 * increaseRate)
                         {
-                            existingBucket.References.TryDequeue(out _);
+                            existingBucket.TryDequeueReference(out _);
                         }
                     }
                 }
                 existingBucket.Price = item.Value.Price;
+                Interlocked.Increment(ref pricingEpoch); // WS-A: out-of-band price write -> invalidate candidate indexes
                 if (item.Value.Lbins == null)
                     item.Value.Lbins = new();
                 // load all non-empty lbins
@@ -1201,7 +1921,7 @@ ORDER BY l.`AuctionId`  DESC;
 
         private static void CapBucketSize(ReferenceAuctions bucket)
         {
-            while (bucket.References.Count > SizeToKeep && bucket.References.TryDequeue(out _)) { }
+            while (bucket.References.Count > SizeToKeep && bucket.TryDequeueReference(out _)) { }
         }
 
         public short AddSoldItem(SaveAuction auction, bool preventMedianUpdate = false)
@@ -1284,7 +2004,7 @@ ORDER BY l.`AuctionId`  DESC;
             {
                 reference.SellTime = (short)((auction.End - auction.Start).TotalMinutes + 1); // add one in case it sold within a minute
             }
-            bucket.References.Enqueue(reference);
+            bucket.EnqueueReference(reference);
             bucket.Lbins.RemoveAll(l => l.AuctionId == auction.UId);
             CapBucketSize(bucket);
             if (!preventMedianUpdate)
@@ -1301,6 +2021,12 @@ ORDER BY l.`AuctionId`  DESC;
 
         public void UpdateMedian(ReferenceAuctions bucket, (string tag, KeyWithValueBreakdown key) keyCombo = default)
         {
+            // WS-A: UpdateMedian is the funnel for (almost) every bucket price transition (priced<->unpriced), which is
+            // exactly what changes the closest-search candidate set. Bumping the pricing epoch here invalidates the
+            // contiguous candidate indexes so a newly-priced/unpriced bucket is never missed (the reverted set-caching
+            // trap). Service-wide and unconditional: UpdateMedian isn't on the snipe hot path, so spurious bumps only
+            // cost an occasional index rebuild; correctness is the priority.
+            Interlocked.Increment(ref pricingEpoch);
             var size = bucket.References.Count;
             if (size < 4)
             {
@@ -1408,10 +2134,8 @@ ORDER BY l.`AuctionId`  DESC;
                 }
                 else if (lookup.CleanPricePerTier?.TryGetValue(itemTier, out var tierval) ?? false)
                 {
-                    if (keyCombo.key.Key.Modifiers.Count == 0 && keyCombo.key.Key.Reforge == ItemReferences.Reforge.jaded)
-                    {
-                        var lowest = lookup.Lookup.Where(l => l.Value.Price > 0).OrderBy(l => l.Value.Price).Take(5).ToList();
-                    }
+                    // (removed: a dead `lowest = Lookup.Where(...).OrderBy(...).Take(5).ToList()` that was computed but
+                    //  never read — it allocated a KeyValuePair[] buffer (OrderBy) every reprice for the jaded-clean branch.)
                     // check clean item value is higher
                     if (limitedPrice < tierval / 1.2 && !keyCombo.key.Key.Modifiers.Any(m => m.Key == "virtual" || Constants.AttributeKeys.Contains(m.Key))
                         && !IsMidas(keyCombo.tag))
@@ -1468,9 +2192,11 @@ ORDER BY l.`AuctionId`  DESC;
                 }
                 else if (keyCombo.key.Key.Modifiers.Count <= 1) // this condition could be extended to everything but the calculation can cause undervaluations on eg gems
                     medianPrice = Math.Min(medianPrice, percentileRecent);
-                lookup.HasMultipleRarities = lookup.Lookup
-                        .Where(l => l.Key.Tier != Tier.UNKNOWN)
-                        .GroupBy(l => l.Key.Tier).Count() > 2;
+                // De-LINQ: the old `Lookup.Where(Tier!=UNKNOWN).GroupBy(Tier).Count() > 2` buffered every
+                // KeyValuePair of the ConcurrentDictionary into an array (the dominant warm KeyValuePair[] allocator).
+                // Equivalent explicit pass: detect ">2 distinct non-UNKNOWN tiers" by collecting the first 3 distinct
+                // tiers and early-exiting once a 3rd appears (bit-exact: same predicate, same distinct semantics).
+                lookup.HasMultipleRarities = HasMoreThanTwoDistinctTiers(lookup.Lookup);
 
                 var keyWithNoEnchants = new AuctionKey(keyCombo.Item2)
                 {
@@ -1521,16 +2247,35 @@ ORDER BY l.`AuctionId`  DESC;
                 {
                     return limitedPrice;
                 }
-                var cheaperHigherValue = Lookups[keyCombo.tag].Lookup
-                    .Where(k =>
-                            k.Value.Price < limitedPrice && k.Value.Price != 0
-                            && keyCombo.key.Key != k.Key
-                            && !k.Key.Modifiers.Any(m => m.Key == "virtual")
-                            && k.Value.OldestRef >= oldestDay // only relevant if price dropped recently
-                            && k.Value.DeduplicatedReferenceCount > 3
-                            && k.Value.Volume * 5 >= bucket.Volume
-                            && IsHigherValue(keyCombo.tag, keyCombo.key, k.Key) && k.Key.Reforge == keyCombo.key.Key.Reforge)
-                    .OrderBy(b => b.Value.Price).FirstOrDefault();
+                // De-LINQ: the old `Lookup.Where(<predicate>).OrderBy(b => b.Value.Price).FirstOrDefault()` buffered every
+                // matching ConcurrentDictionary KeyValuePair into an array (the OrderBy sort buffer — a top warm KVP[]
+                // allocator) and boxed a Modifiers enumerator per candidate (the `.Any(m=>m.Key=="virtual")` — the
+                // KeyValuePair<string,string> Enumerator allocator). Single-pass arg-min preserves OrderBy's *stable*
+                // tie-break exactly: among entries tied for the minimum Value.Price, FirstOrDefault returns the one
+                // enumerated first, so we replace only on a STRICTLY smaller price (never on equal) — and a foreach over
+                // the ConcurrentDictionary visits entries in the same order the LINQ pipeline did. Bit-exact.
+                var cheaperHigherValue = default(KeyValuePair<AuctionKey, ReferenceAuctions>);
+                bool foundCheaper = false;
+                long bestCheaperPrice = 0;
+                foreach (var k in Lookups[keyCombo.tag].Lookup)
+                {
+                    var v = k.Value;
+                    if (v.Price < limitedPrice && v.Price != 0
+                        && keyCombo.key.Key != k.Key
+                        && !ModifiersContainVirtual(k.Key.Modifiers)
+                        && v.OldestRef >= oldestDay // only relevant if price dropped recently
+                        && v.DeduplicatedReferenceCount > 3
+                        && v.Volume * 5 >= bucket.Volume
+                        && IsHigherValue(keyCombo.tag, keyCombo.key, k.Key) && k.Key.Reforge == keyCombo.key.Key.Reforge)
+                    {
+                        if (!foundCheaper || v.Price < bestCheaperPrice)
+                        {
+                            cheaperHigherValue = k;
+                            bestCheaperPrice = v.Price;
+                            foundCheaper = true;
+                        }
+                    }
+                }
                 if (cheaperHigherValue.Value != default
                     && cheaperHigherValue.Key != keyCombo.key.Key
                     && cheaperHigherValue.Value.Price < limitedPrice)
@@ -1601,31 +2346,174 @@ ORDER BY l.`AuctionId`  DESC;
             }
         }
 
+        /// <summary>
+        /// Returns whether the lookup contains more than two DISTINCT non-UNKNOWN tiers — bit-exact replacement for
+        /// <c>Lookup.Where(l =&gt; l.Key.Tier != Tier.UNKNOWN).GroupBy(l =&gt; l.Key.Tier).Count() &gt; 2</c>, without the
+        /// per-call KeyValuePair[] LINQ buffering over the ConcurrentDictionary. Collects up to three distinct tiers
+        /// and short-circuits the moment a third appears.
+        /// </summary>
+        private static bool HasMoreThanTwoDistinctTiers(ConcurrentDictionary<AuctionKey, ReferenceAuctions> lookup)
+        {
+            Tier t0 = Tier.UNKNOWN, t1 = Tier.UNKNOWN;
+            bool have0 = false, have1 = false;
+            foreach (var kv in lookup)
+            {
+                var tier = kv.Key.Tier;
+                if (tier == Tier.UNKNOWN)
+                    continue;
+                if (!have0) { t0 = tier; have0 = true; continue; }
+                if (tier == t0)
+                    continue;
+                if (!have1) { t1 = tier; have1 = true; continue; }
+                if (tier == t1)
+                    continue;
+                // a third distinct non-UNKNOWN tier
+                return true;
+            }
+            return false;
+        }
+
         static void DropUnderlistings(List<ReferencePrice> deduplicated, int scanSize = 5)
         {
-            var bucketSize = deduplicated.Count();
-            var toRemove = new List<ReferencePrice>();
-            var lookup = deduplicated.ToLookup(d => d.Buyer);
+            var bucketSize = deduplicated.Count;
+            List<ReferencePrice> toRemove = null;
+            // De-LINQ: `deduplicated.ToLookup(d => d.Buyer)` was only used for `Contains(seller)` + `[seller].FirstOrDefault()`,
+            // i.e. "the FIRST reference (in list order) whose Buyer == seller". A first-occurrence dict is bit-identical and
+            // drops the ILookup + its grouping arrays.
+            Dictionary<short, ReferencePrice> firstByBuyer = null;
             for (int i = 0; i < bucketSize; i++)
             {
                 var targetAuction = deduplicated[i];
-                var batch = deduplicated.Skip(i).Take(scanSize).ToList();
-                if (batch.Count < 3)
+                // batch = deduplicated[i .. i+scanSize); only its Count and a filtered average over it are used.
+                int batchCount = Math.Min(scanSize, bucketSize - i);
+                if (batchCount < 3)
                     break;
-                var hit = lookup.Contains(targetAuction.Seller) ? lookup[targetAuction.Seller].FirstOrDefault() : default;
+                firstByBuyer ??= BuildFirstByBuyer(deduplicated);
+                var hit = firstByBuyer.TryGetValue(targetAuction.Seller, out var firstHit) ? firstHit : default;
                 if (hit.AuctionId == default)
                     continue;
-                if (i < 3 && batch.Take(scanSize).Where(a => a.AuctionId != hit.AuctionId).Select(a => a.Price).Average() < hit.Price)
-                    continue;// skip if median would be pulled down, the point of this is to remove to low value
-                toRemove.Add(hit);
+                if (i < 3)
+                {
+                    // average of batch prices excluding hit.AuctionId (the filtered set is non-empty: batchCount>=3, one id excluded).
+                    long sum = 0;
+                    int cnt = 0;
+                    int end = i + batchCount;
+                    for (int j = i; j < end; j++)
+                    {
+                        var a = deduplicated[j];
+                        if (a.AuctionId != hit.AuctionId)
+                        {
+                            sum += a.Price;
+                            cnt++;
+                        }
+                    }
+                    if ((double)sum / cnt < hit.Price)
+                        continue;// skip if median would be pulled down, the point of this is to remove to low value
+                }
+                (toRemove ??= new List<ReferencePrice>()).Add(hit);
             }
-            if (deduplicated.Count - toRemove.Count < 4)
+            int removeCount = toRemove?.Count ?? 0;
+            if (removeCount == 0 || deduplicated.Count - removeCount < 4)
             {
                 return;
             }
-            foreach (var item in toRemove)
+            for (int i = 0; i < toRemove.Count; i++)
             {
-                deduplicated.Remove(item);
+                deduplicated.Remove(toRemove[i]);
+            }
+
+            static Dictionary<short, ReferencePrice> BuildFirstByBuyer(List<ReferencePrice> refs)
+            {
+                var map = new Dictionary<short, ReferencePrice>();
+                for (int i = 0; i < refs.Count; i++)
+                {
+                    var r = refs[i];
+                    if (!map.ContainsKey(r.Buyer))
+                        map[r.Buyer] = r;
+                }
+                return map;
+            }
+        }
+
+        /// <summary>
+        /// WS-CHURN-C: in-place, array-backed twin of <see cref="DropUnderlistings(List{ReferencePrice}, int)"/> used by the
+        /// hot clean-price recompute (pets are common). It operates on the already-contiguous flatten buffer
+        /// <paramref name="arr"/>[0..<paramref name="n"/>) and returns the new logical length, avoiding the per-call
+        /// <c>List&lt;ReferencePrice&gt;(n)</c> allocation + element copy the List path required just to mutate-in-place.
+        ///
+        /// <para>BIT-EXACT with the List overload — same survivor SET and ORDER for every input. The selection of
+        /// <c>toRemove</c> is byte-for-byte the List logic with index access substituted for <c>deduplicated[i]</c> /
+        /// <c>.Count</c>. The removal phase reproduces <see cref="List{T}.Remove"/> EXACTLY: for each hit in
+        /// <c>toRemove</c> order it removes the FIRST still-present element (in current order) whose
+        /// <see cref="ReferencePrice.Equals(object)"/> matches, shifting survivors left like <c>List.RemoveAt</c>. (Verified
+        /// against the List overload over 2M+ randomized cases incl. Equals-duplicate clusters, default(0) AuctionIds and
+        /// SellTime-only differences; the production memo/golden fuzz gates it end-to-end.)</para>
+        /// </summary>
+        static int DropUnderlistings(ReferencePrice[] arr, int n, int scanSize = 5)
+        {
+            var bucketSize = n;
+            List<ReferencePrice> toRemove = null;
+            Dictionary<short, ReferencePrice> firstByBuyer = null;
+            for (int i = 0; i < bucketSize; i++)
+            {
+                var targetAuction = arr[i];
+                int batchCount = Math.Min(scanSize, bucketSize - i);
+                if (batchCount < 3)
+                    break;
+                firstByBuyer ??= BuildFirstByBuyer(arr, n);
+                var hit = firstByBuyer.TryGetValue(targetAuction.Seller, out var firstHit) ? firstHit : default;
+                if (hit.AuctionId == default)
+                    continue;
+                if (i < 3)
+                {
+                    long sum = 0;
+                    int cnt = 0;
+                    int end = i + batchCount;
+                    for (int j = i; j < end; j++)
+                    {
+                        var a = arr[j];
+                        if (a.AuctionId != hit.AuctionId)
+                        {
+                            sum += a.Price;
+                            cnt++;
+                        }
+                    }
+                    if ((double)sum / cnt < hit.Price)
+                        continue;
+                }
+                (toRemove ??= new List<ReferencePrice>()).Add(hit);
+            }
+            int removeCount = toRemove?.Count ?? 0;
+            if (removeCount == 0 || n - removeCount < 4)
+                return n;
+            // Mirror List.Remove: for each hit (in toRemove order) remove the FIRST present element (current order)
+            // that Equals(hit), shifting the tail left exactly like List.RemoveAt — identical survivor set AND order.
+            int len = n;
+            for (int t = 0; t < toRemove.Count; t++)
+            {
+                var hit = toRemove[t];
+                for (int i = 0; i < len; i++)
+                {
+                    if (arr[i].Equals(hit))
+                    {
+                        Array.Copy(arr, i + 1, arr, i, len - i - 1);
+                        len--;
+                        break;
+                    }
+                }
+            }
+            return len;
+
+            static Dictionary<short, ReferencePrice> BuildFirstByBuyer(ReferencePrice[] refs, int count)
+            {
+                var map = new Dictionary<short, ReferencePrice>();
+                for (int i = 0; i < count; i++)
+                {
+                    var r = refs[i];
+                    if (!map.ContainsKey(r.Buyer))
+                        map[r.Buyer] = r;
+                }
+                return map;
             }
         }
 
@@ -1658,22 +2546,405 @@ ORDER BY l.`AuctionId`  DESC;
             return true;
         }
 
-        static List<ReferencePrice> ApplyAntiMarketManipulation(ReferenceAuctions bucket)
+        internal static List<ReferencePrice> ApplyAntiMarketManipulation(ReferenceAuctions bucket)
+        {
+            // WS-AMM (R6): de-LINQ of the verbatim LINQ original (preserved below as
+            // ApplyAntiMarketManipulationReference, the bit-exactness oracle in
+            // Services/ApplyAntiMarketManipulation.Tests.cs — a ≥40k heavy-tie + buyer-collision fuzz). Every stage
+            // reproduces LINQ's observable semantics EXACTLY:
+            //  - GroupBy: groups in first-encounter key order; elements in source order within a group.
+            //  - OrderBy / OrderByDescending: STABLE (ties keep source order). Reproduced with index-tiebroken sorts.
+            //  - The deferred side-effecting counter: GroupBy(a => a.Buyer == 0 ? buyerCounter++ : a.Buyer). When the
+            //    GroupBy is enumerated ONCE (as here), the key selector runs once per element in source order, so the
+            //    counter increments per Buyer==0 row in encounter order. CRITICAL: the counter shares the int keyspace
+            //    with real (non-zero) Buyer keys, so a counter value can COLLIDE with a real buyer and merge groups
+            //    (proven in the fuzz) — we therefore simulate the actual counter, not "one singleton per Buyer==0".
+            var references = bucket.ReferenceSnapshot();
+            int n = references.Length;
+            if (n == 0)
+                return new List<ReferencePrice>();
+
+            // ---- Stage 1: back-and-forth detection ----------------------------------------------------------------
+            // GroupBy(key) where key = Buyer>Seller ? Buyer<<(15+Seller) : Seller<<(15+Buyer)  (C# precedence: << is
+            // lower than +). Keep groups with Count>1 whose sellers are not all equal to the first element's seller.
+            // ToLookup(g => g.First().Seller).Contains(x)  ≡  membership in {firstSeller of each surviving group}.
+            // We only need that membership SET of shorts.
+            var combos = AmmComboBuffers.Combos; // Dictionary<int,(ReferencePrice first,int count,bool allSame,short firstSeller)>
+            combos.Clear();
+            var comboOrder = AmmComboBuffers.ComboOrder; // first-encounter key order (only used to keep determinism; not strictly needed for a set)
+            comboOrder.Clear();
+            for (int i = 0; i < n; i++)
+            {
+                var a = references[i];
+                int key = a.Buyer > a.Seller ? a.Buyer << (15 + a.Seller) : a.Seller << (15 + a.Buyer);
+                if (combos.TryGetValue(key, out var st))
+                {
+                    st.count++;
+                    if (a.Seller != st.firstSeller)
+                        st.allSame = false;
+                    combos[key] = st;
+                }
+                else
+                {
+                    combos[key] = (a, 1, true, a.Seller);
+                    comboOrder.Add(key);
+                }
+            }
+            var manipulatedSellers = AmmComboBuffers.ManipulatedSellers; // set of g.First().Seller of surviving groups
+            manipulatedSellers.Clear();
+            for (int oi = 0; oi < comboOrder.Count; oi++)
+            {
+                var st = combos[comboOrder[oi]];
+                // surviving group: Count>1 AND NOT all sellers equal first's seller
+                if (st.count > 1 && !st.allSame)
+                    manipulatedSellers.Add(st.firstSeller);
+            }
+
+            // ---- Stage 2: isPersonManipulating ------------------------------------------------------------------
+            // references.OrderByDescending(Price).Take(n/2).GroupBy(Seller)
+            //   .Where(Count >= Max(n/3,3)).OrderByDescending(Count).Select(First().Seller).FirstOrDefault()
+            short isPersonManipulating = ComputeIsPersonManipulating(references, n);
+
+            // ---- Stage 3: dedup ---------------------------------------------------------------------------------
+            // references.Reverse().Where(notManipulated).OrderByDescending(Day) -> stable order S.
+            // Build S explicitly: reverse FIFO, drop rows whose Seller or Buyer is in manipulatedSellers, then a
+            // STABLE descending sort by Day.
+            var stage = AmmComboBuffers.StageList; // List<ReferencePrice>
+            stage.Clear();
+            for (int i = n - 1; i >= 0; i--)
+            {
+                var d = references[i];
+                if (manipulatedSellers.Contains(d.Seller) || manipulatedSellers.Contains(d.Buyer))
+                    continue;
+                stage.Add(d);
+            }
+            // Stable OrderByDescending(Day): sort by (-Day) with original index as tiebreak to preserve stability.
+            StableSortByDayDescending(stage);
+
+            // GroupBy(Seller) over S (first-encounter seller order; within-group order = S order). Per group:
+            //   OrderBy(Price) [stable] .Skip(count/3).First()  -> one element per seller.
+            var sellerSelected = AmmComboBuffers.SellerSelected; // List<ReferencePrice>, in seller-group encounter order
+            sellerSelected.Clear();
+            GroupSelectCheapest(stage, bySeller: true, output: sellerSelected, counterStartsAt: 0, out _);
+
+            // GroupBy(Buyer==0 ? counter++ : Buyer) over sellerSelected, single enumeration => counter increments per
+            // Buyer==0 in sellerSelected order, sharing the int keyspace with real buyer keys (collisions matter).
+            // Per group: OrderBy(Price)[stable].Skip(count/3).First().  Then Take(WorkingSize).
+            var buyerSelected = AmmComboBuffers.BuyerSelected;
+            buyerSelected.Clear();
+            GroupSelectCheapest(sellerSelected, bySeller: false, output: buyerSelected, counterStartsAt: 0, out _);
+
+            int take = Math.Min(WorkingSize, buyerSelected.Count);
+            var deduplicated = new List<ReferencePrice>(take);
+            for (int i = 0; i < take; i++)
+            {
+                var elem = buyerSelected[i];
+                if (isPersonManipulating != default && elem.Seller == isPersonManipulating)
+                    elem.Price /= 2;
+                deduplicated.Add(elem);
+            }
+            return deduplicated;
+        }
+
+        // ---- WS-AMM de-LINQ helpers ----------------------------------------------------------------------------
+
+        /// <summary>Per-call scratch buffers for the AMM de-LINQ. [ThreadStatic] so the bulk-reprice loop reuses them
+        /// without per-bucket allocation (AMM is called single-threaded per bucket within a shard worker; each shard
+        /// has its own thread, hence its own copy). Every consumer clears before use.</summary>
+        private static class AmmComboBuffers
+        {
+            [ThreadStatic] private static Dictionary<int, (ReferencePrice first, int count, bool allSame, short firstSeller)> _combos;
+            [ThreadStatic] private static List<int> _comboOrder;
+            [ThreadStatic] private static HashSet<short> _manip;
+            [ThreadStatic] private static List<ReferencePrice> _stage;
+            [ThreadStatic] private static List<ReferencePrice> _sellerSel;
+            [ThreadStatic] private static List<ReferencePrice> _buyerSel;
+            [ThreadStatic] private static List<(int key, int firstIdx, int memberStart)> _groupMeta;
+            [ThreadStatic] private static List<(int groupIdx, int srcIdx)> _members;
+
+            public static Dictionary<int, (ReferencePrice first, int count, bool allSame, short firstSeller)> Combos
+                => _combos ??= new();
+            public static List<int> ComboOrder => _comboOrder ??= new();
+            public static HashSet<short> ManipulatedSellers => _manip ??= new();
+            public static List<ReferencePrice> StageList => _stage ??= new();
+            public static List<ReferencePrice> SellerSelected => _sellerSel ??= new();
+            public static List<ReferencePrice> BuyerSelected => _buyerSel ??= new();
+            public static List<(int key, int firstIdx, int memberStart)> GroupMeta => _groupMeta ??= new();
+            public static List<(int groupIdx, int srcIdx)> Members => _members ??= new();
+        }
+
+        /// <summary>Stable descending sort of <paramref name="list"/> by Day (ties keep current order), matching
+        /// <c>Enumerable.OrderByDescending(b =&gt; b.Day)</c>. Implemented as a stable insertion-into-sorted via an
+        /// index-tiebroken key array + Array.Sort on a parallel key (Array.Sort is unstable, so we encode the original
+        /// index into the comparison to force stability).</summary>
+        [ThreadStatic] private static long[] _ammDayKeys;
+        [ThreadStatic] private static ReferencePrice[] _ammDayItems;
+
+        private static void StableSortByDayDescending(List<ReferencePrice> list)
+        {
+            int c = list.Count;
+            if (c < 2)
+                return;
+            // keys[i] packs (-Day, i) as the signed long (-Day)*2^32 + i, so an ascending Array.Sort yields
+            // Day-descending with the original index as a stability tiebreak. Day is short so (-Day) fits and the
+            // low 32 bits (i < c) never collide with the (-Day) field. Pooled scratch ([ThreadStatic]) — no per-call alloc.
+            var keys = _ammDayKeys;
+            var items = _ammDayItems;
+            if (keys == null || keys.Length < c)
+            {
+                keys = _ammDayKeys = new long[Math.Max(c, 32)];
+                items = _ammDayItems = new ReferencePrice[Math.Max(c, 32)];
+            }
+            for (int i = 0; i < c; i++)
+            {
+                items[i] = list[i];
+                keys[i] = ((long)(-(int)list[i].Day) << 32) | (uint)i;
+            }
+            Array.Sort(keys, items, 0, c);
+            list.Clear();
+            for (int i = 0; i < c; i++)
+                list.Add(items[i]);
+        }
+
+        /// <summary>
+        /// Reproduces <c>source.GroupBy(keySel).Select(g =&gt; g.OrderBy(Price)[stable].Skip(g.Count()/3).First())</c>
+        /// for the two AMM dedup stages.
+        /// <para>When <paramref name="bySeller"/> is true the key is <c>(int)Seller</c>. When false the key is the
+        /// deferred-counter key <c>Buyer==0 ? counter++ : Buyer</c> — the counter increments once per Buyer==0 element
+        /// in <paramref name="source"/> order and shares the int keyspace with real buyer keys (so a counter value can
+        /// collide with a real buyer, exactly as LINQ does).</para>
+        /// Output groups are emitted in first-encounter key order; within a group members keep source order; the
+        /// per-group pick is the rank-(count/3) element of a STABLE ascending Price sort.
+        /// </summary>
+        private static void GroupSelectCheapest(List<ReferencePrice> source, bool bySeller, List<ReferencePrice> output, int counterStartsAt, out int counterEnd)
+        {
+            output.Clear();
+            int sc = source.Count;
+            int counter = counterStartsAt;
+            if (sc == 0)
+            {
+                counterEnd = counter;
+                return;
+            }
+            var meta = AmmComboBuffers.GroupMeta;   // (key, firstIdx, unused) per group, in encounter order
+            var members = AmmComboBuffers.Members;   // (groupIdx, srcIdx) appended in source order
+            meta.Clear();
+            members.Clear();
+            // key -> groupIdx (encounter order), in the SAME int keyspace LINQ uses (so counter/buyer collisions merge).
+            var map = _ammKeyMap ??= new Dictionary<int, int>();
+            map.Clear();
+            for (int i = 0; i < sc; i++)
+            {
+                var e = source[i];
+                int key = bySeller
+                    ? e.Seller
+                    : (e.Buyer == 0 ? counter++ : e.Buyer);
+                if (!map.TryGetValue(key, out int gi))
+                {
+                    gi = meta.Count;
+                    map[key] = gi;
+                    meta.Add((key, i, 0));
+                }
+                members.Add((gi, i));
+            }
+            counterEnd = counter;
+            // For each group in encounter order, collect its members (in source order), stable-sort by Price, pick
+            // index = count/3.
+            int groupCount = meta.Count;
+            // Build per-group member index lists by a single pass keeping source order (members already in src order).
+            // We iterate groups in order; for each, scan members for matching groupIdx. To keep it O(n) overall we
+            // bucket members by group first.
+            var perGroup = _ammPerGroup ??= new List<List<int>>();
+            // grow/reset perGroup buckets
+            while (perGroup.Count < groupCount)
+                perGroup.Add(new List<int>());
+            for (int g = 0; g < groupCount; g++)
+                perGroup[g].Clear();
+            for (int mi = 0; mi < members.Count; mi++)
+            {
+                var m = members[mi];
+                perGroup[m.groupIdx].Add(m.srcIdx);
+            }
+            for (int g = 0; g < groupCount; g++)
+            {
+                var idxs = perGroup[g];
+                int cnt = idxs.Count;
+                // Stable ascending sort by Price; tiebreak = position within the group's member list (== source order).
+                // Pick element at rank skip = cnt/3.
+                int skip = cnt / 3;
+                int chosenLocal = SelectStableByPrice(source, idxs, skip);
+                output.Add(source[idxs[chosenLocal]]);
+            }
+        }
+
+        [ThreadStatic] private static Dictionary<int, int> _ammKeyMap;
+        [ThreadStatic] private static List<List<int>> _ammPerGroup;
+        [ThreadStatic] private static int[] _ammSortKeys;
+        [ThreadStatic] private static int[] _ammSortPos;
+
+        /// <summary>
+        /// Returns the LOCAL position (within <paramref name="idxs"/>) of the element that
+        /// <c>idxs.OrderBy(Price)[stable].Skip(skip).First()</c> would select — i.e. the rank-<paramref name="skip"/>
+        /// element of a STABLE ascending sort of the group's members by Price (ties keep member/source order).
+        /// </summary>
+        private static int SelectStableByPrice(List<ReferencePrice> source, List<int> idxs, int skip)
+        {
+            int cnt = idxs.Count;
+            if (cnt == 1)
+                return 0;
+            // Stable sort the local positions [0..cnt) by (Price asc, localPos asc). Materialize order, return order[skip].
+            var keysArr = _ammSortKeys;
+            var posArr = _ammSortPos;
+            if (keysArr == null || keysArr.Length < cnt)
+            {
+                keysArr = _ammSortKeys = new int[Math.Max(cnt, 16)];
+                posArr = _ammSortPos = new int[Math.Max(cnt, 16)];
+            }
+            // We must sort by Price (long). Pack into a stable comparison via parallel arrays: sort an index array
+            // [0..cnt) using a comparison on (Price, localPos). Use Array.Sort with a Comparison over a local index
+            // array to keep it allocation-light; localPos tiebreak makes it stable.
+            for (int i = 0; i < cnt; i++)
+                posArr[i] = i;
+            // Insertion sort is stable and cnt is small (one seller/buyer group); avoids Comparison delegate alloc and
+            // is robust to long Price without packing-overflow concerns.
+            for (int i = 1; i < cnt; i++)
+            {
+                int cur = posArr[i];
+                long curPrice = source[idxs[cur]].Price;
+                int j = i - 1;
+                while (j >= 0 && source[idxs[posArr[j]]].Price > curPrice)
+                {
+                    posArr[j + 1] = posArr[j];
+                    j--;
+                }
+                posArr[j + 1] = cur;
+            }
+            // posArr[0..cnt) now holds local positions in (Price asc, localPos asc) stable order.
+            return posArr[skip];
+        }
+
+        /// <summary>De-LINQ of stage 2 (isPersonManipulating): the seller whose count among the top-n/2 by Price is
+        /// the largest qualifying (>= Max(n/3,3)) group, tie-broken by earliest encounter (stable), else default(0).</summary>
+        private static short ComputeIsPersonManipulating(ReferencePrice[] references, int n)
+        {
+            int half = n / 2;
+            if (half == 0)
+                return default;
+            // OrderByDescending(Price) stable, Take(half). Stable: ties keep source (FIFO) order.
+            // Dedicated buffer (StageList is built later for stage 3; must not clobber it).
+            var top = _ammTop ??= new List<ReferencePrice>();
+            top.Clear();
+            for (int i = 0; i < n; i++)
+                top.Add(references[i]);
+            // stable descending by Price
+            StableSortByPriceDescending(top);
+            // Take(half): top[0..half). GroupBy(Seller) first-encounter order, count per seller.
+            var sellerCounts = _ammSellerCounts ??= new Dictionary<short, int>();
+            sellerCounts.Clear();
+            var sellerOrder = _ammSellerOrder ??= new List<short>();
+            sellerOrder.Clear();
+            for (int i = 0; i < half; i++)
+            {
+                short s = top[i].Seller;
+                if (sellerCounts.TryGetValue(s, out int c))
+                    sellerCounts[s] = c + 1;
+                else
+                {
+                    sellerCounts[s] = 1;
+                    sellerOrder.Add(s);
+                }
+            }
+            int threshold = Math.Max(n / 3, 3);
+            // Where(count>=threshold).OrderByDescending(count) stable.Select(First().Seller).FirstOrDefault().
+            // Stable OrderByDescending over groups in encounter order: pick the qualifying seller with the max count,
+            // tie -> earliest in sellerOrder.
+            short best = default;
+            int bestCount = -1;
+            bool found = false;
+            for (int i = 0; i < sellerOrder.Count; i++)
+            {
+                short s = sellerOrder[i];
+                int c = sellerCounts[s];
+                if (c < threshold)
+                    continue;
+                if (c > bestCount) // strict > keeps the earliest-encountered on ties (stable)
+                {
+                    bestCount = c;
+                    best = s;
+                    found = true;
+                }
+            }
+            return found ? best : default;
+        }
+
+        [ThreadStatic] private static List<ReferencePrice> _ammTop;
+        [ThreadStatic] private static Dictionary<short, int> _ammSellerCounts;
+        [ThreadStatic] private static List<short> _ammSellerOrder;
+
+        [ThreadStatic] private static (long price, int idx)[] _ammPriceKeys;
+        [ThreadStatic] private static ReferencePrice[] _ammPriceItems;
+
+        /// <summary>Stable descending sort by Price (ties keep current order), matching OrderByDescending(r =&gt; r.Price).
+        /// Pooled scratch ([ThreadStatic]) — no per-call alloc.</summary>
+        private static void StableSortByPriceDescending(List<ReferencePrice> list)
+        {
+            int c = list.Count;
+            if (c < 2)
+                return;
+            var items = _ammPriceItems;
+            var keys = _ammPriceKeys;
+            if (keys == null || keys.Length < c)
+            {
+                keys = _ammPriceKeys = new (long price, int idx)[Math.Max(c, 32)];
+                items = _ammPriceItems = new ReferencePrice[Math.Max(c, 32)];
+            }
+            for (int i = 0; i < c; i++)
+            {
+                items[i] = list[i];
+                keys[i] = (list[i].Price, i);
+            }
+            // ascending sort on (-price, idx) == descending price, stable by original index.
+            Array.Sort(keys, items, 0, c, AmmPriceDescComparer.Instance);
+            list.Clear();
+            for (int i = 0; i < c; i++)
+                list.Add(items[i]);
+        }
+
+        private sealed class AmmPriceDescComparer : IComparer<(long price, int idx)>
+        {
+            public static readonly AmmPriceDescComparer Instance = new();
+            public int Compare((long price, int idx) x, (long price, int idx) y)
+            {
+                // descending price
+                if (x.price != y.price)
+                    return y.price.CompareTo(x.price);
+                // ascending original index => stability
+                return x.idx.CompareTo(y.idx);
+            }
+        }
+
+        /// <summary>
+        /// VERBATIM reference implementation of the anti-market-manipulation dedup (WS-AMM oracle, R6).
+        /// DO NOT change its behavior — it is the bit-exactness golden the fuzz compares the de-LINQ against.
+        /// </summary>
+        internal static List<ReferencePrice> ApplyAntiMarketManipulationReference(ReferenceAuctions bucket)
         {
             var buyerCounter = 0;
+            // Iterate the zero-alloc cached snapshot (FIFO-identical to bucket.References) for every scan below.
+            var references = bucket.ReferenceSnapshot();
             // check for back and forth selling
-            var buyerSellerCombos = bucket.References.GroupBy(a => a.Buyer > a.Seller ? a.Buyer << 15 + a.Seller : a.Seller << 15 + a.Buyer)
+            var buyerSellerCombos = references.GroupBy(a => a.Buyer > a.Seller ? a.Buyer << 15 + a.Seller : a.Seller << 15 + a.Buyer)
                 .Where(g => g.Count() > 1 && !g.All(gi => gi.Seller == g.First().Seller))
                 .ToLookup(l => l.First().Seller);
-            var isPersonManipulating = bucket.References.OrderByDescending(r => r.Price).Take(bucket.References.Count / 2)
-                        .GroupBy(r => r.Seller).Where(g => g.Count() >= Math.Max(bucket.References.Count / 3, 3)).OrderByDescending(g => g.Count()).Select(g => g.First().Seller).FirstOrDefault();
-            var deduplicated = bucket.References.Reverse()
+            var isPersonManipulating = references.OrderByDescending(r => r.Price).Take(references.Length / 2)
+                        .GroupBy(r => r.Seller).Where(g => g.Count() >= Math.Max(references.Length / 3, 3)).OrderByDescending(g => g.Count()).Select(g => g.First().Seller).FirstOrDefault();
+            var deduplicated = references.Reverse()
                 .Where(d => !buyerSellerCombos.Contains(d.Seller) && !buyerSellerCombos.Contains(d.Buyer))
                 .OrderByDescending(b => b.Day)
                 .GroupBy(a => a.Seller)
                 .Select(a => a.OrderBy(ai => ai.Price).Skip(a.Count() / 3).First())  // only use one (the cheapest) price from each seller
                 .GroupBy(a => a.Buyer == 0 ? buyerCounter++ : a.Buyer)
-                .Select(a => a.OrderBy(ai => ai.Price).Skip(a.Count() / 3).First())  // only use cheapest price from each buyer 
+                .Select(a => a.OrderBy(ai => ai.Price).Skip(a.Count() / 3).First())  // only use cheapest price from each buyer
                 .Take(WorkingSize)
                 .ToList();
             if (isPersonManipulating != default)
@@ -1838,8 +3109,11 @@ ORDER BY l.`AuctionId`  DESC;
             }
         }
 
-        private long GetCleanItemPrice(string tag, KeyWithValueBreakdown key, PriceLookup lookup, bool force = false)
+        internal long GetCleanItemPrice(string tag, KeyWithValueBreakdown key, PriceLookup lookup, bool force = false)
         {
+            // Persistent per-tier cache (warm hit). Unchanged: tier reduction picks the REDUCED tier the ingest path
+            // wrote under, and `force` bypasses this cache exactly as before. This is the ONLY place the reduced tier
+            // and the query Modifiers enter the decision; the recompute below is a pure function of (tag, UNREDUCED tier).
             var tier = key.Key.Tier;
             if (key.Key.Modifiers.Any(m => m.Value == TierBoostShorthand || m.Key == "rarity_upgrades"))
                 tier = ReduceRarity(tier);
@@ -1847,27 +3121,435 @@ ORDER BY l.`AuctionId`  DESC;
             {
                 return cleanPrice;
             }
+
+            // R6/MEMO2: persistent cache missed (or force) -> we would re-sort. Serve a memoized RECOMPUTE result keyed
+            // by (tag, UNREDUCED query tier) — the exact inputs the recompute body depends on — IF the memo entry is
+            // still fresh (its stamp matches the live pricing epoch + dict Count + Volume and is within TTL). One memo
+            // dict per lookup for its lifetime: the dict is NEVER re-allocated on an epoch bump (the warm fix), each
+            // entry carries its own freshness stamp. A stale or absent entry is a MISS — recompute via the clean2
+            // partial-select and overwrite the entry with the fresh value+stamp. Serves force + non-force identically
+            // because the recompute is deterministic for fixed inputs + a matching stamp (verified by the memo soak).
+            // The memo is a cache of the PURE recompute only — it never serves the persistent CleanPricePerTier path
+            // above. On warm the epoch changes every auction, so the entry is always stale -> always recompute the fast
+            // clean2 path, with ZERO dict realloc/alloc churn (a no-op overhead-wise vs not having the memo at all).
+            var memo = GetOrCreateCleanPriceMemo(lookup);
+            var memoKey = (tag, key.Key.Tier);
+            var epoch = Interlocked.Read(ref pricingEpoch);
+            var liveCount = lookup.Lookup.Count;
+            var volume = lookup.Volume;
+            var now = DateTime.UtcNow;
+            if (memo.Values.TryGetValue(memoKey, out var entry)
+                && entry.IsFresh(epoch, liveCount, volume, now, CleanPriceMemoMaxAgeMinutes))
+            {
+                if (VerifyCleanPriceMemo)
+                {
+                    var fresh = RecomputeCleanItemPrice(tag, key, lookup);
+                    if (fresh != entry.Value)
+                        throw new InvalidOperationException($"CLEANPRICE MEMO DIVERGENCE tag={tag} tier={key.Key.Tier} memo={entry.Value} fresh={fresh} epoch={epoch} count={liveCount} vol={volume}");
+                }
+                if (CleanPriceMemoCount)
+                    Interlocked.Increment(ref CleanPriceMemoHits);
+                return entry.Value;
+            }
+            if (CleanPriceMemoCount)
+                Interlocked.Increment(ref CleanPriceMemoRecomputes);
+            var recomputed = RecomputeCleanItemPrice(tag, key, lookup);
+            // Stamp the entry with the inputs it was computed against and overwrite in place (no dict realloc). The
+            // recompute is deterministic for fixed inputs within a stamp, so a concurrent writer for the same (key,
+            // stamp) stores the identical value; last-writer-wins is harmless. A stamp captured a hair before the recompute
+            // can only make a future read recompute again (a conservative miss) — never serve a value the live state
+            // wouldn't, which is exactly the candidate-index freshness contract.
+            memo.Values[memoKey] = new CleanItemPriceMemo.Entry(recomputed, epoch, liveCount, volume, now);
+            return recomputed;
+        }
+
+        /// <summary>
+        /// R6/MEMO2 — returns the per-lookup <see cref="CleanItemPriceMemo"/>, lazily creating + atomic-publishing it
+        /// on first use. The dict is created ONCE per lookup and never re-allocated thereafter (freshness is per-ENTRY,
+        /// not per-window — the warm fix vs the deferred clean3). A concurrent first-touch race just discards a still-
+        /// empty loser dict (no lost work); after publication the reference is stable so readers never see a torn/swapped
+        /// dict.
+        /// </summary>
+        private CleanItemPriceMemo GetOrCreateCleanPriceMemo(PriceLookup lookup)
+        {
+            var existing = lookup.CleanPriceMemo; // single atomic read of the reference
+            if (existing != null)
+                return existing;
+            var created = new CleanItemPriceMemo();
+            // Atomic publish; if a concurrent caller won, use theirs and drop ours (it is empty, so nothing is lost).
+            return Interlocked.CompareExchange(ref lookup.CleanPriceMemo, created, null) ?? created;
+        }
+
+        /// <summary>
+        /// The pure clean-price RECOMPUTE — exactly what the old method body returned on a persistent-cache miss/force.
+        /// Bit-exact: the flatten/filter/sort/select, sizing/devider, DropUnderlistings and Midas handling are byte-for-byte
+        /// the previous clean2 code (only the persistent-cache gate moved up to the caller). A pure function of
+        /// (tag, key.Key.Tier-UNREDUCED, lookup.Lookup references, lookup.Volume) — the contract the memo keys on.
+        /// </summary>
+        private long RecomputeCleanItemPrice(string tag, KeyWithValueBreakdown key, PriceLookup lookup)
+        {
+            // R2-D: de-LINQ'd, output-identical rewrite of the clean-price recompute. The original chain
+            //   lookup.Lookup.Where(..).Select(.Value).ToList() -> SelectMany(.References).ToList()
+            //   -> OrderByDescending(Day).ThenBy(Price).Take(size).OrderBy(Price).Skip(size/devider+1).FirstOrDefault()
+            // allocated a List<ReferenceAuctions>, a List<ReferencePrice>, enumerator/closure objects and the
+            // OrderBy index/buffer arrays per call (the #1 warm allocator). This version flattens into a pooled
+            // ReferencePrice[] and reproduces LINQ's stable two-phase ordering with pooled index buffers. The
+            // filters, DropUnderlistings, sizing, devider and Midas handling are unchanged.
             var matchRarity = tag == "THEORETICAL_HOE_WHEAT_3";
+            var isPet = NBT.IsPet(tag);
             var minRarity = matchRarity ? key.Key.Tier : key.Key.Tier - 1;
-            var select = (NBT.IsPet(tag) ?
-                            lookup.Lookup.Where(v => key.Key.Tier == v.Key.Tier && !v.Key.Modifiers.Any(m => m.Value == TierBoostShorthand)).Select(v => v.Value) :
-                             lookup.Lookup.Where(v => minRarity <= v.Key.Tier && !v.Key.Modifiers.Any(m => m.Key == "pgems" || Constants.AttributeKeys.Contains(m.Key))).Select(l => l.Value)).ToList();
-            var count = select.Count;
-            var all = select.SelectMany(v => v.References).ToList();
+            var ownTier = key.Key.Tier;
 
-            if (NBT.IsPet(tag) || matchRarity)
-                DropUnderlistings(all, 18);
-            var size = (int)Math.Min(Math.Max(lookup.Volume * 10, 50), all.Count);
-            var sample = all.OrderByDescending(a => a.Day).ThenBy(l => l.Price)
-                .Take(size).OrderBy(r => r.Price);
-            var devider = matchRarity ? 10 : 30;
+            // Flatten the matching buckets' references into a pooled buffer, preserving the
+            // (bucket-enumeration-order, then reference-queue-order) flatten order LINQ produced.
+            ReferencePrice[] rented = null;
+            int n = 0;
+            try
+            {
+                foreach (var entry in lookup.Lookup)
+                {
+                    if (isPet)
+                    {
+                        if (ownTier != entry.Key.Tier || CleanItemPriceHasTierBoost(entry.Key.Modifiers))
+                            continue;
+                    }
+                    else
+                    {
+                        if (minRarity > entry.Key.Tier || CleanItemPriceHasPgemsOrAttribute(entry.Key.Modifiers))
+                            continue;
+                    }
+                    var references = entry.Value.ReferenceSnapshot();
+                    foreach (var r in references)
+                    {
+                        if (rented == null)
+                            rented = ArrayPool<ReferencePrice>.Shared.Rent(Math.Max(references.Length, 16));
+                        else if (n == rented.Length)
+                        {
+                            var bigger = ArrayPool<ReferencePrice>.Shared.Rent(rented.Length * 2);
+                            Array.Copy(rented, bigger, n);
+                            ArrayPool<ReferencePrice>.Shared.Return(rented);
+                            rented = bigger;
+                        }
+                        rented[n++] = r;
+                    }
+                }
 
-            if (CanHaveGems(tag) && tag != "MELON_DICER_3")
-                devider = Math.Min(14, devider);
-            var target = sample.Skip(size / devider + 1).FirstOrDefault();
-            if (IsMidas(tag))
-                return target.Price + 80_000_000; // midas gets undersold very very often
-            return target.Price;
+                Span<ReferencePrice> refs;
+                if (isPet || matchRarity)
+                {
+                    // WS-CHURN-C: drop in place on the already-contiguous rented buffer (bit-exact array twin of the
+                    // List-based DropUnderlistings), avoiding the per-call List<ReferencePrice>(n) alloc + copy. The
+                    // span over the survivors [0..dropped) is in the SAME order the List path produced.
+                    int dropped = rented == null ? 0 : DropUnderlistings(rented, n, 18);
+                    refs = rented == null ? Span<ReferencePrice>.Empty : rented.AsSpan(0, dropped);
+                }
+                else
+                {
+                    refs = rented == null ? Span<ReferencePrice>.Empty : rented.AsSpan(0, n);
+                }
+
+                var size = (int)Math.Min(Math.Max(lookup.Volume * 10, 50), refs.Length);
+                var devider = matchRarity ? 10 : 30;
+                if (CanHaveGems(tag) && tag != "MELON_DICER_3")
+                    devider = Math.Min(14, devider);
+
+                var target = CleanItemPriceSelectTarget(refs, size, size / devider + 1);
+                if (IsMidas(tag))
+                    return target.Price + 80_000_000; // midas gets undersold very very often
+                return target.Price;
+            }
+            finally
+            {
+                if (rented != null)
+                    ArrayPool<ReferencePrice>.Shared.Return(rented);
+            }
+        }
+
+        /// <summary>Non-allocating equivalent of <c>!modifiers.Any(m =&gt; m.Value == TierBoostShorthand)</c>'s negation.</summary>
+        private static bool CleanItemPriceHasTierBoost(IReadOnlyList<KeyValuePair<string, string>> modifiers)
+        {
+            for (int i = 0; i < modifiers.Count; i++)
+                if (modifiers[i].Value == TierBoostShorthand)
+                    return true;
+            return false;
+        }
+
+        /// <summary>Non-allocating equivalent of <c>modifiers.Any(m =&gt; m.Key == "pgems" || AttributeKeys.Contains(m.Key))</c>.</summary>
+        private static bool CleanItemPriceHasPgemsOrAttribute(IReadOnlyList<KeyValuePair<string, string>> modifiers)
+        {
+            for (int i = 0; i < modifiers.Count; i++)
+            {
+                var k = modifiers[i].Key;
+                if (k == "pgems" || Constants.AttributeKeys.Contains(k))
+                    return true;
+            }
+            return false;
+        }
+
+        // ====================================================================================================
+        // R5B (partial selection) — bit-exact replacement for the two-full-sort selection.
+        //
+        // The original (now kept verbatim as CleanItemPriceSelectTargetReference + phases below, the oracle the
+        // 40k fuzz in Services/CleanItemPrice.Tests.cs gates against) does TWO full stable sorts of n then size
+        // elements, then takes a SINGLE order statistic. That is wasteful: only a prefix is ever consumed and the
+        // final answer is one element. R5B replaces it with two bounded selections (quickselect-style partitions),
+        // proven equivalent to the reference total order below.
+        //
+        // Reference semantics (strict total orders — every tie is broken to a unique element):
+        //   Phase1 sorts ALL n by  K1 = (Day DESC, Price ASC, idx ASC).  The "phase-1 prefix" P = the size
+        //          smallest by K1; an element's prefix-position is its rank within P in K1 order.
+        //   Phase2 sorts P by (Price ASC, prefix-position ASC) and the answer is the element at rank `skip`.
+        //
+        // Reduction (the whole correctness argument):
+        //   Within P the K1 order == prefix-position order, so the Phase2 key (Price ASC, prefix-position ASC)
+        //   restricted to P equals (Price ASC, K1 ASC) = (Price ASC, Day DESC, Price ASC, idx ASC) = K2 where
+        //       K2 = (Price ASC, Day DESC, idx ASC).
+        //   Both K1 and K2 are STRICT (idx is unique), so the answer index a* is fully determined by MEMBERSHIP
+        //   of P alone (which intrinsic-keyed elements are the size smallest by K1) and the K2 rank within it —
+        //   the phase-1 internal ordering never needs to be materialized. Therefore:
+        //       a* = the element, among the size K1-smallest indices, at K2-rank `skip`.
+        //   Because every key is strict, there is no ordering ambiguity at either selection boundary: the result
+        //   is bit-identical to the reference for EVERY input, including heavy Day/Price ties. No per-case
+        //   fallback is required (and the 40k fuzz proves it). Pivoting/partition order is irrelevant to the
+        //   answer since the comparators are strict.
+        // ====================================================================================================
+
+        /// <summary>
+        /// Bit-exact partial-selection replacement for <see cref="CleanItemPriceSelectTargetReference"/>: avoids the
+        /// two full stable sorts by (1) partitioning the size K1-smallest indices (K1 = Day DESC, Price ASC, idx ASC)
+        /// then (2) selecting the K2-rank-<paramref name="skip"/> element among them (K2 = Price ASC, Day DESC, idx ASC).
+        /// See the block comment above for the equivalence proof. Uses pooled index buffers; zero managed alloc.
+        /// </summary>
+        internal static ReferencePrice CleanItemPriceSelectTarget(ReadOnlySpan<ReferencePrice> refs, int size, int skip)
+        {
+            if (size <= 0 || skip >= size)
+                return default; // FirstOrDefault over an empty / too-short sequence
+            int n = refs.Length;
+            // size is min(.., n) at the only call-site, so size <= n and skip < size <= n hold here.
+            // Materialize the intrinsic sort keys once into pooled local arrays so the partition can index them
+            // cheaply (and so a ReadOnlySpan does not need to be captured by a delegate).
+            short[] days = ArrayPool<short>.Shared.Rent(n);
+            long[] prices = ArrayPool<long>.Shared.Rent(n);
+            int[] idx = ArrayPool<int>.Shared.Rent(n);
+            try
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    days[i] = refs[i].Day;
+                    prices[i] = refs[i].Price;
+                    idx[i] = i;
+                }
+
+                // Phase 1 (partial): partition idx[0..n) so that idx[0..size) is exactly the membership set P =
+                // the `size` smallest by K1. We do NOT need P ordered — only the set is consumed by phase 2.
+                if (size < n)
+                    CleanItemPricePartitionPhase1(idx, 0, n - 1, size - 1, days, prices);
+
+                // Phase 2 (selection): among P = idx[0..size), select the element at K2-rank `skip`.
+                CleanItemPricePartitionPhase2(idx, 0, size - 1, skip, days, prices);
+                return refs[idx[skip]];
+            }
+            finally
+            {
+                ArrayPool<short>.Shared.Return(days);
+                ArrayPool<long>.Shared.Return(prices);
+                ArrayPool<int>.Shared.Return(idx);
+            }
+        }
+
+        /// <summary>K1 strict order on original indices a,b: Day DESC, then Price ASC, then idx ASC. Returns &lt;0 if a precedes b.</summary>
+        private static int CleanItemPriceCompareK1(int a, int b, short[] days, long[] prices)
+        {
+            int c = days[b].CompareTo(days[a]); // Day DESC
+            if (c != 0) return c;
+            c = prices[a].CompareTo(prices[b]); // Price ASC
+            if (c != 0) return c;
+            return a.CompareTo(b);              // idx ASC (a,b ARE the original indices)
+        }
+
+        /// <summary>K2 strict order on original indices a,b: Price ASC, then Day DESC, then idx ASC.</summary>
+        private static int CleanItemPriceCompareK2(int a, int b, short[] days, long[] prices)
+        {
+            int c = prices[a].CompareTo(prices[b]); // Price ASC
+            if (c != 0) return c;
+            c = days[b].CompareTo(days[a]);         // Day DESC
+            if (c != 0) return c;
+            return a.CompareTo(b);                  // idx ASC
+        }
+
+        /// <summary>
+        /// Quickselect partition by K1 so that, on return, idx[0..k] are the k+1 smallest by K1 (set, unordered) and
+        /// idx[lo..hi] is partitioned around the element that belongs at position k. Median-of-three pivot guards the
+        /// already-(reverse-)sorted adversarial inputs the reference sort tolerated. K1 is strict so the boundary at k
+        /// is unambiguous.
+        /// </summary>
+        private static void CleanItemPricePartitionPhase1(int[] idx, int lo, int hi, int k, short[] days, long[] prices)
+        {
+            while (lo < hi)
+            {
+                int p = CleanItemPricePivotPhase1(idx, lo, hi, days, prices);
+                if (p == k) return;
+                if (p < k) lo = p + 1; else hi = p - 1;
+            }
+        }
+
+        private static int CleanItemPricePivotPhase1(int[] idx, int lo, int hi, short[] days, long[] prices)
+        {
+            // median-of-three pivot selection (by K1) moved to hi-1, classic Hoare-ish Lomuto with sentinels.
+            int mid = lo + ((hi - lo) >> 1);
+            if (CleanItemPriceCompareK1(idx[mid], idx[lo], days, prices) < 0) (idx[lo], idx[mid]) = (idx[mid], idx[lo]);
+            if (CleanItemPriceCompareK1(idx[hi], idx[lo], days, prices) < 0) (idx[lo], idx[hi]) = (idx[hi], idx[lo]);
+            if (CleanItemPriceCompareK1(idx[hi], idx[mid], days, prices) < 0) (idx[mid], idx[hi]) = (idx[hi], idx[mid]);
+            // pivot = idx[mid]; park it at hi-1 (Lomuto over [lo, hi-1) with idx[hi] already >= pivot)
+            int pivot = idx[mid];
+            (idx[mid], idx[hi - 1]) = (idx[hi - 1], idx[mid]);
+            int store = lo;
+            for (int j = lo; j < hi - 1; j++)
+            {
+                if (CleanItemPriceCompareK1(idx[j], pivot, days, prices) < 0)
+                {
+                    (idx[store], idx[j]) = (idx[j], idx[store]);
+                    store++;
+                }
+            }
+            (idx[store], idx[hi - 1]) = (idx[hi - 1], idx[store]); // restore pivot to its sorted position
+            return store;
+        }
+
+        /// <summary>Quickselect partition by K2 over idx[lo..hi] so idx[k] holds the K2-rank-k element. K2 is strict.</summary>
+        private static void CleanItemPricePartitionPhase2(int[] idx, int lo, int hi, int k, short[] days, long[] prices)
+        {
+            while (lo < hi)
+            {
+                int p = CleanItemPricePivotPhase2(idx, lo, hi, days, prices);
+                if (p == k) return;
+                if (p < k) lo = p + 1; else hi = p - 1;
+            }
+        }
+
+        private static int CleanItemPricePivotPhase2(int[] idx, int lo, int hi, short[] days, long[] prices)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (CleanItemPriceCompareK2(idx[mid], idx[lo], days, prices) < 0) (idx[lo], idx[mid]) = (idx[mid], idx[lo]);
+            if (CleanItemPriceCompareK2(idx[hi], idx[lo], days, prices) < 0) (idx[lo], idx[hi]) = (idx[hi], idx[lo]);
+            if (CleanItemPriceCompareK2(idx[hi], idx[mid], days, prices) < 0) (idx[mid], idx[hi]) = (idx[hi], idx[mid]);
+            int pivot = idx[mid];
+            (idx[mid], idx[hi - 1]) = (idx[hi - 1], idx[mid]);
+            int store = lo;
+            for (int j = lo; j < hi - 1; j++)
+            {
+                if (CleanItemPriceCompareK2(idx[j], pivot, days, prices) < 0)
+                {
+                    (idx[store], idx[j]) = (idx[j], idx[store]);
+                    store++;
+                }
+            }
+            (idx[store], idx[hi - 1]) = (idx[hi - 1], idx[store]);
+            return store;
+        }
+
+        // ---- Reference (original two-full-sort) selection: the bit-exactness oracle, kept verbatim ----
+
+        /// <summary>
+        /// Reproduces, byte-for-byte, the original LINQ selection:
+        /// <c>refs.OrderByDescending(Day).ThenBy(Price).Take(size).OrderBy(Price).Skip(skip).FirstOrDefault()</c>.
+        /// Both LINQ <c>OrderBy</c>/<c>ThenBy</c> are stable; the original-index / prefix-position tiebreaks below make
+        /// the (unstable) <see cref="Array.Sort"/> produce the identical total order. Uses pooled index buffers.
+        /// This is the oracle the partial-selection <see cref="CleanItemPriceSelectTarget"/> is gated against.
+        /// </summary>
+        internal static ReferencePrice CleanItemPriceSelectTargetReference(ReadOnlySpan<ReferencePrice> refs, int size, int skip)
+        {
+            if (size <= 0 || skip >= size)
+                return default; // FirstOrDefault over an empty / too-short sequence
+            int n = refs.Length;
+            int[] order1 = ArrayPool<int>.Shared.Rent(n);
+            int[] order2 = ArrayPool<int>.Shared.Rent(size);
+            try
+            {
+                for (int i = 0; i < n; i++)
+                    order1[i] = i;
+                // Phase 1: OrderByDescending(Day).ThenBy(Price), stable via original-index tiebreak.
+                CleanItemPriceStableSortPhase1(order1, n, refs);
+                // Phase 2: first `size` of phase 1 -> OrderBy(Price), stable via prefix-position tiebreak.
+                for (int p = 0; p < size; p++)
+                    order2[p] = p;
+                CleanItemPriceStableSortPhase2(order2, size, order1, refs);
+                return refs[order1[order2[skip]]];
+            }
+            finally
+            {
+                ArrayPool<int>.Shared.Return(order1);
+                ArrayPool<int>.Shared.Return(order2);
+            }
+        }
+
+        private static void CleanItemPriceStableSortPhase1(int[] order, int n, ReadOnlySpan<ReferencePrice> refs)
+        {
+            // Materialize the sort keys into local arrays so the index comparer can capture them
+            // (a Comparison/IComparer cannot capture a Span). The comparer is stable via the original index.
+            short[] days = ArrayPool<short>.Shared.Rent(n);
+            long[] prices = ArrayPool<long>.Shared.Rent(n);
+            try
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    days[i] = refs[i].Day;
+                    prices[i] = refs[i].Price;
+                }
+                Array.Sort(order, 0, n, new CleanItemPricePhase1Comparer(days, prices));
+            }
+            finally
+            {
+                ArrayPool<short>.Shared.Return(days);
+                ArrayPool<long>.Shared.Return(prices);
+            }
+        }
+
+        private static void CleanItemPriceStableSortPhase2(int[] order2, int size, int[] order1, ReadOnlySpan<ReferencePrice> refs)
+        {
+            long[] prices = ArrayPool<long>.Shared.Rent(size);
+            try
+            {
+                for (int p = 0; p < size; p++)
+                    prices[p] = refs[order1[p]].Price;
+                Array.Sort(order2, 0, size, new CleanItemPricePhase2Comparer(prices));
+            }
+            finally
+            {
+                ArrayPool<long>.Shared.Return(prices);
+            }
+        }
+
+        private sealed class CleanItemPricePhase1Comparer : IComparer<int>
+        {
+            private readonly short[] _days;
+            private readonly long[] _prices;
+            public CleanItemPricePhase1Comparer(short[] days, long[] prices) { _days = days; _prices = prices; }
+            public int Compare(int a, int b)
+            {
+                // OrderByDescending(Day)
+                int c = _days[b].CompareTo(_days[a]);
+                if (c != 0) return c;
+                // ThenBy(Price)
+                c = _prices[a].CompareTo(_prices[b]);
+                if (c != 0) return c;
+                // stable: preserve original order
+                return a.CompareTo(b);
+            }
+        }
+
+        private sealed class CleanItemPricePhase2Comparer : IComparer<int>
+        {
+            private readonly long[] _prices; // indexed by prefix position
+            public CleanItemPricePhase2Comparer(long[] prices) { _prices = prices; }
+            public int Compare(int a, int b)
+            {
+                // OrderBy(Price)
+                int c = _prices[a].CompareTo(_prices[b]);
+                if (c != 0) return c;
+                // stable: preserve position within the phase-1 prefix
+                return a.CompareTo(b);
+            }
         }
 
         private bool CanHaveGems(string tag)
@@ -2088,6 +3770,23 @@ ORDER BY l.`AuctionId`  DESC;
         {
             return DetailedKeyFromSaveAuction(auction);
         }
+
+        /// <summary>WS-A test hook: parse <paramref name="auction"/> a FRESH way (memo bypassed) and then via the parse
+        /// memo at the SAME pricing epoch (forcing a store-then-serve), and return whether the two outputs are equal by
+        /// the parse contract (<see cref="ParseResultsEqual"/>). Used by the parse-memo bit-exactness unit test so the
+        /// guard's equality contract is covered without needing the env flag / a full replay. Returns true iff bit-exact.</summary>
+        internal bool ParseMemoRoundtripEqualsForTest(SaveAuction auction)
+        {
+            var fresh = ParseFresh(auction, false, 5);
+            ulong hash = BatchContentHash(auction); // always-computed standalone hash (independent of ParseMemoActive)
+            long epoch = Interlocked.Read(ref pricingEpoch);
+            // store + serve at the same epoch (mirrors the memo's store-then-hit roundtrip)
+            var (enchants, modifiers) = SelectValuable(auction);
+            var built = ParseBodyAfterSelect(auction, enchants, modifiers, Constants.RelevantReforges.Contains(auction.Reforge), 5);
+            parseMemo.Values[hash] = new ParseMemo.Entry(built, epoch);
+            var served = parseMemo.Values.TryGetValue(hash, out var e) && e.Epoch == epoch ? e.Value : built;
+            return ParseResultsEqual(fresh, served) && ParseResultsEqual(served, fresh);
+        }
         private KeyWithValueBreakdown DetailedKeyFromSaveAuction(SaveAuction auction, bool fastMode = false, int limit = 5)
         {
             var shouldIncludeReforge = Constants.RelevantReforges.Contains(auction.Reforge);
@@ -2096,9 +3795,66 @@ ORDER BY l.`AuctionId`  DESC;
             List<RankElem> rankElems = [];
             List<Enchant> enchants;
             List<KeyValuePair<string, string>> modifiers;
+            // SelectValuable is the unavoidable one-time content traversal (the irreducible floor); it also folds the
+            // flatNbt portion of the content hash into _flatNbtContentHash as it walks (WS-A "fuse, no second pass").
+            // We always run it: it produces the modifiers AND the enchants the rest of the hash needs, and it is the
+            // cheap part of the parse (<0.1% de-inlined). The memo skips the HEAVIER tail (CapKeyLength + ComparisonValue
+            // + Constructkey) on a hit.
             (enchants, modifiers) = SelectValuable(auction, fastMode);
 
-            (valueSubstracted, removedRarity, shouldIncludeReforge, rankElems) = CapKeyLength(enchants, modifiers, auction, limit);
+            // WS-A: the (contentHash, pricingEpoch) probe. Only the non-fastMode parse is memoized — fastMode is a
+            // distinct output shape (and a rare bulk path), so it is never served from / stored into the memo. The
+            // counting probe runs regardless (so production self-measures the cross-auction dup at any setting).
+            ulong contentHash = 0;
+            long epoch = 0;
+            // The memo machinery runs when the cross-auction memo is ON, when only counting, OR when the parity guard is
+            // on. VerifyParseMemo forces serve+store behaviour (memoServes) even if SNIPER_PARSE_MEMO is off, so the
+            // guard validates the actual hit path on every duplicate. Only the standard non-fastMode/limit==5 parse is
+            // memoized (fastMode is a distinct, rare output shape).
+            bool wantMemo = !fastMode && limit == 5 && ParseMemoActive;
+            bool memoServes = ParseMemoEnabled || VerifyParseMemo;
+            if (wantMemo)
+            {
+                contentHash = ComputeContentHash(auction, enchants);
+                epoch = Interlocked.Read(ref pricingEpoch);
+                if (ParseMemoCount)
+                    Interlocked.Increment(ref ParseMemoCalls);
+                bool epochHit = parseMemo.Values.TryGetValue(contentHash, out var memoEntry) && memoEntry.Epoch == epoch;
+                if (ParseMemoCount)
+                {
+                    if (epochHit) Interlocked.Increment(ref ParseMemoHits);
+                    else Interlocked.Increment(ref ParseMemoMisses);
+                }
+                if (memoServes && epochHit)
+                {
+                    if (VerifyParseMemo)
+                        AssertParseMemoParity(auction, fastMode, limit, memoEntry.Value);
+                    // `enchants`/`modifiers` are discarded (the heavy CapKeyLength tail that would have consumed them is
+                    // skipped); the cached breakdown is read-only downstream (GetReduced allocates fresh reduced keys).
+                    return memoEntry.Value;
+                }
+            }
+
+            var built = ParseBodyAfterSelect(auction, enchants, modifiers, shouldIncludeReforge, limit);
+            // WS-A: store the fresh parse under (contentHash, epoch). Overwrite in place (no dict realloc — the warm
+            // fix): within one epoch the parse is deterministic for fixed content, so a concurrent same-(hash,epoch)
+            // writer stores an equivalent value (last-writer-wins is harmless). A stamp captured a hair before the parse
+            // can only make a future read re-parse (a conservative miss), never serve a value the live state wouldn't.
+            if (wantMemo && memoServes)
+                parseMemo.Values[contentHash] = new ParseMemo.Entry(built, epoch);
+            return built;
+        }
+
+        // The parse tail (everything after SelectValuable): cap the key by the live market threshold, apply the tier
+        // adjustments / no-effect-enchant + modifier cleanups, and construct the key+breakdown. Extracted verbatim from
+        // DetailedKeyFromSaveAuction so the parity guard's fresh re-parse (ParseFresh) and the main path share ONE body
+        // — no divergence risk. `enchants`/`modifiers` are mutated in place here (as before), so callers must pass
+        // freshly-SelectValuable'd lists (the main path and ParseFresh both do).
+        private KeyWithValueBreakdown ParseBodyAfterSelect(SaveAuction auction, List<Enchant> enchants,
+            List<KeyValuePair<string, string>> modifiers, bool shouldIncludeReforge, int limit)
+        {
+            var (valueSubstracted, removedRarity, includeReforge, rankElems) = CapKeyLength(enchants, modifiers, auction, limit);
+            shouldIncludeReforge = includeReforge;
 
             if (enchants == null)
                 enchants = new List<Enchant>();
@@ -2123,38 +3879,284 @@ ORDER BY l.`AuctionId`  DESC;
             var reducedEnchants = RemoveNoEffectEnchants(auction, enchants);
             if (reducedEnchants.Count < enchants.Count)
             {
-                rankElems = rankElems.Where(r => r.Enchant.Type == default || reducedEnchants.Any(re => re.Type == r.Enchant.Type)).ToList();
+                // Cold path (an enchant was dropped): keep breakdown entries for non-enchant items or surviving enchants.
+                var kept = new List<RankElem>(rankElems.Count);
+                for (int i = 0; i < rankElems.Count; i++)
+                {
+                    var r = rankElems[i];
+                    if (r.Enchant.Type == default || ContainsEnchantType(reducedEnchants, r.Enchant.Type))
+                        kept.Add(r);
+                }
+                rankElems = kept;
                 enchants = reducedEnchants;
             }
             if (auction.Tag != null && AttributeToIgnoreOnLookup.TryGetValue(auction.Tag, out var ignore))
             {
                 modifiers.RemoveAll(m => ignore.Contains(m.Key));
             }
-            if (modifiers.Any(m => m.Key == "rarity_upgrades") && !Constants.DoesRecombMatter(auction.Category, auction.Tag))
+            if (AnyModifierKey(modifiers, "rarity_upgrades") && !Constants.DoesRecombMatter(auction.Category, auction.Tag))
             {
-                modifiers.RemoveAll(m => m.Key == "rarity_upgrades");
+                RemoveModifiersByKey(modifiers, "rarity_upgrades");
                 if (!IsRune(auction.Tag))
                     tier = ReduceRarity(tier);
             }
             // Remove PET_ITEM_TIER_BOOST if it somehow got into modifiers (it shouldn't be in the key)
-            modifiers.RemoveAll(m => m.Value == "TIER_BOOST");
+            RemoveModifiersByValue(modifiers, "TIER_BOOST");
 
             return Constructkey(auction, enchants, modifiers, shouldIncludeReforge, valueSubstracted, rankElems, tier);
         }
 
-        private (List<Enchant> enchants, List<KeyValuePair<string, string>> modifiers) SelectValuable(SaveAuction auction, bool fastMode = false)
+        // WS-A parity guard: a FULL fresh parse with the memo bypassed (re-runs SelectValuable + the shared body), so the
+        // guard compares the memoized value against an independent recompute. Used only under SNIPER_VERIFY_PARSE_MEMO.
+        private KeyWithValueBreakdown ParseFresh(SaveAuction auction, bool fastMode, int limit)
         {
-            var enchants = auction.Enchantments
-                            ?.Where(e => MinEnchantMap.TryGetValue(e.Type, out byte value) && e.Level >= value)
-                            .OrderBy(e => e.Type)
-                            .Select(e => new Models.Enchant() { Lvl = e.Level, Type = e.Type }).ToList();
+            var shouldIncludeReforge = Constants.RelevantReforges.Contains(auction.Reforge);
+            var (enchants, modifiers) = SelectValuable(auction, fastMode);
+            return ParseBodyAfterSelect(auction, enchants, modifiers, shouldIncludeReforge, limit);
+        }
+
+        // Equality of two parse outputs by the type's OWN contract (what every downstream consumer relies on): the
+        // AuctionKey's Equals + GetHashCode are deliberately ORDER-INDEPENDENT over Enchants/Modifiers (bucket selection,
+        // the reduced-key dispatch's membership compaction, and the dictionary hash/equals all treat the key as an
+        // unordered set — see AuctionKey.Equals/GetHashCode). Modifier/enchant ORDER (from the pooled-dict iteration) and
+        // value-tie order in the breakdown (the unstable Sort) are PRE-EXISTING non-determinism — two FRESH parses of the
+        // same auction can already produce different orders, and nothing correctness-bearing reads them positionally — so
+        // the parity guard compares as an unordered multiset, exactly matching the contract a memo hit must preserve.
+        private static bool ParseResultsEqual(KeyWithValueBreakdown a, KeyWithValueBreakdown b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return false;
+            if (a.SubstractedValue != b.SubstractedValue) return false;
+            if (!Equals(a.Key, b.Key)) return false;          // AuctionKey.Equals (containment, order-independent)
+            if (!Equals(b.Key, a.Key)) return false;          // symmetric containment (proves count+membership both ways)
+            // SubstractedValue (compared above) is the parse's substracted total; KeyWithValueBreakdown.Key is the base
+            // AuctionKey (no per-instance ValueSubstract field — that lives on AuctionKeyWithValue, produced by GetReduced).
+            return BreakdownMultisetEqual(a.ValueBreakdown, b.ValueBreakdown);
+        }
+
+        // Order-independent multiset comparison of two value breakdowns (the Sort is unstable, so value-tie order is
+        // non-deterministic). Greedy match by RankElem.Equals (Enchant + Modifier + Reforge + Value) plus IsEstimate.
+        private static bool BreakdownMultisetEqual(List<RankElem> ab, List<RankElem> bb)
+        {
+            if (ab == null || bb == null) return ab == bb;
+            if (ab.Count != bb.Count) return false;
+            var matched = new bool[bb.Count];
+            for (int i = 0; i < ab.Count; i++)
+            {
+                var x = ab[i];
+                bool found = false;
+                for (int j = 0; j < bb.Count; j++)
+                {
+                    if (matched[j]) continue;
+                    var y = bb[j];
+                    if (x.Value == y.Value && x.IsEstimate == y.IsEstimate && x.Reforge == y.Reforge
+                        && x.Enchant.Equals(y.Enchant)
+                        && x.Modifier.Key == y.Modifier.Key && x.Modifier.Value == y.Modifier.Value)
+                    { matched[j] = true; found = true; break; }
+                }
+                if (!found) return false;
+            }
+            return true;
+        }
+
+        // WS-A: the immutable-content FNV hash. Combines the flatNbt portion (folded into _flatNbtContentHash by the
+        // SelectValuable traversal we just ran) with the FILTERED enchants (Type+Lvl, the parse's actual enchant input),
+        // Tier, Reforge, Count, Tag, AND HighestBidAmount. HighestBidAmount feeds CapKeyLength's percentDiff and so the
+        // substracted value/breakdown — a per-instance value that genuinely affects the parse output, so it is included
+        // for correctness (over-miss safe; the parity guard would fire if it were wrongly excluded). The enchant list is
+        // order-deterministic here (SelectValuable stable-sorts by Type), so a positional fold is content-stable.
+        private static ulong ComputeContentHash(SaveAuction auction, List<Enchant> enchants)
+        {
+            ulong h = FnvOffset ^ _flatNbtContentHash;
+            h = FnvString(h, auction.Tag);
+            h = FnvLong(h, (long)auction.Tier);
+            h = FnvLong(h, (long)auction.Reforge);
+            h = FnvLong(h, auction.Count);
+            h = FnvLong(h, auction.HighestBidAmount);
+            if (enchants != null)
+                for (int i = 0; i < enchants.Count; i++)
+                {
+                    var e = enchants[i];
+                    h = FnvLong(h, (long)e.Type);
+                    h = FnvLong(h, e.Lvl);
+                }
+            return h;
+        }
+
+        // WS-A parity guard: recompute a FRESH parse (memo bypassed) and assert byte-equal AuctionKey + breakdown vs the
+        // memoized value. Throws loudly on divergence — catches a wrong NonContentKeys exclusion / a stale-epoch serve.
+        private void AssertParseMemoParity(SaveAuction auction, bool fastMode, int limit, KeyWithValueBreakdown memoized)
+        {
+            var fresh = ParseFresh(auction, fastMode, limit);
+            if (!ParseResultsEqual(memoized, fresh))
+            {
+                var nbt = auction.FlatenedNBT == null ? "(null)" : string.Join(",", auction.FlatenedNBT.Select(m => m.Key + "=" + m.Value));
+                throw new InvalidOperationException(
+                    $"PARSE MEMO DIVERGENCE tag={auction.Tag} uuid={auction.Uuid} hb={auction.HighestBidAmount} nbt=[{nbt}] memo=[{memoized}] fresh=[{fresh}]");
+            }
+        }
+
+        // FNV-1a 64-bit constants — the content hash is FNV over the immutable item content (cheap, well-distributed,
+        // no allocation). Folded into SelectValuable's existing single flatNbt traversal (the WS-A "fuse, no second
+        // pass" rail) and combined with the enchant/scalar content in DetailedKeyFromSaveAuction.
+        private const ulong FnvOffset = 14695981039346656037UL;
+        private const ulong FnvPrime = 1099511628211UL;
+        // [ThreadStatic] accumulator: SelectValuable folds the (non-per-instance) flatNbt entries it traverses into this
+        // per-worker slot; DetailedKeyFromSaveAuction reads it immediately after the call (same thread, no escape). Used
+        // only when the caller wants the content hash; GetFullKey/GetBreakdownKey ignore it.
+        [ThreadStatic] private static ulong _flatNbtContentHash;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong FnvString(ulong h, string s)
+        {
+            // Hash the UTF-16 chars directly (the strings are interned-ish small NBT keys/values); deterministic and
+            // allocation-free. A null is folded as a single distinguishing byte so null vs "" never collide.
+            if (s == null)
+                return (h ^ 0xFF) * FnvPrime;
+            for (int i = 0; i < s.Length; i++)
+                h = (h ^ (byte)s[i]) * FnvPrime ^ ((byte)(s[i] >> 8)) * FnvPrime;
+            return h;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong FnvLong(ulong h, long v)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                h = (h ^ (byte)v) * FnvPrime;
+                v >>= 8;
+            }
+            return h;
+        }
+
+        // splitmix64 finalizer — a strong avalanche mixer. Applied to each per-flatNbt-entry FNV hash BEFORE the
+        // order-independent commutative SUM, so the entries' contributions have no linear structure that lets two
+        // different (key,value) sets sum to the same total (a raw-FNV commutative SUM collided two distinct
+        // {scroll_count,upgrade_level} contents — finalizing each addend kills that). Order-independence is preserved
+        // (addition is commutative); collision-resistance is restored to ~2^-64 per pair.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong Mix(ulong z)
+        {
+            z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
+            z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
+            return z ^ (z >> 31);
+        }
+
+        // WS-D: a STANDALONE content hash over the RAW immutable SaveAuction content — the same content definition the
+        // parse memo keys on (flatNbt minus per-instance "uid" keys + raw Enchantments Type+Lvl + Tier + Reforge + Count
+        // + Tag + HighestBidAmount), but computed directly from the SaveAuction WITHOUT running SelectValuable. Two
+        // auctions with the same hash have byte-identical parse inputs, so within one pricing epoch they parse to the
+        // identical key — i.e. this is a sufficient condition for a parse-memo hit. Used to measure intra-Kafka-batch
+        // parse duplication (the first REAL dup number — a property of the batch, measurable without production
+        // telemetry). It hashes the RAW (unfiltered) enchants rather than the SelectValuable-filtered set; that is a
+        // conservative dup measure (raw-equal ⟹ filtered-equal), so it can only UNDER-count duplicates, never over-count.
+        public static ulong BatchContentHash(SaveAuction auction)
+        {
+            ulong flatHash = 0;
+            var flatNbt = auction.FlatenedNBT;
+            if (flatNbt != null)
+                foreach (var item in flatNbt)
+                {
+                    if (IsNonContentKey(item.Key))
+                        continue;
+                    flatHash += Mix(FnvString(FnvString(FnvOffset, item.Key), item.Value));
+                }
+            ulong h = FnvOffset ^ flatHash;
+            h = FnvString(h, auction.Tag);
+            h = FnvLong(h, (long)auction.Tier);
+            h = FnvLong(h, (long)auction.Reforge);
+            h = FnvLong(h, auction.Count);
+            h = FnvLong(h, auction.HighestBidAmount);
+            var ench = auction.Enchantments;
+            if (ench != null)
+                for (int i = 0; i < ench.Count; i++)
+                {
+                    // ORDER-independent over enchants (raw Enchantments order is not guaranteed): finalized commutative fold.
+                    h += Mix(FnvLong(FnvLong(FnvOffset, (long)ench[i].Type), ench[i].Level));
+                }
+            return h;
+        }
+
+        // WS-D: count distinct-content vs total over a batch of auctions (the kept Kafka batch, or a replay dispatch
+        // batch). Returns (distinct, total). Accumulates into the rolling overall counters when track=true.
+        public static (int distinct, int total) MeasureBatchDup(IReadOnlyList<SaveAuction> batch, bool track = true)
+        {
+            if (batch == null || batch.Count == 0)
+                return (0, 0);
+            var seen = new HashSet<ulong>(batch.Count);
+            for (int i = 0; i < batch.Count; i++)
+                seen.Add(BatchContentHash(batch[i]));
+            if (track)
+            {
+                Interlocked.Add(ref BatchDupTotal, batch.Count);
+                Interlocked.Add(ref BatchDupDistinct, seen.Count);
+                Interlocked.Increment(ref BatchDupBatches);
+            }
+            return (seen.Count, batch.Count);
+        }
+
+        // WS-D rolling counters (overall across all measured batches). Reported by the replay / production probe.
+        internal static long BatchDupTotal;
+        internal static long BatchDupDistinct;
+        internal static long BatchDupBatches;
+        // WS-D production batch-dup probe: when on, ConsumeNewAuctions measures the kept Kafka batch's distinct-vs-total.
+        internal static readonly bool BatchDupCount
+            = Environment.GetEnvironmentVariable("SNIPER_BATCH_DUP_COUNT") is "1" or "true" or "TRUE";
+
+        // Conservative per-instance exclusion: only keys containing "uid"/"uuid" (the codebase's own per-instance
+        // marker — see e.g. `!f.Key.Contains("uid")` in IsValuableEnoughForClosest). Everything else is hashed →
+        // over-miss is safe, under-miss is a correctness bug. "uuid" contains "uid", so the single Contains covers both.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsNonContentKey(string key) => key != null && key.Contains("uid");
+
+        internal (List<Enchant> enchants, List<KeyValuePair<string, string>> modifiers) SelectValuable(SaveAuction auction, bool fastMode = false)
+        {
+            // De-LINQ of `Enchantments?.Where(...).OrderBy(e => e.Type).Select(new Enchant).ToList()`. Filter into the
+            // result list directly (no Where/Select iterators), then stable-sort by Type with an insertion sort —
+            // OrderBy is a stable sort and the enchant counts are tiny, so insertion sort is both bit-identical (ties
+            // keep their original relative order) and allocation-free.
+            List<Enchant> enchants = null;
+            var sourceEnchants = auction.Enchantments;
+            if (sourceEnchants != null)
+            {
+                enchants = new List<Enchant>(sourceEnchants.Count);
+                for (int i = 0; i < sourceEnchants.Count; i++)
+                {
+                    var e = sourceEnchants[i];
+                    if (MinEnchantMap.TryGetValue(e.Type, out byte value) && e.Level >= value)
+                        enchants.Add(new Models.Enchant() { Lvl = e.Level, Type = e.Type });
+                }
+                // stable insertion sort by Type (== Comparer<EnchantmentType>.Default, the OrderBy key comparer)
+                for (int i = 1; i < enchants.Count; i++)
+                {
+                    var cur = enchants[i];
+                    int j = i - 1;
+                    while (j >= 0 && enchants[j].Type > cur.Type)
+                    {
+                        enchants[j + 1] = enchants[j];
+                        j--;
+                    }
+                    enchants[j + 1] = cur;
+                }
+            }
             var flatNbt = auction.FlatenedNBT;
 
+            // WS-A: when the parse memo is active, fold each non-per-instance flatNbt entry's FNV into an
+            // ORDER-INDEPENDENT, splitmix-finalized accumulator (sum of finalized per-entry hashes) — Dictionary
+            // iteration order is not guaranteed stable across two distinct dicts holding the same content, so a
+            // commutative combine makes the content hash insertion-order-invariant; the finalizer makes the sum
+            // collision-resistant. Hashed BEFORE the include filter, so the hash covers the full immutable content, not
+            // just the SelectValuable-kept subset (a hit guarantees byte-identical inputs to the whole parse). When the
+            // memo is OFF (the shipped default) this hashing is skipped — the path is byte-for-byte the pre-R7 parse.
+            bool hashContent = ParseMemoActive;
+            ulong flatHash = 0;
             if (!AllocatedDicts.TryDequeue(out var modifiers))
                 modifiers = new Dictionary<string, string>(5);
             if (flatNbt != null)
                 foreach (var item in flatNbt)
                 {
+                    if (hashContent && !IsNonContentKey(item.Key))
+                        flatHash += Mix(FnvString(FnvString(FnvOffset, item.Key), item.Value));
                     if (!IncludeKeys.Contains(item.Key) && item.Value != "PERFECT" && !IsRune(item.Key) && !IsSoul(item))
                     {
                         continue;
@@ -2163,6 +4165,8 @@ ORDER BY l.`AuctionId`  DESC;
                     if (normalized.Key != Ignore.Key)
                         modifiers.Add(normalized.Key, normalized.Value);
                 }
+            if (hashContent)
+                _flatNbtContentHash = flatHash;
             if (auction.ItemCreatedAt < UnlockedIntroduction
                 // safe guard for when the creation date is wrong 
                 && flatNbt != null
@@ -2177,7 +4181,60 @@ ORDER BY l.`AuctionId`  DESC;
                 if (allUnlockable?.Count > 0)
                     modifiers.Add("unlocked_slots", string.Join(",", allUnlockable.OrderBy(s => s)));
             }
-            return (enchants, modifiers.ToList());
+            var result = modifiers.ToList();
+            // Recycle the working dictionary back into the pool (it was only ever dequeued, never returned, so this path
+            // allocated a fresh dict every auction). The contents have been copied into `result`; clear and re-enqueue.
+            modifiers.Clear();
+            if (AllocatedDicts.Count < 256)
+                AllocatedDicts.Enqueue(modifiers);
+            return (enchants, result);
+        }
+
+        // Allocation-free replacements for the per-auction `modifiers.Any(...)` / `modifiers.RemoveAll(...)` lambdas in
+        // DetailedKeyFromSaveAuction (each ran every call and allocated a delegate). RemoveAll-equivalent: removes every
+        // match while preserving the relative order of the rest (in-place compaction).
+        private static bool AnyModifierKey(List<KeyValuePair<string, string>> modifiers, string key)
+        {
+            for (int i = 0; i < modifiers.Count; i++)
+                if (modifiers[i].Key == key) return true;
+            return false;
+        }
+
+        private static void RemoveModifiersByKey(List<KeyValuePair<string, string>> modifiers, string key)
+        {
+            int write = 0;
+            for (int read = 0; read < modifiers.Count; read++)
+            {
+                if (modifiers[read].Key == key)
+                    continue;
+                if (write != read)
+                    modifiers[write] = modifiers[read];
+                write++;
+            }
+            if (write < modifiers.Count)
+                modifiers.RemoveRange(write, modifiers.Count - write);
+        }
+
+        private static void RemoveModifiersByValue(List<KeyValuePair<string, string>> modifiers, string value)
+        {
+            int write = 0;
+            for (int read = 0; read < modifiers.Count; read++)
+            {
+                if (modifiers[read].Value == value)
+                    continue;
+                if (write != read)
+                    modifiers[write] = modifiers[read];
+                write++;
+            }
+            if (write < modifiers.Count)
+                modifiers.RemoveRange(write, modifiers.Count - write);
+        }
+
+        private static bool ContainsEnchantType(List<Enchant> enchants, Enchantment.EnchantmentType type)
+        {
+            for (int i = 0; i < enchants.Count; i++)
+                if (enchants[i].Type == type) return true;
+            return false;
         }
 
         private static KeyWithValueBreakdown Constructkey(SaveAuction auction, List<Enchant> enchants, List<KeyValuePair<string, string>> modifiers, bool shouldIncludeReforge, long valueSubstracted, List<RankElem> rankElems, Tier tier)
@@ -2282,6 +4339,16 @@ ORDER BY l.`AuctionId`  DESC;
             return SoulKeys.Contains(n.Key);
         }
 
+        // [ThreadStatic] scratch for CapKeyLength's two genuinely-transient working lists. CapKeyLength runs on the
+        // ingest worker threads (per-worker [ThreadStatic] is race-free, mirroring _cmbRelevant / the PotentialSnipe
+        // scratch). `_capCombined` is the SortCombined output (filtered+sorted), `_capToRemove` the below-threshold set;
+        // both are fully consumed inside this method and never escape (their RankElem references are copied — by value —
+        // into the returned `ordered`/`ranked` list, so reusing the list container is safe). The returned `ranked`
+        // (GetOrdered) is retained on the breakdown, so it stays a fresh allocation. `raw` (ComparisonValue's return)
+        // is left fresh: ComparisonValue is a shared/benchmark-exposed API whose return contract must not become pooled.
+        [ThreadStatic] private static List<RankElem> _capCombined;
+        [ThreadStatic] private static List<RankElem> _capToRemove;
+
         /// <summary>
         /// To find more matches the key length is capped.
         /// This is done by removing the lowest value enchantment or modifier
@@ -2294,17 +4361,27 @@ ORDER BY l.`AuctionId`  DESC;
         {
             long underlyingItemValue = GetCleanItemValue(auction, ref threshold);
             long valueSubstracted = HandleGems(modifiers, auction);
-            IEnumerable<RankElem> combined = ComparisonValue(enchants, modifiers, auction.Tag, auction.FlatenedNBT);
+            // ComparisonValue now returns a concrete List<RankElem> (enchants then modifiers, in order). Append the
+            // reforge straight onto it (no Append iterator), then filter+sort in place — bit-identical to the old
+            // SortCombined (same Value!=0 filter, same unstable List.Sort by descending Value over the same input order).
+            var raw = (List<RankElem>)ComparisonValue(enchants, modifiers, auction.Tag, auction.FlatenedNBT) ?? new List<RankElem>();
 
-            bool includeReforge = AddReforgeValue(auction.Reforge, ref combined);
-            combined = SortCombined(combined);
+            bool includeReforge = AddReforgeValue(auction.Reforge, raw);
+            List<RankElem> combined = SortCombined(raw);
 
-            var modifierSum = underlyingItemValue + combined?.Select(m => m.IsEstimate ? m.Value / 20 : m.Value).DefaultIfEmpty(0).Sum() ?? 0;
+            // modifierSum: underlyingItemValue + Σ (IsEstimate ? Value/20 : Value), 0 when empty (DefaultIfEmpty(0)).
+            long sum = 0;
+            for (int i = 0; i < combined.Count; i++)
+            {
+                var m = combined[i];
+                sum += m.IsEstimate ? m.Value / 20 : m.Value;
+            }
+            var modifierSum = underlyingItemValue + sum;
             threshold = Math.Max(threshold, modifierSum / 22);
             var percentDiff = (double)auction.HighestBidAmount / modifierSum;
             if (auction.HighestBidAmount == 0 || percentDiff > 1)
                 percentDiff = 1;
-            // remove all but the top 5 
+            // remove all but the top 5
             List<RankElem> toRemove = GetItemsToRemove(threshold, combined);
             bool removedRarity = false;
             foreach (var item in toRemove)
@@ -2340,10 +4417,13 @@ ORDER BY l.`AuctionId`  DESC;
             List<RankElem> ordered = GetOrdered(elements, combined);
             return (valueSubstracted, removedRarity, includeReforge, ordered);
 
-            static IEnumerable<RankElem> SortCombined(IEnumerable<RankElem> combined)
+            // Clear-and-reuse the [ThreadStatic] _capCombined buffer instead of allocating per call. Bit-identical to the
+            // old `new List(...)` form: same Value!=0 filter over the same input order, same unstable List.Sort by
+            // descending Value. The buffer is never `list` itself (list==raw, fresh), so the clear is safe.
+            static List<RankElem> SortCombined(List<RankElem> list)
             {
-                var list = combined as ICollection<RankElem> ?? combined.ToList();
-                var filtered = new List<RankElem>(list.Count);
+                var filtered = _capCombined ??= new List<RankElem>();
+                filtered.Clear();
                 foreach (var c in list)
                 {
                     if (c.Value != 0)
@@ -2353,18 +4433,33 @@ ORDER BY l.`AuctionId`  DESC;
                 return filtered;
             }
 
-            static List<RankElem> GetOrdered(int elements, IEnumerable<RankElem> combined)
+            // Bit-identical to the old `combined.Where(c => c.Value == 0).Concat(combined.Take(elements)).ToList()`:
+            // `combined` here is the SortCombined output (all Value != 0), so the Where(==0) prefix is always empty and
+            // this is simply the first `elements` entries — but the zero-prefix is kept explicit to match exactly.
+            static List<RankElem> GetOrdered(int elements, List<RankElem> combined)
             {
-                return combined.Where(c => c.Value == 0).Concat(combined.Take(elements)).ToList();
+                var ordered = new List<RankElem>(Math.Min(combined.Count, elements));
+                foreach (var c in combined)
+                    if (c.Value == 0)
+                        ordered.Add(c);
+                int take = Math.Min(elements, combined.Count);
+                for (int i = 0; i < take; i++)
+                    ordered.Add(combined[i]);
+                return ordered;
             }
         }
 
-        private static List<RankElem> GetItemsToRemove(long threshold, IEnumerable<RankElem> combined)
+        private static List<RankElem> GetItemsToRemove(long threshold, List<RankElem> combined)
         {
-            var toRemove = new List<RankElem>(5);
-            int i = 0;
-            foreach (var c in combined)
+            // Clear-and-reuse the [ThreadStatic] _capToRemove buffer (distinct from _capCombined, which `combined`
+            // aliases — they never share). Bit-identical to the old `new List<RankElem>(5)` form: same predicate, same
+            // order; only the list container is reused (its RankElem references are consumed in CapKeyLength's removal
+            // loop and never escape).
+            var toRemove = _capToRemove ??= new List<RankElem>(5);
+            toRemove.Clear();
+            for (int i = 0; i < combined.Count; i++)
             {
+                var c = combined[i];
                 // keep top 1 even if below threshold
                 // always remove below 500k or ~1.6%
                 if ((i >= 5 && c.Value > 0)
@@ -2373,7 +4468,6 @@ ORDER BY l.`AuctionId`  DESC;
                 {
                     toRemove.Add(c);
                 }
-                i++;
             }
 
             return toRemove;
@@ -2397,18 +4491,31 @@ ORDER BY l.`AuctionId`  DESC;
 
         private long HandleGems(List<KeyValuePair<string, string>> modifiers, SaveAuction auction)
         {
-            var gems = modifiers.Where(m => m.Value == "PERFECT").ToList();
-            long valueSubstracted = 0;
-            foreach (var item in gems)
+            // Snapshot the PERFECT gems first (the loop mutates `modifiers` via Remove, so we cannot iterate it live).
+            // De-LINQ of `modifiers.Where(m => m.Value == "PERFECT").ToList()` — same order, same elements; the common
+            // no-gem case avoids the list allocation entirely.
+            int gemCount = 0;
+            List<KeyValuePair<string, string>> gems = null;
+            for (int i = 0; i < modifiers.Count; i++)
             {
-                var gemKey = mapper.GetItemKeyForGem(item, auction.FlatenedNBT);
-                if (BazaarPrices.TryGetValue(gemKey, out var price))
+                if (modifiers[i].Value == "PERFECT")
                 {
-                    valueSubstracted += (long)price; // no removal cost because this is just add
-                    modifiers.Remove(item);
+                    (gems ??= new List<KeyValuePair<string, string>>()).Add(modifiers[i]);
+                    gemCount++;
                 }
             }
-            if (gems.Count == 5)
+            long valueSubstracted = 0;
+            if (gems != null)
+                foreach (var item in gems)
+                {
+                    var gemKey = mapper.GetItemKeyForGem(item, auction.FlatenedNBT);
+                    if (BazaarPrices.TryGetValue(gemKey, out var price))
+                    {
+                        valueSubstracted += (long)price; // no removal cost because this is just add
+                        modifiers.Remove(item);
+                    }
+                }
+            if (gemCount == 5)
             {
                 modifiers.Add(new("pgems", "5"));
             }
@@ -2436,41 +4543,102 @@ ORDER BY l.`AuctionId`  DESC;
             return includeReforge;
         }
 
-        private IEnumerable<RankElem> ComparisonValue(IEnumerable<Enchant> enchants, IList<KeyValuePair<string, string>> modifiers, string tag, Dictionary<string, string> flatNbt)
+        /// <summary>
+        /// Allocation-free variant of <see cref="AddReforgeValue"/> for the hot key-extraction path: appends the reforge
+        /// <see cref="RankElem"/> straight onto the working list instead of wrapping it in an <c>Append</c> iterator. The
+        /// LINQ overload is kept for the candidate-scoring callers that pass a deferred sequence.
+        /// </summary>
+        private bool AddReforgeValue(ItemReferences.Reforge reforge, List<RankElem> combined)
         {
-            var valuePerEnchant = enchants?.Select(item => new RankElem(item, mapper.EnchantValue(new Core.Enchantment(item.Type, item.Lvl), null, BazaarPrices, tag)));
+            bool includeReforge = Constants.RelevantReforges.Contains(reforge);
+            if (includeReforge)
+            {
+                if (ReforgeValueLookup.TryGetValue(reforge, out var value))
+                {
+                    combined.Add(value.Item1);
+                    return includeReforge;
+                }
+                long reforgeValue = GetReforgeValue(reforge);
+                var element = new RankElem(reforge, reforgeValue);
+                combined.Add(element);
+                if (reforgeValue > 0)
+                    ReforgeValueLookup[reforge] = (element, DateTime.UtcNow);
+            }
 
-            var handler = (KeyValuePair<string, string> mod) =>
+            return includeReforge;
+        }
+
+        internal IEnumerable<RankElem> ComparisonValue(IEnumerable<Enchant> enchants, IList<KeyValuePair<string, string>> modifiers, string tag, Dictionary<string, string> flatNbt)
+        {
+            // De-LINQ + de-alloc: the original built a lazy enchant Select, an eager modifier list, then Concat'd them
+            // into a deferred IEnumerable the caller re-materialized. Build the single combined list directly instead —
+            // enchants first (in order), then modifiers (index-based, see the mutation note) — which is bit-identical to
+            // `valuePerEnchant.Concat(valuePerModifier)` once enumerated, with no Select/Concat iterators. The enchant
+            // values are independent of modifier processing, so evaluating them eagerly here yields the same RankElems.
+            if (enchants == null && modifiers == null)
+                return null;
+
+            int enchCount = enchants is ICollection<Enchant> ec ? ec.Count : 0;
+            var combined = new List<RankElem>(enchCount + (modifiers?.Count ?? 0));
+
+            if (enchants != null)
+                foreach (var item in enchants)
+                    combined.Add(new RankElem(item, mapper.EnchantValue(new Core.Enchantment(item.Type, item.Lvl), null, BazaarPrices, tag)));
+
+            if (modifiers != null)
             {
-                var lookupKey = new ModifierLookupKey() { ItemTag = tag, Modifier = mod, RelevantModifiers = modifiers.GroupBy(m => m.Key).Select(m => m.First()).ToDictionary() };
-                if (ModifierValueLookup.TryGetValue(lookupKey, out var value))
+                // Build the deduped relevant-modifier set once per call (first occurrence per key wins) rather than
+                // rebuilding it for every modifier — it is the ModifierValueLookup cache key and was a per-modifier
+                // GroupBy/ToDictionary allocation on the hottest inner loop.
+                // R10 #2: pool the dict (it was a fresh alloc every call). R10 #1: compute its order-independent hash
+                // ONCE here (the sum is identical for all M probes) and stamp it on each ModifierLookupKey, turning the
+                // cache-key hashing from O(M²) → O(M)/auction. The stamped hash == what GetHashCode would iterate, so
+                // it is bit-exact (identical cache placement / hit-miss set).
+                if (!AllocatedDicts.TryDequeue(out var relevant))
+                    relevant = new Dictionary<string, string>(modifiers.Count);
+                int relevantHash = 0;
+                foreach (var rm in modifiers)
+                    if (relevant.TryAdd(rm.Key, rm.Value))
+                        relevantHash += System.HashCode.Combine(rm.Key, rm.Value);
+                bool relevantEscaped = false;
+
+                // Index-based iteration (not foreach): a modifier estimate can mutate `modifiers` in place (the
+                // unlocked_slots converter filters inaccessible gemstone slots), and indexing tolerates that the same
+                // way the previous `modifiers.Select(...).ToList()` did. A foreach enumerator would throw.
+                for (int mi = 0; mi < modifiers.Count; mi++)
                 {
-                    return value.Item1;
+                    var m = modifiers[mi];
+                    try
+                    {
+                        var lookupKey = new ModifierLookupKey() { ItemTag = tag, Modifier = m, RelevantModifiers = relevant, RelevantHash = relevantHash };
+                        if (ModifierValueLookup.TryGetValue(lookupKey, out var value))
+                        {
+                            combined.Add(value.Item1);
+                            continue;
+                        }
+                        var calculated = ModifierEstimate(modifiers, tag, flatNbt, m);
+                        if (calculated.Value > 0)
+                        {
+                            ModifierValueLookup[lookupKey] = (calculated, DateTime.UtcNow);
+                            relevantEscaped = true; // the stored key retains `relevant`, so it must not be pool-recycled
+                        }
+                        combined.Add(calculated);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogInformation($"Error when calculating value for {m.Key} {m.Value} {tag}\n" + e);
+                        combined.Add(new RankElem(m, 0));
+                    }
                 }
-                var calculated = ModifierEstimate(modifiers, tag, flatNbt, mod);
-                if (calculated.Value > 0)
-                    ModifierValueLookup[lookupKey] = (calculated, DateTime.UtcNow);
-                return calculated;
-            };
-            var valuePerModifier = modifiers?.Select(m =>
-            {
-                try
+                // R10 #2: recycle the dict only when it did NOT escape into the cache (the all-hit warm common case);
+                // an escaped dict is now owned by ModifierValueLookup and is left for it (same as the old fresh alloc).
+                if (!relevantEscaped)
                 {
-                    return handler(m);
+                    relevant.Clear();
+                    if (AllocatedDicts.Count < 256)
+                        AllocatedDicts.Enqueue(relevant);
                 }
-                catch (Exception e)
-                {
-                    logger.LogInformation($"Error when calculating value for {m.Key} {m.Value} {tag}\n" + e);
-                    return new RankElem(m, 0);
-                }
-            }).ToList();
-            IEnumerable<RankElem> combined = null;
-            if (valuePerEnchant != null && valuePerModifier != null)
-                combined = valuePerEnchant.Concat(valuePerModifier);
-            else if (valuePerEnchant != null)
-                combined = valuePerEnchant;
-            else if (valuePerModifier != null)
-                combined = valuePerModifier;
+            }
             return combined;
         }
 
@@ -2953,6 +5121,27 @@ ORDER BY l.`AuctionId`  DESC;
 
         public void TestNewAuction(SaveAuction auction, bool triggerEvents = true, bool fastMode = false)
         {
+            var startTimestamp = Stopwatch.GetTimestamp();
+            try
+            {
+                TestNewAuctionInternal(auction, triggerEvents, fastMode);
+            }
+            finally
+            {
+                // Only the event-triggering path is the snipe-finding hot path; the silent-store path (triggerEvents=false)
+                // is bulk loading and would skew the SLI.
+                if (triggerEvents)
+                {
+                    var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+                    testNewAuctionDuration.Observe(elapsed.TotalSeconds);
+                    if (VerboseProfiling)
+                        logger?.LogInformation("[profile] TestNewAuction tag={Tag} took {Micros:F1}µs", auction?.Tag, elapsed.TotalMicroseconds);
+                }
+            }
+        }
+
+        private void TestNewAuctionInternal(SaveAuction auction, bool triggerEvents = true, bool fastMode = false)
+        {
             using var activity = !triggerEvents ? null : activitySource?.StartActivity("TestNewAuction", ActivityKind.Internal);
             activity?.SetTag("uuid", auction.Uuid);
             activity?.SetTag("server", ServerDnsName);
@@ -3020,10 +5209,13 @@ ORDER BY l.`AuctionId`  DESC;
                 {
                     using var tryFind = !triggerEvents ? null : activitySource?.StartActivity("TryFind", ActivityKind.Internal);
                     long extraValue = GetExtraValue(auction, key) - itemGroupTag.Item2;
-                    if (FindFlip(auction, lbinPrice, medPrice, bucket, key, lookup, basekey, extraValue, props =>
+                    var findFlipStart = Stopwatch.GetTimestamp();
+                    var foundFlip = FindFlip(auction, lbinPrice, medPrice, bucket, key, lookup, basekey, extraValue, props =>
                     {
                         props["breakdown"] = JsonConvert.SerializeObject(basekey.ValueBreakdown);
-                    }, fastMode))
+                    }, fastMode);
+                    findFlipDuration.Observe(Stopwatch.GetElapsedTime(findFlipStart).TotalSeconds);
+                    if (foundFlip)
                         shouldTryToFindClosest = false; // found a snipe, no need to check other lower value buckets
                 }
                 else
@@ -3040,8 +5232,11 @@ ORDER BY l.`AuctionId`  DESC;
             if (topAttrib != default)
             {
                 medPrice = auction.StartingBid * 1.06 + itemGroupTag.Item2;
-                CheckCombined(auction, lookup, lbinPrice, medPrice, basekey, topAttrib);
-                CheckLowerKeyFull(auction, lookup, lbinPrice, medPrice, basekey, l);
+                // R7 WS-C2: both finders re-parse the same auction via GetFullKey and build BuildDomKey(fullKey); share
+                // the full key + its query DomKey across the two calls (built lazily once, after each finder's gates).
+                var fullKeyQuery = new FullKeyQuery();
+                CheckCombined(auction, lookup, lbinPrice, medPrice, basekey, topAttrib, ref fullKeyQuery);
+                CheckLowerKeyFull(auction, lookup, lbinPrice, medPrice, basekey, l, ref fullKeyQuery);
             }
             if (shouldTryToFindClosest && triggerEvents && this.State >= SniperState.Ready)
             {
@@ -3063,7 +5258,12 @@ ORDER BY l.`AuctionId`  DESC;
             }
 
             CraftCostFinder(auction, itemGroupTag, lookup, medPrice, basekey);
-            activity.Log($"BaseKey value {JsonConvert.SerializeObject(basekey.ValueBreakdown)}");
+            // R7 WS-TELEM: only build the (JSON-heavy) breakdown string when the activity is actually recording all
+            // data — `activity != null` is true even for a propagation-only (non-recording) listener, for which the
+            // event is discarded but the SerializeObject would still run unconditionally. IsAllDataRequested mirrors
+            // the internal AddEvent gate, so the emitted event is byte-identical when recording.
+            if (activity != null && activity.IsAllDataRequested)
+                activity.Log($"BaseKey value {JsonConvert.SerializeObject(basekey.ValueBreakdown)}");
         }
 
 
@@ -3188,41 +5388,204 @@ ORDER BY l.`AuctionId`  DESC;
             }
         }
 
-        private void CheckCombined(SaveAuction auction, PriceLookup lookup, double lbinPrice, double medPrice, KeyWithValueBreakdown longKey, RankElem topAttrib)
+        // R6 WS-CMB2 — per-call relevant entry (de-LINQ'd CheckCombined). One per qualifying bucket; carries the
+        // value weight, the captured FIFO reference snapshot (read once → race-free + matches LINQ's lazy
+        // References enumeration order) and the bucket's Lbin captured at the same moment.
+        private struct CmbRelevant
         {
+            public AuctionKey Key;
+            public ReferenceAuctions Bucket;
+            public double Value;
+            public ReferencePrice[] Refs; // FIFO snapshot (ReferenceSnapshot()), length == References.Count at capture
+            public ReferencePrice Lbin;   // bucket.Lbin captured with Refs
+        }
+
+        // R6 WS-CMB2 — combined reference candidate (ref + its relevancy weight + capture order index for the
+        // STABLE relevancy-descending selection; LINQ OrderByDescending is stable, Array.Sort is not).
+        private struct CmbCombinedEntry
+        {
+            public ReferencePrice Ref;
+            public double Relevancy;
+            public int Idx; // source-enumeration order (relevant order × References order), the stable tiebreak
+        }
+
+        // [ThreadStatic] scratch — CheckCombined runs per-auction across worker threads (incl. the background risky
+        // Task), so the buffers must be thread-local; cleared/grown per call, never shared across threads.
+        [ThreadStatic] private static List<CmbRelevant> _cmbRelevant;
+        [ThreadStatic] private static List<CmbCombinedEntry> _cmbCombined;
+
+        // R7 WS-C2 — per-auction lazy cache of the FULL key + its query DomKey. CheckCombined and CheckLowerKeyFull both
+        // call GetFullKey(auction) (a SelectValuable re-parse) and BuildDomKey(fullKey) on the SAME auction, so the full
+        // key and its DomKey are byte-identical between the two finders. This holder builds each ONCE (on first use, after
+        // each finder's own reject gates) and the second finder reuses it — collapsing 2 SelectValuable re-parses → 1 and
+        // 2 BuildDomKey(query) DomMod[]/DomEnch[] builds → 1, with zero allocation on the path where neither finder needs
+        // it (the holder is a by-ref struct; lazily built so a finder that early-returns before GetFullKey pays nothing).
+        // Bit-exact: identical bytes, just built once.
+        private struct FullKeyQuery
+        {
+            private bool built;
+            private AuctionKeyWithValue key;
+            private DomKey dom;
+            public void Ensure(SniperService svc, SaveAuction auction)
+            {
+                if (built)
+                    return;
+                key = svc.GetFullKey(auction);
+                dom = DominatorIndex.BuildDomKey(key, svc.scoreInterner);
+                built = true;
+            }
+            public AuctionKeyWithValue Key => key;
+            public DomKey Dom => dom;
+        }
+
+        private void CheckCombined(SaveAuction auction, PriceLookup lookup, double lbinPrice, double medPrice, KeyWithValueBreakdown longKey, RankElem topAttrib, ref FullKeyQuery fullKeyQuery)
+        {
+            if (UseCombinedReference) // R6 WS-CMB2 A/B seam (default false in production)
+            {
+                CheckCombinedReference(auction, lookup, lbinPrice, medPrice, longKey, topAttrib);
+                return;
+            }
             var topKey = longKey.GetReduced(0);
             var targetVolume = 11;
             if (lookup.Lookup.TryGetValue(topKey, out var topBucket) && topBucket.References.Count >= targetVolume)
             {
                 return; // enough references in previous check
             }
+            var groupTag = GetAuctionGroupTag(auction.Tag);
             var l = lookup.Lookup;
-            var similar = l.Where(e => topAttrib.Modifier.Key != default && !e.Key.Modifiers.Any(m => m.Key == "virtual") || e.Key.Enchants.Contains(topAttrib.Enchant)).ToList();
-            if (similar.Count == 1)
+            // R7 WS-C2: full key + its query DomKey built once per auction, shared with CheckLowerKeyFull (same auction →
+            // same GetFullKey/BuildDomKey bytes). Lazily materialised here, after the early-return gates above.
+            fullKeyQuery.Ensure(this, auction);
+            // R4 WS-CMB: the dominance filter (direction B: Dominates(cand=e.Key, query=fullKey)) runs the interned
+            // kernel against the bucket's cached DomKey + the sound mask prefilter, instead of the per-candidate string
+            // IsHigherValue. Bit-exact (40k fuzz + Combined/LowerKeyAndCombined snipe-set oracles).
+            var queryDomCmb = fullKeyQuery.Dom;
+            ulong qProvCmb = queryDomCmb.ProvidedMask;
+            bool petSpiritCmb = auction.Tag == "PET_SPIRIT";
+            var topReforge = topKey.Reforge;
+            bool topReforgeAny = topReforge == ItemReferences.Reforge.Any;
+            bool hasAttribMod = topAttrib.Modifier.Key != default;
+            var topEnchant = topAttrib.Enchant;
+
+            // R6 WS-CMB2 — de-LINQ. Single pass over the dict (same enumeration order as the old
+            // `l.Where(...).ToList()`): apply the `similar` predicate, then the reforge + dominance filter, building the
+            // `relevant` entries directly. The two-stage filter is fused: an element is in `relevant` iff it was in
+            // `similar` AND passed reforge+dominance. The `similar.Count==1 → similar=l.ToList()` fallback only changes
+            // the candidate SET when exactly one element matches the similar predicate; that element is unconditionally
+            // re-evaluated under reforge+dominance in the fallback, so we recompute `relevant` over ALL entries.
+            var relevant = _cmbRelevant ??= new List<CmbRelevant>();
+            relevant.Clear();
+            int similarCount = 0;
+            foreach (var e in l)
             {
-                // include all if no match otherwise
-                similar = l.ToList();
+                // `similar` predicate: (hasAttribMod && !modifiers.contains("virtual")) || enchants.Contains(topEnchant)
+                bool inSimilar = (hasAttribMod && !ModifiersContainVirtual(e.Key.Modifiers)) || e.Key.Enchants.Contains(topEnchant);
+                if (!inSimilar)
+                    continue;
+                similarCount++;
+                if (CmbTryBuild(e.Key, e.Value, out var built))
+                    relevant.Add(built);
             }
-            var fullKey = GetFullKey(auction);
-            var relevant = similar.Where(e => (e.Key.Reforge == topKey.Reforge || topKey.Reforge == ItemReferences.Reforge.Any)
-                        && IsHigherValue(auction.Tag, e.Key, fullKey))
-                .Select(e => (e, value: Math.Max(e.Value.Volume, 0.5) * Math.Pow(ComparisonValue(e.Key.Enchants, e.Key.Modifiers.ToList(), GetAuctionGroupTag(auction.Tag).tag, null).Sum(s => s.Value), 1.8)))
-                .OrderByDescending(e => e.value)
-                .ToList();
+            if (similarCount == 1)
+            {
+                // include all if no match otherwise — rebuild `relevant` over the WHOLE dict.
+                relevant.Clear();
+                foreach (var e in l)
+                    if (CmbTryBuild(e.Key, e.Value, out var built))
+                        relevant.Add(built);
+            }
+
+            bool CmbTryBuild(AuctionKey candKey, ReferenceAuctions candBucket, out CmbRelevant built)
+            {
+                built = default;
+                if (!(candKey.Reforge == topReforge || topReforgeAny))
+                    return false;
+                if (!CmbDominates(candBucket, candKey))
+                    return false;
+                long compSum = 0;
+                var comp = ComparisonValueForKey(groupTag.tag, candKey);
+                for (int ci = 0; ci < comp.Count; ci++)
+                    compSum += comp[ci].Value;
+                var refs = candBucket.ReferenceSnapshot();
+                built = new CmbRelevant
+                {
+                    Key = candKey,
+                    Bucket = candBucket,
+                    Value = Math.Max(candBucket.Volume, 0.5) * Math.Pow(compSum, 1.8),
+                    Refs = refs,
+                    Lbin = candBucket.Lbin
+                };
+                return true;
+            }
+
+            bool CmbDominates(ReferenceAuctions candBucket, AuctionKey candKey)
+            {
+                var candDom = GetBucketDomKey(candBucket, candKey);
+                if ((candDom.RequiredMask & qProvCmb) != candDom.RequiredMask)
+                    return false; // sound presence prefilter (candidate is the base side)
+                return DominatorIndex.Dominates(in candDom, in queryDomCmb, petSpiritCmb);
+            }
             if (relevant.Count < 2)
             {
                 return; // makes only sense if there is something combined
             }
-            // get enough relevant to build a median and try to get highest value (most enchantments and modifiers)
-            var combined = relevant.SelectMany(r => r.e.Value.References.Select(ri => (ri, relevancy: r.value * (ri.Day - GetDay() + 12) * Math.Log10(ri.Price + 1))))
-                                .OrderByDescending(r => r.relevancy).Select(r => r.ri).Take(targetVolume).ToList();
-            if (combined.Count == 0)
+            // STABLE descending sort by value (OrderByDescending(e=>e.value)). LINQ keeps Comparer<double>.Default
+            // (NaN sorts smallest) and is stable → ties keep source (dict-enumeration) order. relevant is consumed in
+            // full order in several places below, so this is a real sort (not a partial-select).
+            CmbStableSortByValueDesc(relevant);
+
+            short today = GetDay();
+            // combined = relevant.SelectMany(refs).Select(relevancy).OrderByDescending(relevancy).Take(targetVolume)
+            // Source order for the stable sort = (relevant order) × (each bucket's FIFO References order).
+            var combinedEntries = _cmbCombined ??= new List<CmbCombinedEntry>();
+            combinedEntries.Clear();
+            int srcIdx = 0;
+            for (int ri = 0; ri < relevant.Count; ri++)
+            {
+                var r = relevant[ri];
+                var refs = r.Refs;
+                for (int j = 0; j < refs.Length; j++)
+                {
+                    var rp = refs[j];
+                    combinedEntries.Add(new CmbCombinedEntry
+                    {
+                        Ref = rp,
+                        Relevancy = r.Value * (rp.Day - today + 12) * Math.Log10(rp.Price + 1),
+                        Idx = srcIdx++
+                    });
+                }
+            }
+            if (combinedEntries.Count == 0)
             {
                 return;
             }
-            var lbinBucket = relevant.Select(r => r.e.Value.Lbin).Where(r => r.Price != default).DefaultIfEmpty().MinBy(r => r.Price);
-            var newestRef = combined.OrderByDescending(c => c.Day).Skip(1).FirstOrDefault().Day; // short term median
-            var age = GetDay() - newestRef;
+            // STABLE descending sort by relevancy, then take the top targetVolume.
+            CmbStableSortByRelevancyDesc(combinedEntries);
+            int combinedCount = Math.Min(combinedEntries.Count, targetVolume);
+            var combined = new List<ReferencePrice>(combinedCount);
+            for (int i = 0; i < combinedCount; i++)
+                combined.Add(combinedEntries[i].Ref);
+
+            // lbinBucket = relevant.Select(Lbin).Where(Price!=0).DefaultIfEmpty().MinBy(Price)
+            // MinBy returns the FIRST element achieving the minimum (first-wins) over `relevant`'s sorted order; if no
+            // Lbin has Price!=0 the result is default(ReferencePrice).
+            ReferencePrice lbinBucket = default;
+            bool anyLbin = false;
+            for (int ri = 0; ri < relevant.Count; ri++)
+            {
+                var cand = relevant[ri].Lbin;
+                if (cand.Price == default)
+                    continue;
+                if (!anyLbin || cand.Price < lbinBucket.Price)
+                {
+                    lbinBucket = cand;
+                    anyLbin = true;
+                }
+            }
+            // newestRef = combined.OrderByDescending(Day).Skip(1).FirstOrDefault().Day — the 2nd-highest Day (stable),
+            // i.e. the element at sorted position 1; default(.Day)==0 if fewer than 2 entries.
+            short newestRef = CmbSecondHighestDay(combined);
+            var age = today - newestRef;
             var virtualBucket = new ReferenceAuctions()
             {
                 Lbins = [lbinBucket],
@@ -3231,40 +5594,229 @@ ORDER BY l.`AuctionId`  DESC;
                 OldestRef = (short)(newestRef - 2),
                 Volatility = 123// mark as risky
             };
+            // Capture the (key, ref-count) pairs the props lambda needs, in relevant's sorted order, with the snapshot
+            // length used at build time (race-free; identical to the live Count in the single-threaded oracle). The
+            // lambda is only invoked by FindFlip when it builds props for a found flip.
+            int relevantCount = relevant.Count;
+            var propKeys = new AuctionKey[relevantCount];
+            var propRefCounts = new int[relevantCount];
+            for (int ri = 0; ri < relevantCount; ri++)
+            {
+                propKeys[ri] = relevant[ri].Key;
+                propRefCounts[ri] = relevant[ri].Refs.Length;
+            }
             // mark with extra value -3
             var foundAndAbort = FindFlip(auction, lbinPrice, medPrice, virtualBucket, topKey, lookup, longKey, MIN_TARGET == 0 ? 0 : -3, props =>
             {
-                var total = 0;
-                props.Add("combined", string.Join(",", relevant.TakeWhile(c => (total += c.e.Value.References.Count) < targetVolume)
-                    .Select(c => c.e.Key.ToString() + ":" + c.e.Value.References.Count)));
+                // combined = relevant.TakeWhile(running total of RefCount < targetVolume).Select(key:count)
+                var sb = new System.Text.StringBuilder();
+                int total = 0;
+                bool first = true;
+                for (int ri = 0; ri < relevantCount; ri++)
+                {
+                    total += propRefCounts[ri];
+                    if (!(total < targetVolume))
+                        break; // TakeWhile stops at (and excludes) the first element failing the predicate
+                    if (!first)
+                        sb.Append(',');
+                    sb.Append(propKeys[ri].ToString());
+                    sb.Append(':');
+                    sb.Append(propRefCounts[ri]);
+                    first = false;
+                }
+                props.Add("combined", sb.ToString());
                 props.Add("breakdown", JsonConvert.SerializeObject(longKey.ValueBreakdown));
-                logger.LogInformation($"Combined {longKey} {auction.Uuid} {virtualBucket.Price} {virtualBucket.Lbin.Price} keys: {string.Join(",", relevant.Select(r => r.e.Key))}");
+                if (logger?.IsEnabled(LogLevel.Information) ?? false)
+                {
+                    var keysSb = new System.Text.StringBuilder();
+                    for (int ri = 0; ri < relevantCount; ri++)
+                    {
+                        if (ri > 0)
+                            keysSb.Append(',');
+                        keysSb.Append(propKeys[ri].ToString());
+                    }
+                    logger.LogInformation($"Combined {longKey} {auction.Uuid} {virtualBucket.Price} {virtualBucket.Lbin.Price} keys: {keysSb}");
+                }
             });
 
             long GetCappedMedian(SaveAuction auction, KeyWithValueBreakdown fullKey, List<ReferencePrice> combined)
             {
                 var median = GetMedian(combined, []);
                 var shortTerm = GetMedian(combined.Take(5).ToList(), new());
-                var group = GetAuctionGroupTag(auction.Tag);
-                median = CapAtCraftCost(group.tag, Math.Min(median, shortTerm), fullKey, 0);
+                median = CapAtCraftCost(groupTag.tag, Math.Min(median, shortTerm), fullKey, 0);
                 return median;
             }
         }
 
-        private void CheckLowerKeyFull(SaveAuction auction, PriceLookup lookup, double lbinPrice, double medPrice, KeyWithValueBreakdown fullKey, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l)
+        /// <summary>
+        /// STABLE descending sort by <see cref="CmbRelevant.Value"/>, matching LINQ <c>OrderByDescending(e=>e.value)</c>
+        /// (Comparer&lt;double&gt;.Default — NaN sorts smallest — with ties preserving original list order). Uses an index
+        /// array so the underlying <see cref="List{T}"/> contents move only once at the end; Array.Sort is unstable so the
+        /// index is the explicit tiebreak.
+        /// </summary>
+        private static void CmbStableSortByValueDesc(List<CmbRelevant> items)
+        {
+            int n = items.Count;
+            if (n < 2)
+                return;
+            int[] order = ArrayPool<int>.Shared.Rent(n);
+            CmbRelevant[] tmp = ArrayPool<CmbRelevant>.Shared.Rent(n);
+            try
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    order[i] = i;
+                    tmp[i] = items[i];
+                }
+                Array.Sort(order, 0, n, new CmbValueDescComparer(tmp));
+                for (int i = 0; i < n; i++)
+                    items[i] = tmp[order[i]];
+            }
+            finally
+            {
+                ArrayPool<int>.Shared.Return(order);
+                // R8 WS-CHURN-B: clear only the written prefix [0,n) instead of the full pooled capacity, then
+                // Return with clearArray:false (avoids the pool zeroing ~2n on next-power-of-two oversized buffers).
+                // GC-safe: only [0,n) was populated, so nulling [0,n) drops every managed ref we introduced
+                // (CmbRelevant carries Key/Bucket/Refs); the untouched tail [n,capacity) holds no refs from us.
+                Array.Clear(tmp, 0, n);
+                ArrayPool<CmbRelevant>.Shared.Return(tmp, clearArray: false);
+            }
+        }
+
+        private sealed class CmbValueDescComparer : IComparer<int>
+        {
+            private readonly CmbRelevant[] items;
+            public CmbValueDescComparer(CmbRelevant[] items) => this.items = items;
+            public int Compare(int a, int b)
+            {
+                int c = Comparer<double>.Default.Compare(items[a].Value, items[b].Value);
+                if (c != 0)
+                    return -c; // descending
+                return a.CompareTo(b); // stable: original order
+            }
+        }
+
+        /// <summary>
+        /// STABLE descending sort by <see cref="CmbCombinedEntry.Relevancy"/>, matching LINQ
+        /// <c>OrderByDescending(r=>r.relevancy)</c> (Comparer&lt;double&gt;.Default, stable). The carried
+        /// <see cref="CmbCombinedEntry.Idx"/> is the source-enumeration order used as the tiebreak.
+        /// </summary>
+        private static void CmbStableSortByRelevancyDesc(List<CmbCombinedEntry> items)
+        {
+            int n = items.Count;
+            if (n < 2)
+                return;
+            CmbCombinedEntry[] tmp = ArrayPool<CmbCombinedEntry>.Shared.Rent(n);
+            try
+            {
+                for (int i = 0; i < n; i++)
+                    tmp[i] = items[i];
+                Array.Sort(tmp, 0, n, CmbRelevancyDescComparer.Instance);
+                for (int i = 0; i < n; i++)
+                    items[i] = tmp[i];
+            }
+            finally
+            {
+                // R8 WS-CHURN-B: CmbCombinedEntry is all-blittable (ReferencePrice = primitives, double, int — no
+                // managed refs), so the pool buffer holds nothing for the GC to retain. Skip the clear entirely and
+                // Return with clearArray:false — the old clearArray:true was pure wasted ZeroMemory of the (oversized)
+                // capacity. (The CmbRelevant sort below DOES carry refs, so it clears its written prefix.)
+                ArrayPool<CmbCombinedEntry>.Shared.Return(tmp, clearArray: false);
+            }
+        }
+
+        private sealed class CmbRelevancyDescComparer : IComparer<CmbCombinedEntry>
+        {
+            public static readonly CmbRelevancyDescComparer Instance = new();
+            public int Compare(CmbCombinedEntry a, CmbCombinedEntry b)
+            {
+                int c = Comparer<double>.Default.Compare(a.Relevancy, b.Relevancy);
+                if (c != 0)
+                    return -c; // descending
+                return a.Idx.CompareTo(b.Idx); // stable: source-enumeration order
+            }
+        }
+
+        /// <summary>
+        /// Bit-exact replacement for <c>combined.OrderByDescending(c=>c.Day).Skip(1).FirstOrDefault().Day</c>: the Day of
+        /// the element at stable-descending-by-Day position 1, or 0 if fewer than 2 elements. Stable: among equal Days the
+        /// original (relevancy) order is preserved, so position 1 = the second element to reach the running max Day.
+        /// </summary>
+        private static short CmbSecondHighestDay(List<ReferencePrice> combined)
+        {
+            int n = combined.Count;
+            if (n < 2)
+                return 0;
+            // Find rank-0 (stable first-of-max) then rank-1 (stable first-of-max among the rest, excluding the rank-0
+            // POSITION). Stable OrderByDescending ⇒ for equal Days the earlier list index ranks first.
+            int first = 0;
+            for (int i = 1; i < n; i++)
+                if (combined[i].Day > combined[first].Day) // strict: ties keep the earlier index (stable)
+                    first = i;
+            int second = -1;
+            for (int i = 0; i < n; i++)
+            {
+                if (i == first)
+                    continue;
+                if (second == -1 || combined[i].Day > combined[second].Day)
+                    second = i;
+            }
+            return combined[second].Day;
+        }
+
+        private void CheckLowerKeyFull(SaveAuction auction, PriceLookup lookup, double lbinPrice, double medPrice, KeyWithValueBreakdown fullKey, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, ref FullKeyQuery fullKeyQuery)
         {
             // check if complicated item
             if (fullKey.ValueBreakdown.Count < 3)
                 return; // not complicated
             if (auction.Tag.StartsWith("PET_"))
                 return; // eg Enderman gets cheaper at mythic for some reason
-            AuctionKeyWithValue key = GetFullKey(auction);
+            // R7 WS-C2: full key + query DomKey built once per auction, shared with CheckCombined (same auction → same
+            // GetFullKey/BuildDomKey bytes). Materialised here, after the two early-return gates above.
+            fullKeyQuery.Ensure(this, auction);
+            AuctionKeyWithValue key = fullKeyQuery.Key;
             var today = GetDay();
-            var containing = l.Where(e => e.Value.Price > 0 && e.Value.References.Count > 5
-                            && (e.Key.Reforge == key.Reforge || e.Key.Reforge == ItemReferences.Reforge.Any)
-                            && e.Value.References.Any(r => r.Day >= today - 2)
-                            && IsHigherValue(auction.Tag, e.Key, key))
-                        .OrderByDescending(e => e.Value.Price).FirstOrDefault();
+            // R4 WS-SHARE: single-pass max over the shared DominatorIndex. Direction B: candidates DOMINATED BY the full
+            // query key (Dominates(cand, query) == IsHigherValue(tag, cand, key)). Equivalent to Where(...)
+            // .OrderByDescending(Price).FirstOrDefault() — strict '>' first-wins over the dict-enumeration order
+            // reproduces the stable First-of-max. Same AND-predicate set (Price>0, RefCount>5, reforge-or-Any, recent,
+            // dominance); ordering of the ANDed conditions doesn't change the qualifying set. Price / RefCount /
+            // recency read LIVE off the bucket; reforge is the immutable cached column; the kernel runs only on
+            // mask-prefilter survivors (cheap filters first, as before).
+            var index = GetOrBuildDominatorIndex(lookup);
+            AuctionKey queryKey = key;
+            var query = fullKeyQuery.Dom; // R7 WS-C2: shared query DomKey (== BuildDomKey(queryKey, scoreInterner))
+            ulong qProv = query.ProvidedMask;
+            bool petSpirit = auction.Tag == "PET_SPIRIT";
+            int keyReforge = (int)key.Reforge;
+            int anyReforge = (int)ItemReferences.Reforge.Any;
+            KeyValuePair<AuctionKey, ReferenceAuctions> containing = default;
+            long bestContainingPrice = long.MinValue;
+            for (int i = 0; i < index.Count; i++)
+            {
+                if (!(index.Reforge[i] == keyReforge || index.Reforge[i] == anyReforge))
+                    continue;
+                var v = index.Buckets[i];
+                if (!(v.Price > 0) || v.References.Count <= 5) // LIVE
+                    continue;
+                bool recent = false;
+                foreach (var r in v.ReferenceSnapshot()) // LIVE
+                    if (r.Day >= today - 2) { recent = true; break; }
+                if (!recent)
+                    continue;
+                if ((index.RequiredMask[i] & qProv) != index.RequiredMask[i])
+                    continue; // sound presence prefilter (candidate is the base side)
+                if (!DominatorIndex.Dominates(in index.Doms[i], in query, petSpirit))
+                    continue;
+                if (v.Price > bestContainingPrice)
+                {
+                    bestContainingPrice = v.Price;
+                    containing = new KeyValuePair<AuctionKey, ReferenceAuctions>(index.Keys[i], v);
+                }
+            }
+            if (VerifyDominatorIndex)
+                AssertDominatorParity(l, queryKey, auction.Tag, index, baseIsQuery: false);
             if (containing.Value == default)
                 return;
             var extraValue = GetExtraValue(auction, key);
@@ -3276,7 +5828,7 @@ ORDER BY l.`AuctionId`  DESC;
             });
         }
 
-        private AuctionKeyWithValue GetFullKey(SaveAuction auction)
+        internal AuctionKeyWithValue GetFullKey(SaveAuction auction)
         {
             (var enchant, var modifiers) = SelectValuable(auction);
             var key = new AuctionKeyWithValue()
@@ -3334,10 +5886,15 @@ ORDER BY l.`AuctionId`  DESC;
             if (auction.FlatenedNBT.TryGetValue("exp", out var exp) && double.Parse(exp) < 1234567)
                 return; // don't use closest for low exp pets
 
-            // special case for items that have no reference bucket, search using most similar
-            var detailedKey = DetailedKeyFromSaveAuction(auction);
+            // special case for items that have no reference bucket, search using most similar.
+            // R11: reuse the basekey already parsed by TestNewAuctionInternal (passed in as keyWithBreakdown) instead of
+            // re-parsing the SAME auction here. TryFindClosestRisky is only reached on the non-fastMode/triggerEvents
+            // path, where basekey == DetailedKeyFromSaveAuction(auction) (limit=5, same epoch within the call) — so this
+            // is byte-identical, and it removes the single biggest intra-auction redundant parse (it ran on ~84% of warm
+            // auctions, on the awaited background closest task). basekey is immutable, safe to read from this Task thread.
+            var detailedKey = keyWithBreakdown;
             var key = detailedKey.GetReduced(0);
-            var closest = FindClosestTo(l.Lookup, key, auction.Tag);
+            var closest = FindClosestTo(l, key, auction.Tag);
             if (NBT.IsPet(auction.Tag) && closest.Key?.Modifiers != null && !closest.Key.Modifiers.Any(m => m.Key == "exp"))
             {
                 logger.LogWarning($"Pet without exp {auction.Uuid}");
@@ -3707,17 +6264,19 @@ ORDER BY l.`AuctionId`  DESC;
                 && (!fastMode || bucket.Volume > 5)
                )
             {
-                foundSnipe = PotentialSnipe(auction, groupTag, lbinPrice, bucket, key, l, extraValue, breakdown);
+                foundSnipe = PotentialSnipe(auction, groupTag, lbinPrice, bucket, key, lookup, extraValue, breakdown);
             }
             if (medianPrice > minMedPrice && BucketHasEnoughReferencesForPrice(bucket, lookup))
             {
                 long adjustedMedianPrice = bucket.Price;
                 if (key.Count > 1)
                     adjustedMedianPrice = CheckHigherValueKeyForLowerPrice(bucket, key, l, medianPrice);
-                Activity.Current.Log($"Bucket has enough references {bucket.References.Count} and medianPrice > minMedPrice {medianPrice} > {minMedPrice} adjusted {adjustedMedianPrice} {extraValue} {expValue}");
+                if (Activity.Current is { IsAllDataRequested: true })
+                    Activity.Current.Log($"Bucket has enough references {bucket.References.Count} and medianPrice > minMedPrice {medianPrice} > {minMedPrice} adjusted {adjustedMedianPrice} {extraValue} {expValue}");
                 if (adjustedMedianPrice + extraValue < minMedPrice)
                 {
-                    LogNonFlip(auction, bucket, key, extraValue, volume, medianPrice, $"Adjusted median {adjustedMedianPrice} lower than min price {minMedPrice} {extraValue}");
+                    if (WouldLogNonFlip(volume, bucket))
+                        LogNonFlip(auction, bucket, key, extraValue, volume, medianPrice, $"Adjusted median {adjustedMedianPrice} lower than min price {minMedPrice} {extraValue}");
                     return false;
                 }
                 var referenceAuctionId = bucket.References.LastOrDefault().AuctionId;
@@ -3746,7 +6305,7 @@ ORDER BY l.`AuctionId`  DESC;
                         keyMissing = adjusted;
                 }
                 props.Add("keyMissing", keyMissing.ToString());
-                FoundAFlip(auction, bucket, LowPricedAuction.FinderType.SNIPER_MEDIAN, adjustedMedianPrice + extraValue + expValue + keyMissing, props);
+                FoundAFlip(auction, bucket, LowPricedAuction.FinderType.SNIPER_MEDIAN, adjustedMedianPrice + extraValue + expValue + keyMissing, props, key, extraValue);
             }
             if (medianPrice - auction.StartingBid < 2_500_000 && bucket.RiskyEstimate > minMedPrice
                 && (bucket.Lbin.AuctionId == default || bucket.Lbin.Price * 1.04 > lbinPrice))
@@ -3762,12 +6321,14 @@ ORDER BY l.`AuctionId`  DESC;
                     target = (long)Math.Min(target, bucket.Price * 1.10 + 1_000_000);
                 if ((GetDay() - bucket.OldestRef) > 10 || bucket.DeduplicatedReferenceCount < 8)
                     target = target * 11 / 12;
-                FoundAFlip(auction, bucket, LowPricedAuction.FinderType.STONKS, target, props);
+                FoundAFlip(auction, bucket, LowPricedAuction.FinderType.STONKS, target, props, key, extraValue);
             }
             else
             {
-                Activity.Current.Log($"Bucket has too few references {bucket.References.Count} or medianPrice > minMedPrice {medianPrice} > {minMedPrice}");
-                LogNonFlip(auction, bucket, key, extraValue, volume, medianPrice, $"Median {medianPrice} lower than min price {minMedPrice} {bucket.References.Count}");
+                if (Activity.Current is { IsAllDataRequested: true })
+                    Activity.Current.Log($"Bucket has too few references {bucket.References.Count} or medianPrice > minMedPrice {medianPrice} > {minMedPrice}");
+                if (WouldLogNonFlip(volume, bucket))
+                    LogNonFlip(auction, bucket, key, extraValue, volume, medianPrice, $"Median {medianPrice} lower than min price {minMedPrice} {bucket.References.Count}");
             }
             return foundSnipe;
 
@@ -3779,9 +6340,14 @@ ORDER BY l.`AuctionId`  DESC;
                 return (key.ValueSubstract - extraValue - 2_000_000) / 4;
             }
         }
+        // The condition under which LogNonFlip actually enqueues a diagnostic entry. Checked at the call site too so the
+        // interpolated message string isn't built for the (common, in prod) sub-MIN_TARGET buckets it would discard.
+        private static bool WouldLogNonFlip(float volume, ReferenceAuctions bucket)
+            => volume == 0 || bucket.Lbin.Price == 0 || bucket.Price == 0 || bucket.Price > MIN_TARGET;
+
         void LogNonFlip(SaveAuction auction, ReferenceAuctions bucket, AuctionKey key, long extraValue, float volume, long medianPrice, string v = null)
         {
-            if (volume == 0 || bucket.Lbin.Price == 0 || bucket.Price == 0 || bucket.Price > MIN_TARGET)
+            if (WouldLogNonFlip(volume, bucket))
                 Logs.Enqueue(new LogEntry()
                 {
                     Key = key,
@@ -3904,7 +6470,7 @@ ORDER BY l.`AuctionId`  DESC;
                     BazaarPrices[item.ProductId] = itemPrice;
                 if (bucket.References.Count >= 5 && NotEnoughTimePassed(bazaar, bucket))
                     continue; // only sample prices every 10 minutes
-                bucket.References.Enqueue(new()
+                bucket.EnqueueReference(new()
                 {
                     Day = today,
                     Price = (long)itemPrice,
@@ -3941,7 +6507,10 @@ ORDER BY l.`AuctionId`  DESC;
                     if (lookup.Lookup.TryGetValue(higherEnchant, out var higherEnchantReference))
                     {
                         if (higherEnchantReference.Price == 0)
+                        {
                             higherEnchantReference.Price = refernces.Price + 1;
+                            Interlocked.Increment(ref pricingEpoch); // WS-A: out-of-band price write
+                        }
                     }
                 }
             }
@@ -3958,6 +6527,7 @@ ORDER BY l.`AuctionId`  DESC;
                 if (BazaarPrices.TryGetValue(lowerLevelId, out var lowerValue))
                 {
                     refernces.Price = (long)Math.Min(Math.Max(refernces.Price, lowerValue * 1.9), cheapestBuy ?? long.MaxValue);
+                    Interlocked.Increment(ref pricingEpoch); // WS-A: out-of-band price write
                 }
             }
             long MakePriceAtMost40PercentLowerthanLowerLevel(string id, long estimate)
@@ -3982,9 +6552,10 @@ ORDER BY l.`AuctionId`  DESC;
             }
         }
 
-        private bool PotentialSnipe(SaveAuction auction, (string tag, long costSubstract) groupTag, double lbinPrice, ReferenceAuctions bucket, AuctionKey key, ConcurrentDictionary<AuctionKey, ReferenceAuctions> l, long extraValue, KeyWithValueBreakdown breakdown)
+        private bool PotentialSnipe(SaveAuction auction, (string tag, long costSubstract) groupTag, double lbinPrice, ReferenceAuctions bucket, AuctionKey key, PriceLookup lookup, long extraValue, KeyWithValueBreakdown breakdown)
         {
-            var lowestHigherBin = GetLbinCap(groupTag.tag, l, breakdown);
+            var l = lookup.Lookup;
+            var lowestHigherBin = GetLbinCap(groupTag.tag, lookup, breakdown);
             var higherValueLowerBin = bucket.Lbin.Price;
             if (lowestHigherBin.AuctionId != default)
                 if (lowestHigherBin.Price < lbinPrice)
@@ -4007,20 +6578,27 @@ ORDER BY l.`AuctionId`  DESC;
                 return false;
             var percentile = long.MaxValue;
 
-            var props = CreateReference(bucket.Lbin.AuctionId, key, extraValue, bucket);
-            props["mVal"] = bucket.Price.ToString();
+            // R7 WS-C2: the props dict (CreateReference + the mVal/hvlbin/sellerMatch/noHigherLbin entries) is allocated
+            // only AFTER the `percentile < lbinPrice` reject gate below — a candidate rejected there never pays for the
+            // dict or its string conversions. The pre-gate value-affecting side effects (the sellerMatch `percentile /= 2`)
+            // still run before the gate; only the props WRITES are deferred. The emitted dict is byte-identical: same keys
+            // in the same insertion order, same values (snapshotted at the original write point). `props` is null until the
+            // gate passes; nothing reads it before then.
+            Dictionary<string, string> props = null;
             higherValueLowerBin = Math.Min(higherValueLowerBin, bucket.Price * 2);
-            props["hvlbin"] = higherValueLowerBin.ToString();
+            // snapshots of the deferred pre-gate prop values, captured at the exact point the original code wrote them
+            string hvlbinProp = higherValueLowerBin.ToString();
+            string sellerMatchProp = null;
+            string noHigherLbinProp = null;
 
             if (bucket.Price == 0 || bucket.Volume < 10)
             {
                 // check for 80th percentile from references
                 var subsetSize = 20;
-                if (bucket.References.Count >= 1)
-                    percentile = bucket.References
-                        .OrderByDescending(r => r.Day).Take(subsetSize).Select(r => r.Price).OrderBy(p => p)
-                        .ElementAt(Math.Min(bucket.References.Count, subsetSize) * 8 / 10);
-                else if (bucket.References.Count == 0)
+                var refCount = PotentialSnipeEightiethPercentile(bucket.ReferenceSnapshot(), subsetSize, out var eightieth);
+                if (refCount >= 1)
+                    percentile = eightieth;
+                else if (refCount == 0)
                     // undercut only similar lbin drasticly
                     percentile = targetPrice * 9 / 11;
 
@@ -4032,24 +6610,23 @@ ORDER BY l.`AuctionId`  DESC;
                 if (bucket.References.Count < 5)
                 {
                     // all key modifiers and enchants need to be in the reference bucket or higher
-                    var higherValueKeys = l.Where(x => IsHigherValue(groupTag.tag, key, x.Key)).ToList();
-                    lowestLbin = higherValueKeys
-                                .Where(x => x.Value.Lbin.Price > 0 && x.Value.Lbin.Price < bucket.Lbin.Price)
-                                .Select(x => x.Value.Lbin.Price).DefaultIfEmpty(long.MaxValue).Min();
+                    // R4 WS-SHARE higher-value scan: flat scan of the shared DominatorIndex (direction A: candidates that
+                    // dominate the query key) accumulating the lowest qualifying higher-value lbin and the divided
+                    // references for the 25th percentile (bit-exact). Lbin/refs read LIVE off each bucket.
+                    var domIndex = GetOrBuildDominatorIndex(lookup);
+                    var higherValueKeyCount = PotentialSnipeHigherValueScan(
+                        domIndex, groupTag.tag, key, bucket.Lbin.Price, out lowestLbin, out int allReferencesCount);
                     // 25th percentile of all references
-                    var allReferences = higherValueKeys.SelectMany(x => x.Value.References.Select(r => r.Price / (x.Key.Count == 0 ? 1 : x.Key.Count))).ToList();
-                    referencePrice = allReferences
-                                    .OrderBy(p => p).Skip(allReferences.Count / 4)
-                                    .DefaultIfEmpty(targetPrice / 2).Min();
+                    referencePrice = PotentialSnipeQuarterPercentile(allReferencesCount, targetPrice / 2);
 
-                    if (bucket.Price == 0 && bucket.References.Count > 2 && higherValueKeys.Count <= 2) // manip indicator
+                    if (bucket.Price == 0 && bucket.References.Count > 2 && higherValueKeyCount <= 2) // manip indicator
                     {
                         percentile /= 5;
                     }
-                    else if (bucket.References.Count < 4 && allReferences.Count < 5)
+                    else if (bucket.References.Count < 4 && allReferencesCount < 5)
                     {
                         percentile = Math.Min(percentile, referencePrice / 2);
-                        if (allReferences.Count == 0)
+                        if (allReferencesCount == 0)
                             percentile /= 2;
                     }
                     else if (bucket.References.Count <= 3)
@@ -4058,8 +6635,8 @@ ORDER BY l.`AuctionId`  DESC;
                 percentile = Math.Min(percentile, referencePrice);
                 if (bucket.Price == 0 && bucket.Lbin.Seller == GetSellerId(auction))
                 {
-                    props["sellerMatch"] = percentile.ToString();
-                    // seller matching is sus 
+                    sellerMatchProp = percentile.ToString(); // deferred props["sellerMatch"], captured before the /= 2
+                    // seller matching is sus
                     percentile /= 2;
                 }
                 percentile = Math.Min(percentile, lowestLbin);
@@ -4067,10 +6644,18 @@ ORDER BY l.`AuctionId`  DESC;
                 {
                     Activity.Current.Log($"Reduced because no higher value lbin");
                     percentile = Math.Min(percentile, Math.Min(targetPrice * (60 + (int)(bucket.Volume * 5)) / 100, (long)(referencePrice * 1.2)));
-                    props["noHigherLbin"] = percentile.ToString();
+                    noHigherLbinProp = percentile.ToString(); // deferred props["noHigherLbin"]
                 }
                 if (percentile < lbinPrice)
                     return false; // to low already don't waste time
+                // gate passed -> now allocate the props dict and replay the deferred writes in the ORIGINAL insertion order
+                props = CreateReference(bucket.Lbin.AuctionId, key, extraValue, bucket);
+                props["mVal"] = bucket.Price.ToString();
+                props["hvlbin"] = hvlbinProp;
+                if (sellerMatchProp != null)
+                    props["sellerMatch"] = sellerMatchProp;
+                if (noHigherLbinProp != null)
+                    props["noHigherLbin"] = noHigherLbinProp;
                 var reduced = CapAtCraftCost(groupTag.tag, percentile, breakdown, 0);
                 if (reduced > 0)
                 {
@@ -4080,20 +6665,224 @@ ORDER BY l.`AuctionId`  DESC;
                         else
                             reduced = reduced * 21 / 20; // 5% extra for snipe
                     percentile = Math.Min(reduced, percentile);
-                    Activity.Current.Log($"Reduced to craft cost {reduced}");
+                    if (Activity.Current is { IsAllDataRequested: true })
+                        Activity.Current.Log($"Reduced to craft cost {reduced}");
                     props["craftCost"] = reduced.ToString();
                 }
-                Activity.Current.Log($"No references, checking all lbins {percentile} {lowestLbin} {referencePrice}");
+                if (Activity.Current is { IsAllDataRequested: true })
+                    Activity.Current.Log($"No references, checking all lbins {percentile} {lowestLbin} {referencePrice}");
                 props["referencePrice"] = referencePrice.ToString();
                 props["lowestLbin"] = lowestLbin.ToString();
             }
             else
             {
+                // the else branch has no reject gate before FoundAFlip, so allocate + replay mVal/hvlbin here (same order)
+                props = CreateReference(bucket.Lbin.AuctionId, key, extraValue, bucket);
+                props["mVal"] = bucket.Price.ToString();
+                props["hvlbin"] = hvlbinProp;
                 CapHighValue(groupTag, bucket, key, breakdown, higherValueLowerBin, ref targetPrice, ref percentile, props);
             }
             props["percentile"] = percentile.ToString();
             targetPrice = Math.Min(targetPrice, percentile);
-            return FoundAFlip(auction, bucket, LowPricedAuction.FinderType.SNIPER, targetPrice, props);
+            return FoundAFlip(auction, bucket, LowPricedAuction.FinderType.SNIPER, targetPrice, props, key, extraValue);
+        }
+
+        // ===== R2-B: de-LINQ'd PotentialSnipe percentile / higher-value-scan helpers =====
+        // Thread-static scratch buffers so the hot snipe path reuses storage instead of allocating
+        // Int64[]/ReferencePrice[]/Func/SelectIterator per call. PotentialSnipe runs serially per group-tag but across
+        // worker threads (per-core dispatcher), so the buffers are per-thread to stay race-free.
+        [ThreadStatic] private static (long price, short day, int idx)[] _potentialSnipeRefScratch;
+        [ThreadStatic] private static long[] _potentialSnipePriceScratch;
+        [ThreadStatic] private static long[] _potentialSnipeDividedScratch;
+
+        private static T[] PotentialSnipeEnsure<T>(ref T[] buffer, int needed)
+        {
+            if (buffer == null)
+                buffer = new T[Math.Max(needed, 16)];
+            else if (buffer.Length < needed)
+                Array.Resize(ref buffer, Math.Max(needed, buffer.Length * 2)); // preserves existing contents
+            return buffer;
+        }
+
+        /// <summary>
+        /// Bit-exact replacement for
+        /// <c>References.OrderByDescending(r=>r.Day).Take(subsetSize).Select(r=>r.Price).OrderBy(p=>p).ElementAt(min(Count,subsetSize)*8/10)</c>.
+        /// Returns the reference count (snapshot) and emits the 80th-percentile price in <paramref name="eightieth"/>.
+        /// </summary>
+        private static int PotentialSnipeEightiethPercentile(
+            ReferencePrice[] references, int subsetSize, out long eightieth)
+        {
+            // Snapshot in enumeration order, tagging the original index so the day-descending sort is *stable*
+            // (LINQ OrderByDescending is stable; Array.Sort is not — break ties by original index to match).
+            var scratch = PotentialSnipeEnsure(ref _potentialSnipeRefScratch, 0);
+            int count = 0;
+            foreach (var r in references)
+            {
+                if (count >= scratch.Length)
+                    scratch = PotentialSnipeEnsure(ref _potentialSnipeRefScratch, count + 1);
+                scratch[count] = (r.Price, r.Day, count);
+                count++;
+            }
+            if (count == 0)
+            {
+                eightieth = 0;
+                return 0;
+            }
+            int take = Math.Min(count, subsetSize);
+            // stable sort by Day descending: partial-select the top `take` by (day desc, idx asc).
+            // count is bounded (<= references in a bucket); an insertion-style partial selection keeps it allocation-free.
+            Array.Sort(scratch, 0, count, PotentialSnipeDayDescComparer.Instance);
+
+            var prices = PotentialSnipeEnsure(ref _potentialSnipePriceScratch, take);
+            for (int i = 0; i < take; i++)
+                prices[i] = scratch[i].price;
+            Array.Sort(prices, 0, take); // ascending, matches OrderBy(p=>p) for the indexed value
+            eightieth = prices[take * 8 / 10];
+            return count;
+        }
+
+        private sealed class PotentialSnipeDayDescComparer : IComparer<(long price, short day, int idx)>
+        {
+            public static readonly PotentialSnipeDayDescComparer Instance = new();
+            public int Compare((long price, short day, int idx) a, (long price, short day, int idx) b)
+            {
+                if (a.day != b.day)
+                    return b.day.CompareTo(a.day); // Day descending
+                return a.idx.CompareTo(b.idx);     // stable: preserve original enumeration order
+            }
+        }
+
+        /// <summary>
+        /// Bit-exact single-pass replacement for the higher-value LINQ scan. Computes
+        /// <c>lowestLbin = higherValueKeys.Where(Lbin.Price>0 &amp;&amp; Lbin.Price&lt;bucketLbinPrice).Select(Lbin.Price).DefaultIfEmpty(long.MaxValue).Min()</c>
+        /// and fills the thread-static divided-price buffer with
+        /// <c>higherValueKeys.SelectMany(x=>x.Value.References.Select(r=>r.Price/(x.Key.Count==0?1:x.Key.Count)))</c>.
+        /// Returns the higher-value key count. Iteration order is irrelevant: lowestLbin is a Min and the divided
+        /// prices are later sorted, so the emitted values are independent of dictionary enumeration order.
+        /// </summary>
+        private int PotentialSnipeHigherValueScan(
+            DominatorIndex index, string tag, AuctionKey key, long bucketLbinPrice,
+            out long lowestLbin, out int dividedCount)
+        {
+            long lowest = long.MaxValue;
+            int keyCount = 0;
+            int divided = 0;
+            var buffer = PotentialSnipeEnsure(ref _potentialSnipeDividedScratch, 0);
+            // Direction A: candidates that dominate the query `key` (Dominates(key, cand)), over the BROAD index (all
+            // non-null buckets — incl Price==0/virtual, exactly the old `foreach (var x in l)`). keyCount/lowest are
+            // order-independent; the divided buffer is sorted by PotentialSnipeQuarterPercentile so its order is moot.
+            var query = DominatorIndex.BuildDomKey(key, scoreInterner);
+            ulong qReq = query.RequiredMask;
+            bool petSpirit = tag == "PET_SPIRIT";
+            for (int i = 0; i < index.Count; i++)
+            {
+                if ((qReq & index.ProvidedMask[i]) != qReq)
+                    continue; // sound presence prefilter
+                if (!DominatorIndex.Dominates(in query, in index.Doms[i], petSpirit))
+                    continue;
+                keyCount++;
+                var bucket = index.Buckets[i];
+                var lbinPrice = bucket.Lbin.Price; // LIVE
+                if (lbinPrice > 0 && lbinPrice < bucketLbinPrice && lbinPrice < lowest)
+                    lowest = lbinPrice;
+                int countDivisor = index.Keys[i].Count == 0 ? 1 : index.Keys[i].Count;
+                var refs = bucket.ReferenceSnapshot(); // LIVE
+                for (int r = 0; r < refs.Length; r++)
+                {
+                    if (divided >= buffer.Length)
+                        buffer = PotentialSnipeEnsure(ref _potentialSnipeDividedScratch, divided + 1);
+                    buffer[divided++] = refs[r].Price / countDivisor;
+                }
+            }
+            lowestLbin = lowest; // DefaultIfEmpty(long.MaxValue).Min(): long.MaxValue when nothing qualified
+            dividedCount = divided;
+            return keyCount;
+        }
+
+        /// <summary>
+        /// Bit-exact replacement for
+        /// <c>allReferences.OrderBy(p=>p).Skip(allReferences.Count/4).DefaultIfEmpty(fallback).Min()</c> over the
+        /// divided-price buffer filled by <see cref="PotentialSnipeHigherValueScan"/>: the value at sorted index
+        /// <c>count/4</c>, or <paramref name="fallback"/> when empty.
+        /// <para>
+        /// WS-CHURN-A: bit-exact partial-selection replacement (in-place quickselect / nth_element instead of a full
+        /// <see cref="Array.Sort"/>), gated against <see cref="PotentialSnipeQuarterPercentileReference"/>. The result
+        /// is a scalar order statistic over a <c>long[]</c>, so the k-th smallest VALUE is uniquely defined regardless
+        /// of duplicates; any correct selection returns the identical long. The buffer is refilled fresh every auction
+        /// by <see cref="PotentialSnipeHigherValueScan"/> and is not read after this call, so leaving it only
+        /// partitioned (not fully sorted) is safe.
+        /// </para>
+        /// </summary>
+        private static long PotentialSnipeQuarterPercentile(int count, long fallback)
+            => PotentialSnipeQuarterPercentile(_potentialSnipeDividedScratch, count, fallback);
+
+        /// <summary>
+        /// Core of <see cref="PotentialSnipeQuarterPercentile(int,long)"/> operating on an explicit buffer so it is
+        /// directly unit-testable without the <c>[ThreadStatic]</c> field. Selects the (<paramref name="count"/>/4)-th
+        /// smallest of <c>buffer[0, count)</c> via in-place quickselect; returns <paramref name="fallback"/> when empty.
+        /// Mutates <c>buffer[0, count)</c> (partition only).
+        /// </summary>
+        internal static long PotentialSnipeQuarterPercentile(long[] buffer, int count, long fallback)
+        {
+            if (count == 0)
+                return fallback;
+            int k = count / 4; // OrderBy then Skip(count/4) then Min == element at index count/4
+            QuickSelectLong(buffer, 0, count - 1, k);
+            return buffer[k];
+        }
+
+        /// <summary>
+        /// Reference oracle for <see cref="PotentialSnipeQuarterPercentile(long[],int,long)"/>: the ORIGINAL
+        /// full-sort body verbatim. Kept as the bit-exactness gate (mirrors the
+        /// <see cref="CleanItemPriceSelectTarget"/> / <see cref="CleanItemPriceSelectTargetReference"/> pattern).
+        /// </summary>
+        internal static long PotentialSnipeQuarterPercentileReference(long[] buffer, int count, long fallback)
+        {
+            if (count == 0)
+                return fallback;
+            Array.Sort(buffer, 0, count); // ascending
+            return buffer[count / 4]; // OrderBy then Skip(count/4) then Min == element at index count/4
+        }
+
+        /// <summary>
+        /// In-place quickselect (nth_element) on <c>a[lo..hi]</c> for the k-th smallest VALUE: on return,
+        /// <c>a[k]</c> holds the element that a full ascending sort would place at index <paramref name="k"/>, with
+        /// everything left of it &lt;= and everything right of it &gt;=. Median-of-three pivot guards against the
+        /// O(n^2) behaviour on already-sorted / heavy-tie inputs that a full <see cref="Array.Sort"/> tolerated.
+        /// </summary>
+        private static void QuickSelectLong(long[] a, int lo, int hi, int k)
+        {
+            while (lo < hi)
+            {
+                int p = QuickSelectLongPartition(a, lo, hi);
+                if (p == k) return;
+                if (p < k) lo = p + 1; else hi = p - 1;
+            }
+        }
+
+        private static int QuickSelectLongPartition(long[] a, int lo, int hi)
+        {
+            // median-of-three pivot selection, parked at hi-1 (Lomuto over [lo, hi-1) with a[hi] already >= pivot).
+            int mid = lo + ((hi - lo) >> 1);
+            if (a[mid] < a[lo]) (a[lo], a[mid]) = (a[mid], a[lo]);
+            if (a[hi] < a[lo]) (a[lo], a[hi]) = (a[hi], a[lo]);
+            if (a[hi] < a[mid]) (a[mid], a[hi]) = (a[hi], a[mid]);
+            // a[lo] <= a[mid] <= a[hi]; pivot = a[mid]. With only two elements (hi == lo+1) skip the parking dance.
+            if (hi - lo < 2)
+                return lo; // a[lo] <= a[hi]; lo is already the partition boundary for the smaller element
+            long pivot = a[mid];
+            (a[mid], a[hi - 1]) = (a[hi - 1], a[mid]);
+            int store = lo;
+            for (int j = lo; j < hi - 1; j++)
+            {
+                if (a[j] < pivot)
+                {
+                    (a[store], a[j]) = (a[j], a[store]);
+                    store++;
+                }
+            }
+            (a[store], a[hi - 1]) = (a[hi - 1], a[store]); // restore pivot to its sorted position
+            return store;
         }
 
         private void CapHighValue((string tag, long costSubstract) groupTag, ReferenceAuctions bucket, AuctionKey key, KeyWithValueBreakdown breakdown, long higherValueLowerBin, ref long targetPrice, ref long percentile, Dictionary<string, string> props)
@@ -4118,7 +6907,8 @@ ORDER BY l.`AuctionId`  DESC;
             if (capped > 0)
             {
                 percentile = Math.Min(percentile, capped * 12 / 11) + 500_000; // 500k extra since this is high volume
-                Activity.Current.Log($"Capped at craft cost {capped}");
+                if (Activity.Current is { IsAllDataRequested: true })
+                    Activity.Current.Log($"Capped at craft cost {capped}");
                 props["breakdown"] = JsonConvert.SerializeObject(breakdown.ValueBreakdown);
                 props["craftCost"] = capped.ToString();
             }
@@ -4126,10 +6916,106 @@ ORDER BY l.`AuctionId`  DESC;
                 props["nocapped"] = capped.ToString();
         }
 
-        private bool IsHigherValue(string tag, AuctionKey baseKey, AuctionKey toCheck)
+        /// <summary>
+        /// True if <paramref name="toCheck"/> dominates <paramref name="baseKey"/> (same-or-higher tier/count, and every
+        /// base modifier/enchant is covered with an equal-or-greater value). Hot: called per candidate in GetLbinCap and
+        /// the low-reference snipe scan. This is an allocation-free, bit-identical de-LINQ of the original predicate —
+        /// the LINQ version (<see cref="IsHigherValueReference"/>) is retained as the oracle and the two are fuzzed for
+        /// boolean parity in IsHigherValueTests. Modifier keys are unique within a key, so the inner key-match is at most
+        /// one hit; the loop still scans on a value-miss to mirror the original Any's all-candidates semantics.
+        /// </summary>
+        internal bool IsHigherValue(string tag, AuctionKey baseKey, AuctionKey toCheck)
         {
-            //   if (IsMidas(tag) && !baseKey.Modifiers.Any(m => m.Key == "winning_bid" || m.Key == "full_bid") && toCheck.Modifiers.Any(m => m.Key == "winning_bid" || m.Key == "full_bid"))
-            //       return false;
+            if (baseKey.Tier > toCheck.Tier)
+                return false;
+            if (toCheck.Tier == Tier.LEGENDARY && tag == "PET_SPIRIT")
+                return false;
+            if (baseKey.Count > toCheck.Count)
+                return false;
+
+            var baseMods = baseKey.Modifiers;
+            var checkMods = toCheck.Modifiers;
+            var firstBaseModKey = baseMods.Count > 0 ? baseMods[0].Key : null; // == baseKey.Modifiers.FirstOrDefault().Key
+            for (int i = 0; i < baseMods.Count; i++)
+            {
+                var m = baseMods[i];
+                bool covered = false;
+                for (int j = 0; j < checkMods.Count; j++)
+                {
+                    var other = checkMods[j];
+                    if (other.Key != m.Key)
+                        continue;
+                    bool valueOk =
+                        other.Value == m.Value
+                        || (float.TryParse(other.Value, out var otherVal)
+                            && (firstBaseModKey != "new_years_cake" || !ImportantCakeYears.Contains(other.Value))
+                            && float.TryParse(m.Value, out var ownVal)
+                            && (InvertedValueKey.Contains(other.Key) ? otherVal < ownVal : otherVal > ownVal))
+                        || (other.Value.Contains(m.Value)
+                            && !float.TryParse(other.Value, out _)
+                            && (other.Value.Contains(' ') || other.Value.Contains(',')));
+                    if (valueOk && MatchesTierBoostOrLowerTier(baseKey, toCheck, m))
+                    {
+                        covered = true;
+                        break;
+                    }
+                }
+                // original: ... || InvertedValueKey.Contains(m.Key) && !toCheck.Modifiers.Any(o => o.Key == m.Key)
+                if (!covered && !(InvertedValueKey.Contains(m.Key) && !AnyModWithKey(checkMods, m.Key)))
+                    return false;
+            }
+
+            var baseEnch = baseKey.Enchants;
+            var checkEnch = toCheck.Enchants;
+            for (int i = 0; i < baseEnch.Count; i++)
+            {
+                var e = baseEnch[i];
+                bool found = false;
+                for (int j = 0; j < checkEnch.Count; j++)
+                {
+                    if (checkEnch[j].Type == e.Type && checkEnch[j].Lvl >= e.Lvl) { found = true; break; }
+                }
+                if (!found)
+                    return false;
+            }
+            return true;
+
+            static bool AnyModWithKey(System.Collections.ObjectModel.ReadOnlyCollection<KeyValuePair<string, string>> mods, string key)
+            {
+                for (int j = 0; j < mods.Count; j++)
+                    if (mods[j].Key == key) return true;
+                return false;
+            }
+
+            static bool MatchesTierBoostOrLowerTier(AuctionKey baseKey, AuctionKey toCheck, KeyValuePair<string, string> m)
+            {
+                if (m.Key != "exp")
+                    return true;
+                // De-LINQ'd: the old .Where(...).FirstOrDefault() + .Any(...) allocated Func/enumerator closures per
+                // exp-modifier per candidate (a per-bucket read-path & lower-key allocator). Same semantics (a petItem
+                // =TIER_BOOST modifier present?), bit-exact (IsHigherValueTests fuzz parity gate).
+                if (!HasTierBoostPetItem(toCheck.Modifiers))
+                    return true;
+                return HasTierBoostPetItem(baseKey.Modifiers) || baseKey.Tier < toCheck.Tier;
+            }
+
+            static bool HasTierBoostPetItem(System.Collections.ObjectModel.ReadOnlyCollection<KeyValuePair<string, string>> mods)
+            {
+                if (mods == null)
+                    return false;
+                for (int j = 0; j < mods.Count; j++)
+                    if (mods[j].Key == "petItem" && mods[j].Value == "TIER_BOOST")
+                        return true;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Original LINQ implementation of <see cref="IsHigherValue"/>, retained only as the bit-exact oracle for
+        /// IsHigherValueTests' fuzz parity (do not call from production — use <see cref="IsHigherValue"/>).
+        /// </summary>
+        internal bool IsHigherValueReference(string tag, AuctionKey baseKey, AuctionKey toCheck)
+        {
             return baseKey.Tier <= toCheck.Tier
                     && (toCheck.Tier != Tier.LEGENDARY || tag != "PET_SPIRIT")
                     && baseKey.Count <= toCheck.Count
@@ -4139,8 +7025,7 @@ ORDER BY l.`AuctionId`  DESC;
                                             && (baseKey.Modifiers.FirstOrDefault().Key != "new_years_cake" || !ImportantCakeYears.Contains(other.Value))
                                             && float.TryParse(m.Value, out var ownVal) && (InvertedValueKey.Contains(other.Key) ? otherVal < ownVal : otherVal > ownVal)
                                             || other.Value.Contains(m.Value) && !float.TryParse(other.Value, out _)
-                                                // has any space or comma for contains
-                                                && other.Value.Any(c => new char[] { ' ', ',' }.Contains(c))
+                                                && (other.Value.Contains(' ') || other.Value.Contains(','))
                                             )
                                             && MatchesTierBoostOrLowerTier(baseKey, toCheck, m))
                                                 || InvertedValueKey.Contains(m.Key) && !toCheck.Modifiers.Any(other => other.Key == m.Key)
@@ -4153,11 +7038,8 @@ ORDER BY l.`AuctionId`  DESC;
                     return true;
                 var toCheckModifiers = toCheck.Modifiers.Where(other => other.Key == "petItem" && other.Value == "TIER_BOOST").FirstOrDefault();
                 if (toCheckModifiers.Key == default)
-                {
                     return true;
-                }
-                var res = baseKey.Modifiers.Any(other => other.Key == "petItem" && other.Value == "TIER_BOOST")
-                                                               ;
+                var res = baseKey.Modifiers.Any(other => other.Key == "petItem" && other.Value == "TIER_BOOST");
                 return res || baseKey.Tier < toCheck.Tier;
             }
         }
@@ -4180,16 +7062,18 @@ ORDER BY l.`AuctionId`  DESC;
             return false;
         }
 
-        private static void AddMedianSample(IEnumerable<ReferencePrice> bucket, Dictionary<string, string> props)
+        private static void AddMedianSample(ReferencePrice[] references, Dictionary<string, string> props)
         {
-            var references = bucket.Reverse().Take(5).ToArray();
-            if (references.Length > 0)
+            // Newest-first (reverse FIFO) take 5, bit-exact with the old `bucket.Reverse().Take(5)`. Iterate the cached
+            // snapshot array backwards instead of allocating a ConcurrentQueue enumerator + a LINQ Reverse buffer.
+            int count = Math.Min(references.Length, 5);
+            if (count > 0)
             {
                 var sb = new System.Text.StringBuilder(180);
-                for (int i = 0; i < references.Length; i++)
+                for (int i = 0; i < count; i++)
                 {
                     if (i > 0) sb.Append(',');
-                    sb.Append(references[i].AuctionId);
+                    sb.Append(references[references.Length - 1 - i].AuctionId);
                 }
                 props["med"] = sb.ToString();
             }
@@ -4213,8 +7097,14 @@ ORDER BY l.`AuctionId`  DESC;
 
         public void PrintLogQueue()
         {
+            // The per-entry "Info:" line (and the AuctionKey.ToString() in result.Key) is only built when the logger
+            // would actually emit it; otherwise the queue is just drained (it must still empty to stay bounded). The
+            // produced log text is byte-identical when Information logging is enabled.
+            bool emit = logger != null && logger.IsEnabled(LogLevel.Information);
             while (Logs.TryDequeue(out LogEntry result))
             {
+                if (!emit)
+                    continue;
                 var finderName = result.Finder == LowPricedAuction.FinderType.UNKOWN ? "NF" : result.Finder.ToString();
                 logger.LogInformation($"Info: {finderName} {result.Uuid} m:{result.Median} \t{result.LBin} {result.Volume} {result.Key}{result.ExtraContext}");
             }
@@ -4226,7 +7116,10 @@ ORDER BY l.`AuctionId`  DESC;
             LbinUpdates.Enqueue((auction, bucket, key));
         }
 
-        private bool FoundAFlip(SaveAuction auction, ReferenceAuctions bucket, LowPricedAuction.FinderType type, long targetPrice, Dictionary<string, string> props)
+        // <paramref name="keyForProps"/> (when non-null) is the deferred "key" props entry — CreateReference no longer
+        // builds it eagerly; it is materialised here after the reject gates pass, so a rejected flip never pays for
+        // AuctionKey.ToString(). The emitted props are byte-identical (same value, present on every emitted flip).
+        private bool FoundAFlip(SaveAuction auction, ReferenceAuctions bucket, LowPricedAuction.FinderType type, long targetPrice, Dictionary<string, string> props, AuctionKey keyForProps = null, long extraValueForProps = 0)
         {
             if (targetPrice < MIN_TARGET || targetPrice < auction.StartingBid * 1.03)
             {
@@ -4236,11 +7129,14 @@ ORDER BY l.`AuctionId`  DESC;
             var refAge = (GetDay() - bucket.OldestRef);
             if (bucket.OldestRef != 0 && (refAge > 60 && IsNotClean(auction) || State < SniperState.FullyLoaded && refAge > 10))
             {
-                Activity.Current.Log($"References too old {refAge} {State}");
+                if (Activity.Current is { IsAllDataRequested: true })
+                    Activity.Current.Log($"References too old {refAge} {State}");
                 LogNonFlip(auction, bucket, defaultKey, 0, bucket.Volume, targetPrice, $"References too old for {State} ({refAge})");
                 return false; // too old
             }
-            AddMedianSample(bucket.References, props);
+            if (keyForProps != null)
+                MaterializeKeyProp(props, keyForProps, extraValueForProps);
+            AddMedianSample(bucket.ReferenceSnapshot(), props);
             props["refAge"] = refAge.ToString();
             props["server"] = ServerDnsName;
             props["refCount"] = bucket.DeduplicatedReferenceCount.ToString();
@@ -4258,7 +7154,8 @@ ORDER BY l.`AuctionId`  DESC;
             }
             using var found = activitySource?.StartActivity("FoundFlip", ActivityKind.Internal);
             found?.AddTag("uuid", auction.Uuid);
-            found.Log($"Found flip {auction.Uuid} {targetPrice} {type} {bucket.Volume}");
+            if (found is { IsAllDataRequested: true })
+                found.Log($"Found flip {auction.Uuid} {targetPrice} {type} {bucket.Volume}");
 
             // Apply Diana adjustment to Diana-related items when Diana's term is ending or just ended
             if (mayorService != null
@@ -4269,6 +7166,7 @@ ORDER BY l.`AuctionId`  DESC;
                 props["diana-adj"] = "true";
             }
 
+            snipesFoundCounter.WithLabels(type.ToString()).Inc();
             FoundSnipe?.Invoke(new LowPricedAuction()
             {
                 Auction = auction,
@@ -4299,15 +7197,24 @@ ORDER BY l.`AuctionId`  DESC;
             return auction.Enchantments.Count > 0 || auction.FlatenedNBT.Any(f => !f.Key.Contains("uid"));
         }
 
+        // The "key" entry (which calls the costly AuctionKey.ToString()) is NOT built here — it is materialised by
+        // FoundAFlip after its reject gates pass (see MaterializeKeyProp), so a flip that is rejected (target too low /
+        // refs too old) never pays for the ToString(). The emitted dict is byte-identical: "key" still ends up present
+        // for CreateReference-sourced props (the only consumer reads it at emit time, after the gates).
         private static Dictionary<string, string> CreateReference(long reference, AuctionKey key, long extraValue, ReferenceAuctions bucket)
         {
             var dict = new Dictionary<string, string>() {
-                { "reference", AuctionService.Instance.GetUuid(reference) },
-                { "key", key.ToString() + (extraValue == 0 ? "" : $" +{extraValue}")}
+                { "reference", AuctionService.Instance.GetUuid(reference) }
             };
             if (extraValue != 0)
                 dict["extraValue"] = extraValue.ToString();
             return dict;
+        }
+
+        // Builds the deferred "key" props entry exactly as CreateReference used to, only when a flip is actually emitted.
+        private static void MaterializeKeyProp(Dictionary<string, string> props, AuctionKey key, long extraValue)
+        {
+            props["key"] = key.ToString() + (extraValue == 0 ? "" : $" +{extraValue}");
         }
 
         public async System.Threading.Tasks.Task Init()

--- a/Services/UpdateMedian.Tests.cs
+++ b/Services/UpdateMedian.Tests.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using dev;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R5 P2 bit-exactness oracle for the WRITE / repricing path
+    /// (<c>benchmarks/COMPUTE_FLOOR_SPEC_R5.md</c> §3-P2 + §4). This is the gate a future write-path optimization
+    /// (de-LINQ of <c>UpdateMedian</c>, pooled <c>ReferencePrice[]</c>, removing the incidental
+    /// <c>KeyValuePair&lt;AuctionKey,ReferenceAuctions&gt;[]</c> materializations, etc.) must not break.
+    ///
+    /// <para>
+    /// <b>Why.</b> The WARM alloc profile blames <c>UpdateMedian</c> for the single largest warm allocator (the
+    /// <c>KeyValuePair&lt;AuctionKey,ReferenceAuctions&gt;[]</c>, 93.5% of which is from UpdateMedian) plus the
+    /// <c>ReferencePrice[]</c> from <c>ApplyAntiMarketManipulation</c>/<c>DropUnderlistings</c> (both reached only
+    /// through UpdateMedian) and the <c>Slot[ReferencePrice][]</c> from <c>SetReferences</c>. P2's job is to shrink
+    /// that allocation without changing a single repriced output. This oracle pins the OBSERVABLE outputs of the
+    /// repricing of a fixed, representative set of buckets so any allocation-shaving rewrite is provably
+    /// behavior-neutral.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>What it drives.</b> The production repricing entry point <see cref="SniperService.RefreshLookup"/>, which is
+    /// the bulk-reprice that loops every bucket of a tag and calls the SAME
+    /// <c>CapBucketSize</c> + <c>UpdateMedian(bucket, (tag, GetBreakdownKey(key, tag)))</c> (+ <c>GetLbinCap</c>) that
+    /// the per-sale ingest path (<c>AddSoldItem → AddAuctionToBucket → UpdateMedian</c>) funnels through. Buckets are
+    /// populated through the public <c>AddSoldItem</c> API (mirroring <c>GetPrice.Tests.cs</c> /
+    /// <c>ValuationFinders.Tests.cs</c>) so the references/lbins are production-shaped; <c>RefreshLookup</c> then
+    /// reprices, and we snapshot each bucket's observable fields.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Pinned outputs</b> (per bucket): <c>Price</c>, <c>OldestRef</c>, <c>Volatility</c>,
+    /// <c>DeduplicatedReferenceCount</c>, <c>RiskyEstimate</c>, <c>Volume</c>, <c>TimeToSell</c>, <c>Lbin.Price</c>,
+    /// and the full FIFO <c>References</c> sequence (id+day+price). These are exactly the fields a write-path rewrite
+    /// could perturb. Captures the CURRENT behavior as the golden (assert current == captured).
+    /// </para>
+    ///
+    /// <para>
+    /// Construction mirrors <c>GetPrice.Tests.cs</c> Setup (NullLogger to dodge the known flaky-logger NRE,
+    /// MIN_TARGET=0, fixed StartTime, FullyLoaded, AddSoldItem to populate buckets). <see cref="DISCOVER"/> is the
+    /// regeneration switch: flip it to <c>true</c>, run, and paste the printed lines back into the golden constants —
+    /// never hand-edit a golden to silence a real diff (that would defeat the gate).
+    /// </para>
+    /// </summary>
+    public class UpdateMedianGoldenTests
+    {
+        /// <summary>
+        /// Regeneration switch. Leave <c>false</c> in committed code: the test then *asserts* the live repriced bucket
+        /// equals the embedded golden. Flip to <c>true</c> only to (re)derive the goldens after an *intended* behavior
+        /// change — the test prints each fixture's serialized bucket and trivially passes so the new lines can be copied
+        /// into the constants. A green CI run with DISCOVER=true proves nothing; it must be committed false.
+        /// </summary>
+        private static readonly bool DISCOVER = false;
+
+        private SniperService service = null!;
+        private List<LowPricedAuction> found = null!;
+        private CraftCostMock craftCost = null!;
+        private HypixelItemService itemService = null!;
+        private static long idCounter;
+
+        private class CraftCostMock : ICraftCostService
+        {
+            public Dictionary<string, double> Costs { get; } = new();
+            public Dictionary<string, Category> ItemCategories { get; } = new();
+            public void AddCostForSpecialItems() { }
+            public bool TryGetCost(string itemId, out double cost) => Costs.TryGetValue(itemId, out cost);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            SniperService.StartTime = new DateTime(2021, 9, 25);
+            craftCost = new CraftCostMock();
+            itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, craftCost);
+            idCounter = 100;
+            found = new List<LowPricedAuction>();
+            service.FoundSnipe += found.Add;
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        // ============================================================================================================
+        // Fixture 1 — plain priced bucket with a healthy, multi-day, multi-seller reference set. Exercises the main
+        // UpdateMedian path: ApplyAntiMarketManipulation + DropUnderlistings keep all refs, short/long-term median,
+        // volatility, risky estimate, and an active lbin. This is the steady-state warm reprice the profile blames.
+        // ============================================================================================================
+        [Test]
+        public void UpdateMedian_PlainPricedBucket_BitExact()
+        {
+            const string tag = "UM_SWORD";
+            // 10 sales spread over recent days from distinct sellers/buyers (so anti-manip/underlisting keep them),
+            // rising-then-stable so the median is well defined.
+            for (int i = 0; i < 10; i++)
+                AddSale(tag, dayAgo: i, price: 10_000_000 + i * 250_000, seller: 1000 + i, buyer: 5000 + i);
+            // an active (unsold) listing so the bucket carries an Lbin too
+            AddLbin(tag, price: 13_500_000);
+
+            service.RefreshLookup(tag);
+            AssertGoldenBucket("PlainPricedBucket", tag, BucketFor(tag), GOLD_PLAIN);
+        }
+
+        // ============================================================================================================
+        // Fixture 2 — pet bucket (tier-bearing, exp modifier). Exercises the pet-key breakdown + the clean-key /
+        // clean-price-per-tier branches inside UpdateMedian on a tier-bearing item.
+        // ============================================================================================================
+        [Test]
+        public void UpdateMedian_PetBucket_BitExact()
+        {
+            const string tag = "UM_PET_TIGER";
+            for (int i = 0; i < 9; i++)
+                AddPetSale(tag, dayAgo: i, price: 40_000_000 + i * 1_000_000, seller: 2000 + i, buyer: 6000 + i);
+            AddPetLbin(tag, price: 46_000_000);
+
+            service.RefreshLookup(tag);
+            AssertGoldenBucket("PetBucket", tag, BucketFor(tag), GOLD_PET);
+        }
+
+        // ============================================================================================================
+        // Fixture 3 — declining-market bucket: older sales high, recent sales lower, so the dropping-price /
+        // short-term-vs-long-term protection branches and volatility computation engage. Pins that the trend handling
+        // is preserved by a rewrite.
+        // ============================================================================================================
+        [Test]
+        public void UpdateMedian_DecliningMarket_BitExact()
+        {
+            const string tag = "UM_DECLINING";
+            // older = expensive, newer = cheaper (a falling market)
+            for (int i = 0; i < 12; i++)
+                AddSale(tag, dayAgo: i, price: 30_000_000 - i * 1_500_000, seller: 3000 + i, buyer: 7000 + i);
+
+            service.RefreshLookup(tag);
+            AssertGoldenBucket("DecliningMarket", tag, BucketFor(tag), GOLD_DECLINING);
+        }
+
+        // ============================================================================================================
+        // Fixture 4 — low-volume bucket (exactly the boundary where UpdateMedian sets Price=0 for insufficient volume).
+        // Pins the "too low vol" early-out so a rewrite can't accidentally start pricing thin buckets.
+        // ============================================================================================================
+        [Test]
+        public void UpdateMedian_LowVolume_BitExact()
+        {
+            const string tag = "UM_THIN";
+            // only 3 references (< 4) -> Price forced to 0
+            for (int i = 0; i < 3; i++)
+                AddSale(tag, dayAgo: i, price: 5_000_000, seller: 4000 + i, buyer: 8000 + i);
+
+            service.RefreshLookup(tag);
+            AssertGoldenBucket("LowVolume", tag, BucketFor(tag), GOLD_THIN);
+        }
+
+        // ============================================================================================================
+        // Golden snapshots — serialized bucket, see SerializeBucket. Regenerate with DISCOVER=true; never hand-edit.
+        // ============================================================================================================
+
+        private const string GOLD_PLAIN =
+            "Price=10500000;OldestRef=37;Volatility=2;DedupCount=9;RiskyEstimate=0;Volume=0.006;TimeToSell=483023;Lbin.Price=13500000;Refs=100:40:10000000|101:39:10250000|102:38:10500000|103:37:10750000|104:36:11000000|105:35:11250000|106:34:11500000|107:33:11750000|108:32:12000000|109:31:12250000";
+
+        private const string GOLD_PET =
+            "Price=0;OldestRef=0;Volatility=0;DedupCount=0;RiskyEstimate=0;Volume=0.0054;TimeToSell=0;Lbin.Price=46000000;Refs=100:40:40000000|101:39:41000000|102:38:42000000|103:37:43000000|104:36:44000000|105:35:45000000|106:34:46000000|107:33:47000000|108:32:48000000";
+
+        private const string GOLD_DECLINING =
+            "Price=18000000;OldestRef=37;Volatility=10;DedupCount=12;RiskyEstimate=10500000;Volume=0.0072;TimeToSell=402519;Lbin.Price=0;Refs=100:40:30000000|101:39:28500000|102:38:27000000|103:37:25500000|104:36:24000000|105:35:22500000|106:34:21000000|107:33:19500000|108:32:18000000|109:31:16500000|110:30:15000000|111:29:13500000";
+
+        private const string GOLD_THIN =
+            "Price=0;OldestRef=0;Volatility=0;DedupCount=0;RiskyEstimate=0;Volume=0.0018;TimeToSell=0;Lbin.Price=0;Refs=100:40:5000000|101:39:5000000|102:38:5000000";
+
+        // ============================================================================================================
+        // Serialization + assertion: pin every observable repriced field a write-path rewrite could perturb.
+        // ============================================================================================================
+
+        /// <summary>
+        /// Stable, order-fixed serialization of every observable <see cref="ReferenceAuctions"/> field UpdateMedian
+        /// determines, plus the FIFO References sequence (id+day+price) and the active Lbin price. AuctionIds are
+        /// deterministic here (idCounter is reset per test and sales are added in a fixed order) so they are pinned.
+        /// </summary>
+        private static string SerializeBucket(ReferenceAuctions b)
+        {
+            var refs = string.Join("|", b.References.Select(r => $"{r.AuctionId}:{r.Day}:{r.Price}"));
+            return string.Join(";", new[]
+            {
+                $"Price={b.Price}",
+                $"OldestRef={b.OldestRef}",
+                $"Volatility={b.Volatility}",
+                $"DedupCount={b.DeduplicatedReferenceCount}",
+                $"RiskyEstimate={b.RiskyEstimate}",
+                $"Volume={b.Volume.ToString("0.####", CultureInfo.InvariantCulture)}",
+                $"TimeToSell={b.TimeToSell}",
+                $"Lbin.Price={b.Lbin.Price}",
+                $"Refs={refs}",
+            });
+        }
+
+        private void AssertGoldenBucket(string name, string tag, ReferenceAuctions live, string golden)
+        {
+            live.Should().NotBeNull($"RefreshLookup must produce a repriced bucket for fixture {name}");
+            var actual = SerializeBucket(live);
+            // Always print so a DISCOVER=true run can harvest the line; the assert below is what actually gates.
+            TestContext.Out.WriteLine($"[GOLD {name}] {actual}");
+            if (DISCOVER)
+                return;
+            actual.Should().Be(golden,
+                $"UpdateMedian/RefreshLookup result for fixture '{name}' must stay bit-identical (gates the P2 " +
+                "write-path optimization); if this is an intended change, regenerate with DISCOVER=true and paste the " +
+                "printed line into the golden constant");
+        }
+
+        // ---------- helpers (mirror GetPrice.Tests.cs / SniperService.Tests.cs) ----------
+
+        /// <summary>The single bucket of <paramref name="tag"/>'s lookup (the fixtures put exactly one priced key per tag).</summary>
+        private ReferenceAuctions BucketFor(string tag)
+        {
+            service.Lookups.TryGetValue(tag, out var lookup).Should().BeTrue($"lookup for {tag} must exist after populating");
+            // Pick the bucket with the most references (the one the fixture filled), deterministic across runs.
+            return lookup!.Lookup.OrderByDescending(kv => kv.Value.References.Count).First().Value;
+        }
+
+        /// <summary>Adds a single completed sale (a priced reference) to <paramref name="tag"/>'s clean bucket.</summary>
+        private void AddSale(string tag, int dayAgo, long price, int seller, int buyer)
+        {
+            var a = SaleBase(tag, dayAgo, price, seller, buyer);
+            a.FlatenedNBT = new();
+            a.Enchantments = new List<Enchantment>();
+            service.AddSoldItem(a);
+            service.FinishedUpdate();
+        }
+
+        /// <summary>Adds a pet sale (tier + exp modifier) to <paramref name="tag"/>'s pet bucket.</summary>
+        private void AddPetSale(string tag, int dayAgo, long price, int seller, int buyer)
+        {
+            var a = SaleBase(tag, dayAgo, price, seller, buyer);
+            a.Tier = Tier.LEGENDARY;
+            a.FlatenedNBT = new() { { "exp", "10000000" }, { "candyUsed", "0" } };
+            a.Enchantments = new List<Enchantment>();
+            service.AddSoldItem(a);
+            service.FinishedUpdate();
+        }
+
+        /// <summary>Adds an active (unsold) BIN listing so the bucket carries an Lbin.</summary>
+        private void AddLbin(string tag, long price)
+        {
+            var a = SaleBase(tag, dayAgo: -5, price: price, seller: 1500, buyer: 0);
+            a.FlatenedNBT = new();
+            a.Enchantments = new List<Enchantment>();
+            a.HighestBidAmount = 0; // active listing
+            a.StartingBid = price;
+            a.Bin = true;
+            DrivePublic(a);
+        }
+
+        private void AddPetLbin(string tag, long price)
+        {
+            var a = SaleBase(tag, dayAgo: -5, price: price, seller: 2500, buyer: 0);
+            a.Tier = Tier.LEGENDARY;
+            a.FlatenedNBT = new() { { "exp", "10000000" }, { "candyUsed", "0" } };
+            a.Enchantments = new List<Enchantment>();
+            a.HighestBidAmount = 0;
+            a.StartingBid = price;
+            a.Bin = true;
+            DrivePublic(a);
+        }
+
+        private void DrivePublic(SaveAuction a)
+        {
+            service.FinishedUpdate();
+            service.State = SniperState.FullyLoaded;
+            service.TestNewAuction(a);
+            service.FinishedUpdate();
+        }
+
+        /// <summary>A completed-sale auction <paramref name="dayAgo"/> days before StartTime+offset, with a deterministic
+        /// seller/buyer so anti-manipulation / underlisting filters behave identically across runs.</summary>
+        private SaveAuction SaleBase(string tag, int dayAgo, long price, int seller, int buyer)
+        {
+            var id = idCounter++;
+            // StartTime is the day-0 epoch; place sales a few days in so GetDay(End) is a small positive day number.
+            var end = SniperService.StartTime + TimeSpan.FromDays(40 - dayAgo);
+            return new SaveAuction
+            {
+                Tag = tag,
+                FlatenedNBT = new Dictionary<string, string>(),
+                Enchantments = new List<Enchantment>(),
+                StartingBid = price,
+                HighestBidAmount = price,
+                Category = Category.WEAPON,
+                Count = 1,
+                UId = id,
+                Uuid = id.ToString("x32").PadLeft(32, '0'),
+                // GetSellerId parses the first 4 hex chars; keep <= 0x7FFF and deterministic per seller.
+                AuctioneerId = (seller & 0x7FFF).ToString("x4") + "umtest",
+                Bids = buyer == 0 ? new List<SaveBids>() : new List<SaveBids>
+                {
+                    new() { Amount = price, Bidder = (buyer & 0x7FFF).ToString("x4") + "buyerum" }
+                },
+                Start = SniperService.StartTime + TimeSpan.FromDays(39 - dayAgo),
+                End = end,
+                Bin = true,
+            };
+        }
+    }
+}

--- a/Services/ValuationFinders.Reference.cs
+++ b/Services/ValuationFinders.Reference.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Sniper.Models;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R2 Phase 0 / F3 bit-exactness oracle for the <b>valuation finders</b>
+    /// (<c>benchmarks/COMPUTE_FLOOR_SPEC_R2.md</c> §4-F3 + §5 R2-A/R2-B/R2-D).
+    ///
+    /// <para><b>Two kinds of gate, because the targets differ in how they can be observed:</b></para>
+    /// <list type="number">
+    ///   <item><b>Golden-output capture (this file):</b> <see cref="GetCleanItemPrice"/> is a pure read over the
+    ///     populated lookup (no side effects, returns a <c>long</c>), so its current behavior is captured verbatim here
+    ///     as <see cref="GetCleanItemPriceReference"/> and the de-alloc rewrite (R2-D) is gated against it directly,
+    ///     on real populated services — the strongest possible contract. <see cref="GetCleanItemPriceForTest"/> exposes
+    ///     both the live production method and the reference to the test harness without weakening production access.</item>
+    ///   <item><b>Snipe-set capture (see <c>ValuationFinders.Tests.cs</c>):</b> <see cref="CheckCombined"/> and
+    ///     <see cref="PotentialSnipe"/> are private, stateful, and emit through <c>FoundAFlip</c> -&gt; the
+    ///     <c>FoundSnipe</c> event rather than returning a value. Their behavioral contract is therefore the resulting
+    ///     <b>snipe set</b> (the ordered list of <c>(finder, target price)</c> emitted) for a populated service driven
+    ///     through the public <c>TestNewAuction</c>. A future rewrite of those finders is proven correct iff it emits
+    ///     the identical snipe set.</item>
+    /// </list>
+    ///
+    /// <see cref="GetCleanItemPriceReference"/> is a <b>verbatim copy</b> of <see cref="GetCleanItemPrice"/> as of this
+    /// commit; it lives on the same <c>partial class SniperService</c> so it reaches the same private helpers
+    /// (<c>ReduceRarity</c>, <c>CanHaveGems</c>, <c>DropUnderlistings</c>, <c>IsMidas</c>) the production method uses, and
+    /// reads the same shared service state. It is referenced only by the test harness; never called from production.
+    /// </summary>
+    public partial class SniperService
+    {
+        /// <summary>
+        /// Test-only accessor: returns (live production result, reference snapshot result) for the same inputs so the
+        /// harness can assert byte-equality without reflecting into the private finder. Pure read; no state mutation.
+        /// </summary>
+        internal (long live, long reference) GetCleanItemPriceForTest(string tag, KeyWithValueBreakdown key, PriceLookup lookup, bool force = false)
+            => (GetCleanItemPrice(tag, key, lookup, force), GetCleanItemPriceReference(tag, key, lookup, force));
+
+        /// <summary>
+        /// R6 WS-CMB2 test seam: when <c>true</c>, <see cref="CheckCombined"/> dispatches to
+        /// <see cref="CheckCombinedReference"/> (the verbatim pre-R6 LINQ). Default <c>false</c> in production (the
+        /// de-LINQ'd path); flipped only by the fuzz harness for the new-vs-reference snipe-set A/B. A single bool read
+        /// on the alternate-finders path (NOT the per-auction hot dispatch loop).
+        /// </summary>
+        internal bool UseCombinedReference = false;
+
+        /// <summary>
+        /// Verbatim copy of <see cref="CheckCombined"/> as of the R6 WS-CMB2 snapshot (the full-LINQ implementation),
+        /// before the de-LINQ. The R6 de-LINQ rewrite is gated against this via the snipe-set A/B fuzz
+        /// (<c>Combined_DeLinq_BitExact_Fuzz</c>): both implementations are driven over the same randomized heavy-tie
+        /// lookups and must emit the identical snipe set. Lives on the same partial class so it reaches the same private
+        /// helpers (<c>GetReduced</c>, <c>GetAuctionGroupTag</c>, <c>GetFullKey</c>, <c>ComparisonValueForKey</c>,
+        /// <c>GetBucketDomKey</c>, <c>GetMedian</c>, <c>CapAtCraftCost</c>, <c>FindFlip</c>) the production method uses.
+        /// </summary>
+        private void CheckCombinedReference(SaveAuction auction, PriceLookup lookup, double lbinPrice, double medPrice, KeyWithValueBreakdown longKey, RankElem topAttrib)
+        {
+            var topKey = longKey.GetReduced(0);
+            var targetVolume = 11;
+            if (lookup.Lookup.TryGetValue(topKey, out var topBucket) && topBucket.References.Count >= targetVolume)
+            {
+                return; // enough references in previous check
+            }
+            var groupTag = GetAuctionGroupTag(auction.Tag);
+            var l = lookup.Lookup;
+            var similar = l.Where(e => topAttrib.Modifier.Key != default && !e.Key.Modifiers.Any(m => m.Key == "virtual") || e.Key.Enchants.Contains(topAttrib.Enchant)).ToList();
+            if (similar.Count == 1)
+            {
+                // include all if no match otherwise
+                similar = l.ToList();
+            }
+            var fullKey = GetFullKey(auction);
+            var queryDomCmb = DominatorIndex.BuildDomKey(fullKey, scoreInterner);
+            ulong qProvCmb = queryDomCmb.ProvidedMask;
+            bool petSpiritCmb = auction.Tag == "PET_SPIRIT";
+            var relevant = similar.Where(e => (e.Key.Reforge == topKey.Reforge || topKey.Reforge == ItemReferences.Reforge.Any)
+                        && CmbDominates(e.Value, e.Key))
+                .Select(e => (e, value: Math.Max(e.Value.Volume, 0.5) * Math.Pow(ComparisonValueForKey(groupTag.tag, e.Key).Sum(s => s.Value), 1.8)))
+                .OrderByDescending(e => e.value)
+                .ToList();
+
+            bool CmbDominates(ReferenceAuctions candBucket, AuctionKey candKey)
+            {
+                var candDom = GetBucketDomKey(candBucket, candKey);
+                if ((candDom.RequiredMask & qProvCmb) != candDom.RequiredMask)
+                    return false; // sound presence prefilter (candidate is the base side)
+                return DominatorIndex.Dominates(in candDom, in queryDomCmb, petSpiritCmb);
+            }
+            if (relevant.Count < 2)
+            {
+                return; // makes only sense if there is something combined
+            }
+            // get enough relevant to build a median and try to get highest value (most enchantments and modifiers)
+            var combined = relevant.SelectMany(r => r.e.Value.References.Select(ri => (ri, relevancy: r.value * (ri.Day - GetDay() + 12) * Math.Log10(ri.Price + 1))))
+                                .OrderByDescending(r => r.relevancy).Select(r => r.ri).Take(targetVolume).ToList();
+            if (combined.Count == 0)
+            {
+                return;
+            }
+            var lbinBucket = relevant.Select(r => r.e.Value.Lbin).Where(r => r.Price != default).DefaultIfEmpty().MinBy(r => r.Price);
+            var newestRef = combined.OrderByDescending(c => c.Day).Skip(1).FirstOrDefault().Day; // short term median
+            var age = GetDay() - newestRef;
+            var virtualBucket = new ReferenceAuctions()
+            {
+                Lbins = [lbinBucket],
+                References = new(combined),
+                Price = (combined.Count < 4 ? 0 : GetCappedMedian(auction, longKey, combined) * 98 / 100) * (age > 10 ? (10 - age / 9) : 10) / 10, // older items may have dropped in value
+                OldestRef = (short)(newestRef - 2),
+                Volatility = 123// mark as risky
+            };
+            // mark with extra value -3
+            var foundAndAbort = FindFlip(auction, lbinPrice, medPrice, virtualBucket, topKey, lookup, longKey, MIN_TARGET == 0 ? 0 : -3, props =>
+            {
+                var total = 0;
+                props.Add("combined", string.Join(",", relevant.TakeWhile(c => (total += c.e.Value.References.Count) < targetVolume)
+                    .Select(c => c.e.Key.ToString() + ":" + c.e.Value.References.Count)));
+                props.Add("breakdown", JsonConvert.SerializeObject(longKey.ValueBreakdown));
+                if (logger?.IsEnabled(LogLevel.Information) ?? false)
+                    logger.LogInformation($"Combined {longKey} {auction.Uuid} {virtualBucket.Price} {virtualBucket.Lbin.Price} keys: {string.Join(",", relevant.Select(r => r.e.Key))}");
+            });
+
+            long GetCappedMedian(SaveAuction auction, KeyWithValueBreakdown fullKey, List<ReferencePrice> combined)
+            {
+                var median = GetMedian(combined, []);
+                var shortTerm = GetMedian(combined.Take(5).ToList(), new());
+                median = CapAtCraftCost(groupTag.tag, Math.Min(median, shortTerm), fullKey, 0);
+                return median;
+            }
+        }
+
+        /// <summary>
+        /// Verbatim copy of <see cref="GetCleanItemPrice"/> as of the R2 Phase 0 snapshot — the oracle R2-D
+        /// (clean-price de-alloc + the tier-key fix) is gated against.
+        /// </summary>
+        private long GetCleanItemPriceReference(string tag, KeyWithValueBreakdown key, PriceLookup lookup, bool force = false)
+        {
+            var tier = key.Key.Tier;
+            if (key.Key.Modifiers.Any(m => m.Value == TierBoostShorthand || m.Key == "rarity_upgrades"))
+                tier = ReduceRarity(tier);
+            if (!force && lookup.CleanPricePerTier.TryGetValue(tier, out var cleanPrice))
+            {
+                return cleanPrice;
+            }
+            var matchRarity = tag == "THEORETICAL_HOE_WHEAT_3";
+            var minRarity = matchRarity ? key.Key.Tier : key.Key.Tier - 1;
+            var select = (NBT.IsPet(tag) ?
+                            lookup.Lookup.Where(v => key.Key.Tier == v.Key.Tier && !v.Key.Modifiers.Any(m => m.Value == TierBoostShorthand)).Select(v => v.Value) :
+                             lookup.Lookup.Where(v => minRarity <= v.Key.Tier && !v.Key.Modifiers.Any(m => m.Key == "pgems" || Constants.AttributeKeys.Contains(m.Key))).Select(l => l.Value)).ToList();
+            var count = select.Count;
+            var all = select.SelectMany(v => v.References).ToList();
+
+            if (NBT.IsPet(tag) || matchRarity)
+                DropUnderlistings(all, 18);
+            var size = (int)Math.Min(Math.Max(lookup.Volume * 10, 50), all.Count);
+            var sample = all.OrderByDescending(a => a.Day).ThenBy(l => l.Price)
+                .Take(size).OrderBy(r => r.Price);
+            var devider = matchRarity ? 10 : 30;
+
+            if (CanHaveGems(tag) && tag != "MELON_DICER_3")
+                devider = Math.Min(14, devider);
+            var target = sample.Skip(size / devider + 1).FirstOrDefault();
+            if (IsMidas(tag))
+                return target.Price + 80_000_000; // midas gets undersold very very often
+            return target.Price;
+        }
+    }
+}

--- a/Services/ValuationFinders.Tests.cs
+++ b/Services/ValuationFinders.Tests.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Coflnet.Sky.Core;
+using Coflnet.Sky.Core.Services;
+using Coflnet.Sky.Sniper.Models;
+using AwesomeAssertions;
+using dev;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static Coflnet.Sky.Core.Enchantment;
+
+namespace Coflnet.Sky.Sniper.Services
+{
+    /// <summary>
+    /// R2 Phase 0 / F3 bit-exactness oracles for the valuation finders
+    /// (<c>benchmarks/COMPUTE_FLOOR_SPEC_R2.md</c> §4-F3 + §5 R2-A / R2-B / R2-D). Two complementary gates:
+    ///
+    /// <list type="number">
+    ///   <item><b>Snipe-set oracle</b> (gates <c>CheckCombined</c> = R2-A and <c>PotentialSnipe</c> = R2-B).
+    ///     Those finders are private + stateful and emit through the <c>FoundSnipe</c> event, not a return value, so the
+    ///     contract is the resulting <b>snipe set</b>: the ordered list of <c>(finder, targetPrice)</c> emitted while a
+    ///     populated service processes a fixed scenario through the public <c>TestNewAuction</c>. The scenarios drive the
+    ///     combined-attribute path (<c>CheckCombined</c>, the "combined" prop), the snipe path (<c>PotentialSnipe</c>),
+    ///     and the lower-full-key path. The captured set is asserted against an embedded golden snapshot — a rewrite of
+    ///     either finder is proven correct iff it reproduces the identical snipe set.</item>
+    ///   <item><b>Golden-output oracle</b> (gates <c>GetCleanItemPrice</c> = R2-D). The clean-price recompute is a pure
+    ///     read; the harness drives many (tag, reduced-tier, force) inputs over populated lookups and asserts the live
+    ///     production result is byte-identical to <see cref="SniperService.GetCleanItemPriceForTest"/>'s verbatim
+    ///     reference (<c>ValuationFinders.Reference.cs</c>). Covers pet vs non-pet tier selection, the
+    ///     TIER_BOOST/rarity_upgrades tier-reduction branch, the cached-per-tier fast path, and the gem deviders.</item>
+    /// </list>
+    ///
+    /// Construction mirrors <c>SniperService.Tests.cs</c> Setup (NullLogger to avoid the known flaky-logger NRE,
+    /// MIN_TARGET=0, FullyLoaded state, AddSoldItem/AddVolume to populate buckets) and the
+    /// <c>ChecksLowerValueAllAttributes</c> / <c>UseLbinFromCombinedLowerKeys</c> scenario shapes.
+    /// </summary>
+    public class ValuationFindersTests
+    {
+        private SniperService service = null!;
+        private List<LowPricedAuction> found = null!;
+        private CraftCostMock craftCost = null!;
+        private HypixelItemService itemService = null!;
+        private static long idCounter;
+
+        private class CraftCostMock : ICraftCostService
+        {
+            public Dictionary<string, double> Costs { get; } = new();
+            public Dictionary<string, Category> ItemCategories { get; } = new();
+            public void AddCostForSpecialItems() { }
+            public bool TryGetCost(string itemId, out double cost) => Costs.TryGetValue(itemId, out cost);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            SniperService.MIN_TARGET = 0;
+            SniperService.StartTime = new DateTime(2021, 9, 25);
+            craftCost = new CraftCostMock();
+            itemService = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            service = new SniperService(itemService, null, NullLogger<SniperService>.Instance, craftCost);
+            idCounter = 100;
+            found = new List<LowPricedAuction>();
+            service.FoundSnipe += found.Add;
+        }
+
+        [TearDown]
+        public void TearDown() => SniperService.MIN_TARGET = 200_000;
+
+        // ============================================================================================================
+        // 1) Snipe-set oracle for CheckCombined (R2-A) + PotentialSnipe (R2-B): combined-attribute / lower-key paths.
+        // ============================================================================================================
+
+        /// <summary>
+        /// Combined-key path: a high-value multi-component item whose exact bucket is thin, with a cheaper lower-value
+        /// bucket priced; <c>CheckCombined</c> assembles a virtual bucket from the lower keys and (via FindFlip ->
+        /// PotentialSnipe / SNIPER_MEDIAN) emits. The full emitted snipe set is the gate.
+        /// </summary>
+        [Test]
+        public void Combined_SnipeSet_BitExact()
+        {
+            SetBazaarPrice("ENCHANTMENT_GROWTH_6", 6_200_000);
+            SetBazaarPrice("ENCHANTMENT_PROTECTION_6", 6_200_000);
+            SetBazaarPrice("ENCHANTMENT_MANA_VAMPIRE_4", 2_100_000);
+            SetBazaarPrice("ENCHANTMENT_ULTIMATE_LEGION_3", 1_800_000);
+            SetBazaarPrice("FUMING_POTATO_BOOK", 1_100_000);
+            SetBazaarPrice("HOT_POTATO_BOOK", 80_000);
+            SetBazaarPrice("FIRST_MASTER_STAR", 12_000_000);
+            SetBazaarPrice("FARMING_FOR_DUMMIES", 50_000_000);
+
+            var sample = Dupplicate(Base());
+            sample.Reforge = ItemReferences.Reforge.Magnetic;
+            sample.FlatenedNBT = new() { { "farming_for_dummies_count", "1" }, { "hpc", "9" } };
+            sample.Enchantments = new List<Enchantment>
+            {
+                new(EnchantmentType.growth, 6),
+                new(EnchantmentType.protection, 6),
+                new(EnchantmentType.mana_vampire, 4),
+                new(EnchantmentType.ultimate_legion, 3),
+            };
+
+            var lowerValue = Dupplicate(sample);
+            lowerValue.Enchantments = new List<Enchantment> { new(EnchantmentType.mana_vampire, 4) };
+            lowerValue.HighestBidAmount = 14_000_000;
+            AddVolume(lowerValue, 6);
+
+            DrivePublic(sample);
+
+            // gate: the combined finder must have contributed (the "combined" prop only comes from CheckCombined)
+            found.Should().Contain(f => f.AdditionalProps != null && f.AdditionalProps.ContainsKey("combined"),
+                "CheckCombined must emit at least one snipe carrying the 'combined' prop");
+            // Golden snapshot of the FULL ordered snipe set this scenario emits. CheckCombined assembles the virtual
+            // bucket that drives the first SNIPER_MEDIAN (the one carrying the "combined" prop); the remaining emits
+            // (SNIPER_MEDIAN/STONKS/CraftCost) are part of the same TestNewAuction pass and must all stay identical
+            // when R2-A/R2-B rewrite the finders.
+            CaptureSnipeSet().Should().Be(
+                "SNIPER_MEDIAN@13166986;SNIPER_MEDIAN@13435701;STONKS@15113913;CraftCost@69790701",
+                "the combined/snipe finders' emitted snipe set must stay bit-identical (gates R2-A/R2-B rewrites)");
+        }
+
+        /// <summary>
+        /// Pure snipe path (<c>PotentialSnipe</c>): a priced bucket with volume and a much higher LBIN wall, an incoming
+        /// auction far below — the SNIPER finder fires. The (finder, targetPrice) set is the gate for R2-B.
+        /// </summary>
+        [Test]
+        public void PotentialSnipe_SnipeSet_BitExact()
+        {
+            var sample = Dupplicate(Base());
+            sample.FlatenedNBT = new();
+            sample.Enchantments = new List<Enchantment>();
+            sample.HighestBidAmount = 10_000_000;
+            AddVolume(sample, 12);
+
+            // a higher-priced LBIN wall so PotentialSnipe has room
+            var wall = Dupplicate(sample);
+            wall.HighestBidAmount = 0;
+            wall.StartingBid = 30_000_000;
+            DrivePublic(wall); // adds the lbin
+
+            var snipe = Dupplicate(sample);
+            snipe.HighestBidAmount = 0;
+            snipe.StartingBid = 5;
+            service.FinishedUpdate();
+            service.State = SniperState.FullyLoaded;
+            found.Clear();
+            service.TestNewAuction(Dupplicate(snipe));
+
+            found.Should().Contain(f => f.Finder == LowPricedAuction.FinderType.SNIPER,
+                "an undercut below a priced volume bucket must trigger PotentialSnipe");
+            // PotentialSnipe emits the leading SNIPER; the trailing SNIPER_MEDIAN is the same FindFlip pass. Both pinned.
+            CaptureSnipeSet().Should().Be(
+                "SNIPER@10000000;SNIPER_MEDIAN@10000000",
+                "PotentialSnipe's emitted snipe (finder + target price) must stay bit-identical (gates R2-B)");
+        }
+
+        /// <summary>
+        /// Lower-full-key path (<c>CheckLowerKeyFull</c>) + combined LBIN: the complicated SHADOW_ASSASSIN scenario from
+        /// the suite. Gates the lower-key + combined finders by their emitted SNIPER target.
+        /// </summary>
+        [Test]
+        public void LowerKeyAndCombined_SnipeSet_BitExact()
+        {
+            SetBazaarPrice("ENCHANTMENT_ULTIMATE_LEGION_5", 10_000_000);
+            SetBazaarPrice("RECOMBOBULATOR_3000", 10_000_000);
+            SetBazaarPrice("FINE_JASPER_GEM", 85_000);
+            SetBazaarPrice("ESSENCE_WITHER", 2_600);
+            SetBazaarPrice("HOT_POTATO_BOOK", 80_000);
+            SetBazaarPrice("FUMING_POTATO_BOOK", 1_200_000);
+
+            var first = Dupplicate(Base());
+            first.FlatenedNBT = new() { { "rarity_upgrades", "1" }, { "upgrade_level", "5" }, { "unlocked_slots", "COMBAT_0,JASPER_0" }, { "hpc", "10" } };
+            first.Tag = "SHADOW_ASSASSIN_HELMET";
+            first.StartingBid = 19_000_000;
+            first.HighestBidAmount = 13_000_000;
+            AddVolume(first, 10);
+            first.HighestBidAmount = 0;
+            DrivePublic(first); // add lbin
+
+            var higherValue = Dupplicate(first);
+            higherValue.FlatenedNBT["hpc"] = "15";
+            higherValue.Enchantments = new List<Enchantment> { new(EnchantmentType.ultimate_legion, 5) };
+            higherValue.StartingBid = 14_000_000;
+            higherValue.HighestBidAmount = 14_500_000;
+            AddVolume(higherValue);
+            higherValue.HighestBidAmount = 14_000_000;
+            DrivePublic(higherValue);
+
+            var sniper = found.Where(f => f.Finder == LowPricedAuction.FinderType.SNIPER).ToList();
+            sniper.Should().NotBeEmpty("the combined-lower-key scenario must emit a SNIPER snipe");
+            sniper.Select(f => f.TargetPrice).Should().Contain(18760000L,
+                "the combined-lower-keys SNIPER target must stay bit-identical (gates R2-A + CheckLowerKeyFull)");
+            // full ordered snipe set pinned too, so a finder rewrite that drops/adds an emit is caught.
+            CaptureSnipeSet().Should().Be(
+                "SNIPER@18760000;CraftCost@31834853",
+                "the combined-lower-keys snipe set must stay bit-identical (gates R2-A + CheckLowerKeyFull)");
+        }
+
+        // ============================================================================================================
+        // 1b) R6 WS-CMB2 — snipe-set A/B fuzz: the de-LINQ'd CheckCombined must emit the IDENTICAL snipe set (incl. the
+        //     "combined" prop string) as the verbatim pre-R6 LINQ reference, over randomized HEAVY-TIE lookups. Heavy
+        //     ties stress every stable-sort tiebreak the de-LINQ reproduces: equal value (relevant order), equal
+        //     relevancy (combined order), equal Day (newestRef / props prefix), equal Lbin price (MinBy first-wins).
+        // ============================================================================================================
+
+        /// <summary>
+        /// For many randomized scenarios, drives the SAME populated lookup + incoming auction through both the de-LINQ'd
+        /// CheckCombined (production default) and the verbatim LINQ <c>CheckCombinedReference</c> (via the
+        /// <c>UseCombinedReference</c> seam), asserting the full emitted snipe set — finder, target price, and the
+        /// CheckCombined-only "combined" prop — is byte-identical. Each scenario builds two fresh services from one
+        /// deterministic template list so both see bit-identical state.
+        /// </summary>
+        [Test]
+        public void Combined_DeLinq_BitExact_Fuzz()
+        {
+            int scenarios = 400;
+            int mismatches = 0;
+            int firstMismatch = -1;
+            string detail = null;
+            int withSnipes = 0;
+            int withCombinedProp = 0;
+            for (int seed = 0; seed < scenarios; seed++)
+            {
+                var rnd = new Random(seed * 7919 + 13);
+                var templates = BuildCombinedTemplates(rnd);
+                var incoming = templates.incoming;
+
+                var newSet = RunCombinedScenario(templates.sold, incoming, useReference: false);
+                var refSet = RunCombinedScenario(templates.sold, incoming, useReference: true);
+
+                if (newSet.Length > 0)
+                    withSnipes++;
+                if (newSet.Contains("|") && newSet.Split(';').Any(s => s.Contains('|') && s.Split('|', 2)[1].Length > 0))
+                    withCombinedProp++;
+
+                if (newSet != refSet)
+                {
+                    if (firstMismatch < 0)
+                    {
+                        firstMismatch = seed;
+                        detail = $"seed={seed}\n  new={newSet}\n  ref={refSet}";
+                    }
+                    mismatches++;
+                }
+            }
+            mismatches.Should().Be(0,
+                $"de-LINQ'd CheckCombined must emit the identical snipe set as the LINQ reference across {scenarios} heavy-tie scenarios. First mismatch:\n{detail}");
+            // Coverage guard: the fuzz must actually drive the combined path (else it passes vacuously).
+            withCombinedProp.Should().BeGreaterThan(0,
+                $"the fuzz must exercise CheckCombined's combined-emit path (scenarios with snipes: {withSnipes}/{scenarios}, with a non-empty 'combined' prop: {withCombinedProp})");
+        }
+
+        /// <summary>Builds one randomized scenario: a set of "sold" templates (heavy ties in value/relevancy/Day/lbin) + an incoming auction.</summary>
+        private (List<(SaveAuction tmpl, int volume)> sold, SaveAuction incoming) BuildCombinedTemplates(Random rnd)
+        {
+            // A small pool of enchant types + levels so distinct keys collide on the `similar`/dominance predicates and
+            // value/relevancy frequently TIE (the whole point of the fuzz).
+            EnchantmentType[] enchPool = { EnchantmentType.growth, EnchantmentType.protection, EnchantmentType.mana_vampire, EnchantmentType.ultimate_legion, EnchantmentType.sharpness };
+            string tag = "FUZZ_ITEM";
+            var sold = new List<(SaveAuction, int)>();
+            int buckets = 2 + rnd.Next(6); // 2..7 distinct buckets
+            // Quantized values so many buckets share a value → forces value/relevancy ties.
+            for (int b = 0; b < buckets; b++)
+            {
+                int enchCount = rnd.Next(3); // 0..2 enchants
+                var enchants = new List<Enchantment>();
+                for (int e = 0; e < enchCount; e++)
+                    enchants.Add(new Enchantment(enchPool[rnd.Next(enchPool.Length)], (byte)(1 + rnd.Next(3))));
+                var a = new SaveAuction
+                {
+                    Tag = tag,
+                    Tier = Tier.LEGENDARY,
+                    Category = Category.ARMOR,
+                    Reforge = rnd.Next(2) == 0 ? ItemReferences.Reforge.Any : ItemReferences.Reforge.Magnetic,
+                    FlatenedNBT = new Dictionary<string, string>(),
+                    Enchantments = enchants,
+                    Count = 1,
+                    // quantized bid → repeated Price/Day across buckets → ties
+                    StartingBid = 1_000_000 * (1 + rnd.Next(4)),
+                    HighestBidAmount = 1_000_000 * (1 + rnd.Next(4)),
+                };
+                int volume = 3 + rnd.Next(6); // 3..8 references
+                sold.Add((a, volume));
+            }
+            // incoming: a higher-value multi-component auction whose exact bucket is thin → exercises the combined path
+            var incoming = new SaveAuction
+            {
+                Tag = tag,
+                Tier = Tier.LEGENDARY,
+                Category = Category.ARMOR,
+                Reforge = rnd.Next(2) == 0 ? ItemReferences.Reforge.Any : ItemReferences.Reforge.Magnetic,
+                FlatenedNBT = new Dictionary<string, string>(),
+                Enchantments = new List<Enchantment>
+                {
+                    new(enchPool[rnd.Next(enchPool.Length)], (byte)(1 + rnd.Next(3))),
+                    new(enchPool[rnd.Next(enchPool.Length)], (byte)(1 + rnd.Next(3))),
+                },
+                Count = 1,
+                StartingBid = 5,
+                HighestBidAmount = 0,
+            };
+            return (sold, incoming);
+        }
+
+        /// <summary>Builds a fresh service, populates it from the templates, drives the incoming auction, returns the captured snipe set string.</summary>
+        private string RunCombinedScenario(List<(SaveAuction tmpl, int volume)> sold, SaveAuction incoming, bool useReference)
+        {
+            var localCraft = new CraftCostMock();
+            var localItem = new HypixelItemService(null, NullLogger<HypixelItemService>.Instance);
+            var localService = new SniperService(localItem, null, NullLogger<SniperService>.Instance, localCraft);
+            localService.UseCombinedReference = useReference;
+            var localFound = new List<LowPricedAuction>();
+            localService.FoundSnipe += localFound.Add;
+
+            long localId = 1000;
+            SaveAuction Dup(SaveAuction o) => new SaveAuction(o)
+            {
+                Uuid = (localId++).ToString().PadRight(8, '0'),
+                UId = localId++,
+                AuctioneerId = ((short)(localId++ % 20000)).ToString().PadRight(8, '0'),
+                FlatenedNBT = new Dictionary<string, string>(o.FlatenedNBT),
+                Enchantments = o.Enchantments == null ? null : new List<Enchantment>(o.Enchantments),
+            };
+
+            localService.State = SniperState.FullyLoaded;
+            foreach (var (tmpl, volume) in sold)
+                for (int i = 0; i < volume; i++)
+                    localService.AddSoldItem(Dup(tmpl));
+            localService.FinishedUpdate();
+            localService.State = SniperState.FullyLoaded;
+            localFound.Clear();
+            localService.TestNewAuction(Dup(incoming));
+
+            // Snipe set incl. the CheckCombined-only "combined" prop (the de-LINQ'd prefix/TakeWhile output).
+            return string.Join(";", localFound.Select(f =>
+            {
+                string combinedProp = (f.AdditionalProps != null && f.AdditionalProps.TryGetValue("combined", out var c)) ? c : "";
+                return $"{f.Finder}@{f.TargetPrice}|{combinedProp}";
+            }));
+        }
+
+        // ============================================================================================================
+        // 2) Golden-output oracle for GetCleanItemPrice (R2-D): live == verbatim reference, on populated lookups.
+        // ============================================================================================================
+
+        [Test]
+        public void GetCleanItemPrice_BitExact_VsReference_NonPet()
+        {
+            // build a non-pet item with several priced buckets across tiers
+            string tag = "SOME_SWORD";
+            for (int t = (int)Tier.UNCOMMON; t <= (int)Tier.MYTHIC; t++)
+            {
+                var a = Dupplicate(Base());
+                a.Tag = tag;
+                a.Tier = (Tier)t;
+                a.FlatenedNBT = new();
+                a.Enchantments = new List<Enchantment>();
+                a.HighestBidAmount = 1_000_000L * (t + 1);
+                AddVolume(a, 8);
+            }
+            // a bucket with an attribute modifier (excluded from non-pet clean selection)
+            var attr = Dupplicate(Base());
+            attr.Tag = tag;
+            attr.Tier = Tier.LEGENDARY;
+            attr.FlatenedNBT = new() { { "mending", "5" } };
+            attr.HighestBidAmount = 50_000_000;
+            AddVolume(attr, 8);
+            service.FinishedUpdate();
+
+            AssertCleanPriceParityForAllBuckets(tag);
+        }
+
+        [Test]
+        public void GetCleanItemPrice_BitExact_VsReference_Pet()
+        {
+            string tag = "PET_LION";
+            for (int t = (int)Tier.COMMON; t <= (int)Tier.LEGENDARY; t++)
+            {
+                var a = Dupplicate(Base());
+                a.Tag = tag;
+                a.Tier = (Tier)t;
+                a.FlatenedNBT = new() { { "exp", "10000000" }, { "candyUsed", "0" } };
+                a.Enchantments = new List<Enchantment>();
+                a.HighestBidAmount = 2_000_000L * (t + 1);
+                AddVolume(a, 8);
+            }
+            // a TIER_BOOST bucket (the pet selection excludes TIER_BOOST keys; clean-price tier-reduction branch)
+            var boosted = Dupplicate(Base());
+            boosted.Tag = tag;
+            boosted.Tier = Tier.LEGENDARY;
+            boosted.FlatenedNBT = new() { { "exp", "10000000" }, { "candyUsed", "0" }, { "heldItem", "PET_ITEM_TIER_BOOST" } };
+            boosted.HighestBidAmount = 99_000_000;
+            AddVolume(boosted, 8);
+            service.FinishedUpdate();
+
+            AssertCleanPriceParityForAllBuckets(tag);
+        }
+
+        /// <summary>
+        /// Drives every live bucket key through both the production GetCleanItemPrice and the verbatim reference, with
+        /// and without <c>force</c> (force bypasses the cached-per-tier fast path, exercising the full recompute), and
+        /// asserts byte-equality. Also exercises the TIER_BOOST/rarity_upgrades reduced-tier key branch explicitly.
+        /// </summary>
+        private void AssertCleanPriceParityForAllBuckets(string tag)
+        {
+            service.Lookups.TryGetValue(tag, out var lookup).Should().BeTrue($"lookup for {tag} must exist");
+            int checkedKeys = 0;
+            foreach (var kv in lookup.Lookup.Keys.ToList())
+            {
+                var auction = AuctionFromKey(tag, kv);
+                var detailed = service.ValueKeyForTest(auction);
+                foreach (var force in new[] { false, true })
+                {
+                    var (live, reference) = service.GetCleanItemPriceForTest(tag, detailed, lookup, force);
+                    live.Should().Be(reference,
+                        $"GetCleanItemPrice (force={force}) must equal the verbatim reference for key {kv} (gates R2-D)");
+                }
+                checkedKeys++;
+            }
+            checkedKeys.Should().BeGreaterThan(0, "must have buckets to check");
+
+            // explicit reduced-tier branch: a key carrying TIER_BOOST must read the reduced-tier clean price identically
+            var boostKey = service.ValueKeyForTest(AuctionWith(tag, Tier.LEGENDARY,
+                new() { { SniperService.PetItemKey, SniperService.TierBoostShorthand } }));
+            var (liveB, refB) = service.GetCleanItemPriceForTest(tag, boostKey, lookup, false);
+            liveB.Should().Be(refB, "TIER_BOOST reduced-tier clean price must equal the reference (gates R2-D)");
+
+            var recombKey = service.ValueKeyForTest(AuctionWith(tag, Tier.LEGENDARY,
+                new() { { "rarity_upgrades", "1" } }));
+            var (liveR, refR) = service.GetCleanItemPriceForTest(tag, recombKey, lookup, false);
+            liveR.Should().Be(refR, "rarity_upgrades reduced-tier clean price must equal the reference (gates R2-D)");
+        }
+
+        // ---------- snipe-set capture ----------
+
+        /// <summary>Normalizes the emitted snipe set into a stable, order-preserving string the golden snapshot pins.</summary>
+        private string CaptureSnipeSet()
+            => string.Join(";", found.Select(f => $"{f.Finder}@{f.TargetPrice}"));
+
+        // ---------- helpers (mirror SniperService.Tests.cs) ----------
+
+        private void DrivePublic(SaveAuction a)
+        {
+            var toTest = Dupplicate(a);
+            service.FinishedUpdate();
+            service.State = SniperState.FullyLoaded;
+            service.TestNewAuction(toTest);
+            service.FinishedUpdate();
+        }
+
+        private void AddVolume(SaveAuction toAdd, int count = 4)
+        {
+            for (int i = 0; i < count; i++)
+                service.AddSoldItem(Dupplicate(toAdd));
+        }
+
+        private static SaveAuction Base() => new SaveAuction
+        {
+            Tag = "VAL_TEST",
+            FlatenedNBT = new Dictionary<string, string> { { "skin", "bear" } },
+            StartingBid = 1000,
+            HighestBidAmount = 1000,
+            Category = Category.ARMOR,
+            UId = 5,
+            AuctioneerId = "12c144",
+            Count = 1,
+        };
+
+        private static SaveAuction Dupplicate(SaveAuction origin) => new SaveAuction(origin)
+        {
+            Uuid = (idCounter++).ToString().PadRight(8, '0'),
+            UId = idCounter++,
+            AuctioneerId = ((short)(idCounter++ % 20000)).ToString().PadRight(8, '0'),
+            FlatenedNBT = new Dictionary<string, string>(origin.FlatenedNBT),
+            Enchantments = origin.Enchantments == null ? null : new List<Enchantment>(origin.Enchantments),
+        };
+
+        private static SaveAuction AuctionWith(string tag, Tier tier, Dictionary<string, string> nbt) => new SaveAuction
+        {
+            Tag = tag,
+            Tier = tier,
+            FlatenedNBT = nbt,
+            Enchantments = new List<Enchantment>(),
+            Count = 1,
+            StartingBid = 1000,
+            HighestBidAmount = 1000,
+        };
+
+        private static SaveAuction AuctionFromKey(string tag, AuctionKey key)
+        {
+            var nbt = new Dictionary<string, string>();
+            foreach (var m in key.Modifiers)
+                nbt[m.Key] = m.Value;
+            return new SaveAuction
+            {
+                Tag = tag,
+                Tier = key.Tier,
+                Reforge = key.Reforge,
+                Count = Math.Max((int)key.Count, 1),
+                Category = Category.UNKNOWN,
+                FlatenedNBT = nbt,
+                Enchantments = key.Enchants.Select(e => new Enchantment(e.Type, e.Lvl)).ToList(),
+                StartingBid = 1000,
+                HighestBidAmount = 1000,
+            };
+        }
+
+        private void SetBazaarPrice(string tag, int value, int buyValue = 0)
+        {
+            var sellOrder = new List<SellOrder>();
+            if (value > 0)
+                sellOrder.Add(new SellOrder { PricePerUnit = value });
+            var buyOrder = new List<BuyOrder>();
+            if (buyValue > 0)
+                buyOrder.Add(new BuyOrder { PricePerUnit = buyValue });
+            service.UpdateBazaar(new()
+            {
+                Products = new()
+                {
+                    new() { ProductId = tag, SellSummary = sellOrder, BuySummery = buyOrder }
+                }
+            });
+        }
+    }
+}

--- a/SkySniper.csproj
+++ b/SkySniper.csproj
@@ -6,11 +6,17 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup>
-    <DefaultItemExcludes>$(DefaultItemExcludes);Client\**\*</DefaultItemExcludes>
+    <!-- benchmarks/ is a separate console project (SkySniper.Benchmarks) that references this one; keep its sources out of the web app's compile. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);Client\**\*;benchmarks\**\*</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="../dev/hypixel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Lets the benchmark project measure the internal hot-path method ComparisonValue directly. -->
+    <InternalsVisibleTo Include="SkySniper.Benchmarks" />
   </ItemGroup>
 
 
@@ -28,6 +34,8 @@
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
     <Compile Remove="**\*.Tests.cs" />
+    <!-- Shared test-support fuzz generator (used only by the *.Tests.cs harnesses); not part of the shipped service. -->
+    <Compile Remove="Services\AuctionKeyFuzz.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/benchmarks/PR_DESCRIPTION.md
+++ b/benchmarks/PR_DESCRIPTION.md
@@ -1,0 +1,32 @@
+# perf(sniper): optimize the snipe-finding path (~10× throughput, bit-exact)
+
+## What
+Optimizes `SniperService`'s snipe-finding hot path (`TestNewAuction → FindFlip → FoundAFlip`), which prices every incoming Hypixel auction and emits snipes. This is the squashed **production** change of an 11-round, measurement-driven campaign; the full per-round history, the benchmarking harness, and the profiling write-ups live on `perf/sniper-snipe-path` (separate follow-up PR).
+
+## Results (snipe replay vs the round-1 baseline)
+| metric | baseline | now | Δ |
+|---|---|---|---|
+| throughput | 236 /s | 2,269 /s | **~9.6×** |
+| p50 | 2.77 ms | 0.32 ms | **−88%** |
+| p99 | 38.2 ms | 2.1 ms | **−94.5%** |
+| alloc / auction | 1.61 MB | ~0.02 MB | **−98.8%** |
+
+Also: warm alloc ~115 KB → ~24 KB, rare gen2 GCs 9 → 0, cold p99 38 ms → ~1.3 ms. Machine-readable per-round record: [`benchmarks/speedups.json`](benchmarks/speedups.json).
+
+## Core changes
+- **Columnar dominance/closest kernels** (`DominatorIndex`, `ClosestScoreKernel`, `ClosestCandidateIndex`) with an interned `ulong` mask prefilter, replacing per-candidate LINQ scans over `ConcurrentDictionary`.
+- **De-LINQ'd hot path**: `IsHigherValue`, `GetReduced`, `CheckCombined`, `ApplyAntiMarketManipulation`, `UpdateMedian` → explicit loops + pooled/`[ThreadStatic]` scratch.
+- **Clean-price**: partial-selection (quickselect) instead of two full sorts + an entry-epoch-stamped recompute memo.
+- **Parse/key path**: lazy-memoized hash on the immutable `AuctionKey`; O(M²)→O(M) modifier cache-key hashing; one parse per auction (share `basekey` into the closest finder).
+- **Throughput**: `ShardedAuctionDispatcher` (tag-sharded, per-tag-serial) for near-linear core scaling.
+
+## Correctness — bit-exact
+Emitted snipe set / prices / medians / `GetPrice` are byte-identical to before. Gated by **432 tests + 4 runtime parity guards** (`SNIPER_VERIFY_{DOMINATOR,CLOSEST,CLEANPRICE_MEMO,PARSE}`) + fuzz oracles (40k dominance, 40k clean-price, 60k AMM, 50k GetReduced, 25k key-extraction) + snipe-set/`GetPrice`/`GetCleanItemPrice`/`UpdateMedian` goldens. All green; the guards are verification-only (off in production).
+
+## Rollout / risk
+- **New behavior is off by default**: the cross-auction parse memo ships disabled (`SNIPER_PARSE_MEMO`, 0% relist hit on the synthetic workload — gated on the shipped `SNIPER_PARSE_MEMO_COUNT` production counter); the shard-balance metrics are additive (`sky_sniper_shard_{queue_depth,processed_total}`).
+- Perf numbers are **benchmark-derived** (synthetic replay + micro-benchmarks); correctness is **oracle-proven**. The throughput/shard-balance wins are **instrumented but not yet observed in production** — a canary is advisable.
+- **Heads-up (pre-existing, not introduced here):** `BazaarHasMedian` is a wall-clock-boundary flake (a bazaar entry seeded at `UtcNow.AddHours(-24)` ages in/out of the retention window); it fails identically on the pre-campaign baseline. Worth pinning its clock in a separate fix so it doesn't flake CI.
+
+## Not in this PR
+The benchmarking harness (`benchmarks/`), profiling tooling, and the round-by-round `PIPELINE_PROFILE.md` — a separate PR off `perf/sniper-snipe-path`. The regenerable BenchmarkDotNet `*-report-full.json` dumps are untracked; `speedups.json` is the compact record.

--- a/benchmarks/speedups.json
+++ b/benchmarks/speedups.json
@@ -1,0 +1,214 @@
+{
+  "description": "SniperService snipe-path optimization campaign (rounds 1-11): replay-measured speedups vs the round-1 pre-optimization baseline. Replace the per-round BenchmarkDotNet *-report-full.json dumps. All changes bit-exact (432 tests + 4 runtime parity guards + dominance/clean-price/AMM/key-extraction fuzzes + goldens).",
+  "clock_ghz_effective": 4.3,
+  "headline": {
+    "baseline_round": 1,
+    "current_round": 11,
+    "baseline_commit": "c48015a",
+    "current_commit": "e862b08",
+    "throughput_auctions_per_sec": {
+      "from": 236,
+      "to": 2269,
+      "x": 9.6
+    },
+    "p50_ms": {
+      "from": 2.77,
+      "to": 0.32,
+      "pct": -88.4
+    },
+    "p99_ms": {
+      "from": 38.2,
+      "to": 2.1,
+      "pct": -94.5
+    },
+    "mb_per_auction": {
+      "from": 1.61,
+      "to": 0.02,
+      "pct": -98.8
+    }
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "date": "2026-06-04",
+      "commit": "c48015a",
+      "auctions_per_sec": 236,
+      "p50_ms": 2.77,
+      "p99_ms": 38.2,
+      "mb_per_auction": 1.61,
+      "note": "Pre-optimization snipe-finding baseline",
+      "replay": {
+        "round": 1,
+        "commit": "c48015a",
+        "date": "2026-06-04",
+        "mode": null,
+        "auctions_per_sec": 236,
+        "p50_us": 2767,
+        "p99_us": 38229,
+        "p999_us": 85450,
+        "bytes_per_auction": 1692146,
+        "gen2": 44
+      }
+    },
+    {
+      "round": 2,
+      "date": "2026-06-04",
+      "commit": "c48015a",
+      "auctions_per_sec": 336,
+      "p50_ms": 2.07,
+      "p99_ms": 25.4,
+      "mb_per_auction": 1.57,
+      "note": "T1 single-pass FindClosestTo argmax; T8 gate per-auction JSON/Activity logs; T12/T13 remove hot-path RNG+Console/log; T14 hoist GetAuctionGroupTag in CheckCombi",
+      "replay": {
+        "round": 2,
+        "commit": "c48015a",
+        "date": "2026-06-04",
+        "mode": null,
+        "auctions_per_sec": 336,
+        "p50_us": 2068,
+        "p99_us": 25411,
+        "p999_us": 43427,
+        "bytes_per_auction": 1644701,
+        "gen2": 44
+      }
+    },
+    {
+      "round": 3,
+      "date": "2026-06-04",
+      "commit": "c48015a",
+      "auctions_per_sec": 452,
+      "p50_ms": 1.11,
+      "p99_ms": 25.6,
+      "mb_per_auction": 0.99,
+      "note": "T2 per-key ComparisonValue cache at candidate sites; T5 dedup-once modifier cache key + better ModifierLookupKey hash; T9 GetReduced without Reverse alloc; T10 ",
+      "replay": {
+        "round": 3,
+        "commit": "c48015a",
+        "date": "2026-06-04",
+        "mode": null,
+        "auctions_per_sec": 452,
+        "p50_us": 1107,
+        "p99_us": 25589,
+        "p999_us": 46623,
+        "bytes_per_auction": 1039417,
+        "gen2": 43
+      }
+    },
+    {
+      "round": 4,
+      "date": "2026-06-05",
+      "commit": "d6f6f67",
+      "auctions_per_sec": 4966,
+      "p50_ms": 0.162,
+      "p99_ms": 0.691,
+      "mb_per_auction": 0.037,
+      "note": "R4 dominance flattening: interned columnar DominatorIndex + ulong mask prefilter; 4 finders + CheckCombined off string IsHigherValue; read p50 \u221279%, warm p50 \u22122"
+    },
+    {
+      "round": 5,
+      "date": "2026-06-06",
+      "commit": "diagnosis",
+      "auctions_per_sec": null,
+      "p50_ms": null,
+      "p99_ms": null,
+      "mb_per_auction": null,
+      "note": "R5 DIAGNOSIS: built 6 isolating instruments (CpuProfile P6, IndexRebuild/QueryBuild P1/P5, Parse P3, GetCleanItemPrice P4, write-path mode + UpdateMedian golden"
+    },
+    {
+      "round": 6,
+      "date": "2026-06-06",
+      "commit": "24f91e8",
+      "auctions_per_sec": 3676,
+      "p50_ms": 0.212,
+      "p99_ms": 1.049,
+      "mb_per_auction": 0.035,
+      "note": "R5 Phase B: cleanprice partial-select (CleanItemPrice* CPU ~55%->~28%, cold p99 -64%); idx-grow append-amortized DominatorIndex (rebuild alloc 21.7%->~0%, warm "
+    },
+    {
+      "round": 7,
+      "date": "2026-06-06",
+      "commit": "6d8634e",
+      "auctions_per_sec": 3352,
+      "p50_ms": 0.226,
+      "p99_ms": 1.172,
+      "mb_per_auction": 0.028,
+      "note": "R6 final incremental sweep: CMB2 de-LINQ CheckCombined; MEMO2 clean-price memo (cold/rare p99 -21/-28%, warm neutral); LOH chunk CandidateIndex off LOH (rare ge"
+    },
+    {
+      "round": 8,
+      "date": "2026-06-06",
+      "commit": "r7 close",
+      "auctions_per_sec": 3414,
+      "p50_ms": 0.23,
+      "p99_ms": 1.166,
+      "mb_per_auction": 0.027,
+      "note": "R7 RADICAL round confirms the floor: de-inline proved parse <1% CPU, batch dup ~0% -> parse cache unjustifiable. Shipped C1 de-alloc (-1.3KB) + C2 fullKey-share"
+    },
+    {
+      "round": 9,
+      "date": "2026-06-06",
+      "commit": "c458d00",
+      "auctions_per_sec": 2268,
+      "p50_ms": 0.33,
+      "p99_ms": 1.9,
+      "mb_per_auction": 0.03,
+      "note": "R8 EXECUTED (tail-tightening): WS-CHURN A quickselect percentile / B Cmb clear-prefix(+blittable skip) / C in-place DropUnderlistings; WS-SHARD-OBS per-shard de",
+      "replay": {
+        "round": 9,
+        "commit": "c458d00",
+        "date": "2026-06-06",
+        "mode": "warm",
+        "auctions_per_sec": 2268,
+        "p50_us": 331,
+        "p99_us": 1945,
+        "p999_us": 5513,
+        "bytes_per_auction": 26826,
+        "gen2": 1
+      }
+    },
+    {
+      "round": 10,
+      "date": "2026-06-06",
+      "commit": "a828bd5",
+      "auctions_per_sec": 3514,
+      "p50_ms": 0.23,
+      "p99_ms": 1.0,
+      "mb_per_auction": 0.03,
+      "note": "R9 WS-HASHCACHE: memoize AuctionKey.GetHashCode (immutable key). Warm p50 -10-12%, tails 18ms->7ms, bit-exact 432/0 +4 guards. Disproves part of the parse floor",
+      "replay": {
+        "round": 10,
+        "commit": "a828bd5",
+        "date": "2026-06-06",
+        "mode": "warm",
+        "auctions_per_sec": 3514,
+        "p50_us": 227,
+        "p99_us": 955,
+        "p999_us": 3175,
+        "bytes_per_auction": 26739,
+        "gen2": 1
+      }
+    },
+    {
+      "round": 11,
+      "date": "2026-06-06",
+      "commit": "e862b08",
+      "auctions_per_sec": 2269,
+      "p50_ms": 0.32,
+      "p99_ms": 2.1,
+      "mb_per_auction": 0.02,
+      "note": "R10 WS-VALKEY (O(M^2)->O(M) modifier cache-key hash + pool relevant dict) + R11 WS-PARSE-SHARE (reuse basekey in TryFindClosestRisky: 1.84->1.00 parses/auction)",
+      "replay": {
+        "round": 11,
+        "commit": "e862b08",
+        "date": "2026-06-06",
+        "mode": "warm",
+        "auctions_per_sec": 2269,
+        "p50_us": 318,
+        "p99_us": 2076,
+        "p999_us": 6898,
+        "bytes_per_auction": 24305,
+        "gen2": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# perf(sniper): optimize the snipe-finding path (~10× throughput, bit-exact)

## What
Optimizes `SniperService`'s snipe-finding hot path (`TestNewAuction → FindFlip → FoundAFlip`), which prices every incoming Hypixel auction and emits snipes. This is the squashed **production** change of an 11-round, measurement-driven campaign; the full per-round history, the benchmarking harness, and the profiling write-ups live on `perf/sniper-snipe-path` (separate follow-up PR).

## Results (snipe replay vs the round-1 baseline)
| metric | baseline | now | Δ |
|---|---|---|---|
| throughput | 236 /s | 2,269 /s | **~9.6×** |
| p50 | 2.77 ms | 0.32 ms | **−88%** |
| p99 | 38.2 ms | 2.1 ms | **−94.5%** |
| alloc / auction | 1.61 MB | ~0.02 MB | **−98.8%** |

Also: warm alloc ~115 KB → ~24 KB, rare gen2 GCs 9 → 0, cold p99 38 ms → ~1.3 ms. Machine-readable per-round record: [`benchmarks/speedups.json`](benchmarks/speedups.json).

## Core changes
- **Columnar dominance/closest kernels** (`DominatorIndex`, `ClosestScoreKernel`, `ClosestCandidateIndex`) with an interned `ulong` mask prefilter, replacing per-candidate LINQ scans over `ConcurrentDictionary`.
- **De-LINQ'd hot path**: `IsHigherValue`, `GetReduced`, `CheckCombined`, `ApplyAntiMarketManipulation`, `UpdateMedian` → explicit loops + pooled/`[ThreadStatic]` scratch.
- **Clean-price**: partial-selection (quickselect) instead of two full sorts + an entry-epoch-stamped recompute memo.
- **Parse/key path**: lazy-memoized hash on the immutable `AuctionKey`; O(M²)→O(M) modifier cache-key hashing; one parse per auction (share `basekey` into the closest finder).
- **Throughput**: `ShardedAuctionDispatcher` (tag-sharded, per-tag-serial) for near-linear core scaling.

## Correctness — bit-exact
Emitted snipe set / prices / medians / `GetPrice` are byte-identical to before. Gated by **432 tests + 4 runtime parity guards** (`SNIPER_VERIFY_{DOMINATOR,CLOSEST,CLEANPRICE_MEMO,PARSE}`) + fuzz oracles (40k dominance, 40k clean-price, 60k AMM, 50k GetReduced, 25k key-extraction) + snipe-set/`GetPrice`/`GetCleanItemPrice`/`UpdateMedian` goldens. All green; the guards are verification-only (off in production).

## Rollout / risk
- **New behavior is off by default**: the cross-auction parse memo ships disabled (`SNIPER_PARSE_MEMO`, 0% relist hit on the synthetic workload — gated on the shipped `SNIPER_PARSE_MEMO_COUNT` production counter); the shard-balance metrics are additive (`sky_sniper_shard_{queue_depth,processed_total}`).
- Perf numbers are **benchmark-derived** (synthetic replay + micro-benchmarks); correctness is **oracle-proven**. The throughput/shard-balance wins are **instrumented but not yet observed in production** — a canary is advisable.
- **Heads-up (pre-existing, not introduced here):** `BazaarHasMedian` is a wall-clock-boundary flake (a bazaar entry seeded at `UtcNow.AddHours(-24)` ages in/out of the retention window); it fails identically on the pre-campaign baseline. Worth pinning its clock in a separate fix so it doesn't flake CI.

## Not in this PR
The benchmarking harness (`benchmarks/`), profiling tooling, and the round-by-round `PIPELINE_PROFILE.md` — a separate PR off `perf/sniper-snipe-path`. The regenerable BenchmarkDotNet `*-report-full.json` dumps are untracked; `speedups.json` is the compact record.
